### PR TITLE
working beaker version of acceptance test for discussion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ hieradata/*.eyaml
 Gemfile.lock
 
 /graphs
+.vagrant

--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,9 @@ group :test do
   gem 'webmock'
   gem 'vcr'
   gem 'rspec-puppet', :git => 'https://github.com/rodjek/rspec-puppet.git'
+  gem 'beaker'
+  gem 'beaker-rspec'
+  gem 'vagrant-wrapper'
 end
 
 group :development do
@@ -28,7 +31,6 @@ group :development do
   gem 'guard-rake'
   gem 'rubocop', require: false
   gem 'pry'
-  gem 'librarian-puppet'
   gem 'clamp'
   gem "hiera-eyaml"
 end

--- a/spec/acceptance/aws_spec.rb
+++ b/spec/acceptance/aws_spec.rb
@@ -1,0 +1,75 @@
+require 'spec_helper_acceptance'
+require 'aws-sdk-core'
+
+describe 'ec2_instance' do
+
+  before(:all) do
+    seed = SecureRandom.uuid
+    @name = "#{seed}-instance"
+    @type = 't1.micro'
+    @region = 'sa-east-1'
+    @ami = 'ami-41e85d5c'
+  end
+
+  after(:all) do
+    pp = <<-EOS
+      ec2_instance { '#{@name}':
+        ensure => absent,
+        region => '#{@region}',
+      }
+    EOS
+    apply_manifest(pp, :catch_failures => true)
+  end
+
+  context 'with minimal parameters' do
+    it 'should apply idempotently' do
+      pp = <<-EOS
+        ec2_instance { '#{@name}':
+          ensure => present,
+          region => '#{@region}',
+          image_id => '#{@ami}',
+          instance_type => '#{@type}',
+          security_groups => ['default']
+        }
+      EOS
+
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
+    end
+
+    describe package('aws-sdk-core') do
+      it { should be_installed.by('gem') }
+    end
+
+    describe 'should create a new instance in AWS' do
+
+      before(:all) do
+        client = ::Aws::EC2::Client.new({region: @region})
+        response = client.describe_instances(filters: [
+          {name: 'tag:Name', values: [@name]},
+        ])
+        instances = response.data.reservations.collect do |reservation|
+          reservation.instances.collect do |instance|
+            instance
+          end
+        end.flatten
+        expect(instances.count).to eq(1)
+        @instance = instances.first
+      end
+
+      it "with the specified name" do
+        expect(@instance.tags.detect { |tag| tag.key == 'Name' }.value).to eq(@name)
+      end
+
+      it "with the specified type" do
+        expect(@instance.instance_type).to eq(@type)
+      end
+
+      it "with the specified AMI" do
+        expect(@instance.image_id).to eq(@ami)
+      end
+
+    end
+
+  end
+end

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -1,0 +1,12 @@
+HOSTS:
+  ubuntu-server-1404-x64:
+    roles:
+      - master
+    platform: ubuntu-server-14.04-amd64
+    box: puppetlabs/ubuntu-14.04-64-nocm
+    box_url: https://vagrantcloud.com/puppetlabs/ubuntu-14.04-64-nocm
+    hypervisor: vagrant
+
+CONFIG:
+  log_level: verbose
+  type: foss

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,0 +1,23 @@
+require 'beaker-rspec'
+
+unless ENV["BEAKER_provision"] == "no"
+  hosts.each do |host|
+    install_puppet
+    on host, puppet('resource', 'package', 'aws-sdk-core', 'ensure=installed', 'provider=gem'), { :acceptable_exit_codes => [0,1] }
+  end
+  scp_to hosts, "#{ENV['HOME']}/.aws/credentials", '/root/.aws/credentials'
+end
+
+RSpec.configure do |c|
+  # Project root
+  proj_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
+
+  # Readable test descriptions
+  c.formatter = :documentation
+
+  # Configure all nodes in nodeset
+  c.before :suite do
+    # Install module and dependencies
+    puppet_module_install(:source => proj_root, :module_name => 'aws')
+  end
+end


### PR DESCRIPTION
As discussed this is a version of the acceptance test running within beaker. Compare with: https://github.com/puppetlabs/puppetlabs-aws/pull/11

Pros:
- We can move testing across OS and Ruby versions into the tests, rather than the CI environment

Cons:
- You how need a hypervisor to run the tests
- It's much slower for initial test runs, or for targeted runs of parts of the test suite

@cowofevil @anodelman @Iristyle 
