### PR TITLE
Initial support for VPC resources

### DIFF
--- a/fixtures/vcr_cassettes/create-gateway.yml
+++ b/fixtures/vcr_cassettes/create-gateway.yml
@@ -5,7 +5,7 @@
         uri: "https://ec2.sa-east-1.amazonaws.com/"
         body: 
           encoding: UTF-8
-          string: "AWSAccessKeyId=&Action=DescribeSecurityGroups&Filter.1.Name=group-name&Filter.1.Value.1=web-sg&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-22T10%3A21%3A38Z&Version=2014-06-15"
+          string: "AWSAccessKeyId=&Action=DescribeVpcs&Filter.1.Name=tag%3AName&Filter.1.Value.1=test-vpc&Signature=SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-17T13%3A19%3A03Z&Version=2014-06-15"
         headers: 
           Content-Type: 
             - "application/x-www-form-urlencoded; charset=utf-8"
@@ -14,7 +14,7 @@
           User-Agent: 
             - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
           Content-Length: 
-            - "279"
+            - "265"
           Accept: 
             - "*/*"
       response: 
@@ -29,34 +29,40 @@
           Vary: 
             - Accept-Encoding
           Date: 
-            - "Wed, 22 Oct 2014 10:21:39 GMT"
+            - "Fri, 17 Oct 2014 13:19:04 GMT"
           Server: 
             - AmazonEC2
         body: 
           encoding: UTF-8
           string: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <DescribeSecurityGroupsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
-                <requestId>0fd3a5f8-b87d-40d1-83c1-0d4892072aaf</requestId>
-                <securityGroupInfo>
+            <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>4bd09d29-4b4b-4b32-b3b5-c3a92eda1fcc</requestId>
+                <vpcSet>
                     <item>
-                        <ownerId>482693910459</ownerId>
-                        <groupId>sg-8d3d1e90</groupId>
-                        <groupName>web-sg</groupName>
-                        <groupDescription>test</groupDescription>
-                        <ipPermissions/>
-                        <ipPermissionsEgress/>
+                        <vpcId>vpc-6853ea0d</vpcId>
+                        <state>available</state>
+                        <cidrBlock>10.0.0.0/16</cidrBlock>
+                        <dhcpOptionsId>dopt-e5edfb87</dhcpOptionsId>
+                        <tagSet>
+                            <item>
+                                <key>Name</key>
+                                <value>test-vpc</value>
+                            </item>
+                        </tagSet>
+                        <instanceTenancy>default</instanceTenancy>
+                        <isDefault>false</isDefault>
                     </item>
-                </securityGroupInfo>
-            </DescribeSecurityGroupsResponse>
+                </vpcSet>
+            </DescribeVpcsResponse>
         http_version: 
-      recorded_at: "Wed, 22 Oct 2014 10:21:39 GMT"
+      recorded_at: "Fri, 17 Oct 2014 13:19:04 GMT"
     - request: 
         method: post
         uri: "https://ec2.sa-east-1.amazonaws.com/"
         body: 
           encoding: UTF-8
-          string: "AWSAccessKeyId=&Action=RunInstances&ImageId=ami-67a60d7a&InstanceType=t1.micro&MaxCount=1&MinCount=1&Monitoring.Enabled=false&Placement.AvailabilityZone=sa-east-1a&SecurityGroupId.1=sg-8d3d1e90&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-22T10%3A21%3A39Z&UserData=&Version=2014-06-15"
+          string: "AWSAccessKeyId=&Action=CreateInternetGateway&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-17T13%3A19%3A04Z&Version=2014-06-15"
         headers: 
           Content-Type: 
             - "application/x-www-form-urlencoded; charset=utf-8"
@@ -65,7 +71,7 @@
           User-Agent: 
             - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
           Content-Length: 
-            - "380"
+            - "221"
           Accept: 
             - "*/*"
       response: 
@@ -80,23 +86,29 @@
           Vary: 
             - Accept-Encoding
           Date: 
-            - "Wed, 22 Oct 2014 10:21:40 GMT"
+            - "Fri, 17 Oct 2014 13:19:05 GMT"
           Server: 
             - AmazonEC2
         body: 
           encoding: UTF-8
           string: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <RunInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
-            </RunInstancesResponse>
+            <CreateInternetGatewayResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>5efd5eba-bd33-4f86-9f59-59aabe209a4f</requestId>
+                <internetGateway>
+                    <internetGatewayId>igw-22edf640</internetGatewayId>
+                    <attachmentSet/>
+                    <tagSet/>
+                </internetGateway>
+            </CreateInternetGatewayResponse>
         http_version: 
-      recorded_at: "Wed, 22 Oct 2014 10:21:40 GMT"
+      recorded_at: "Fri, 17 Oct 2014 13:19:05 GMT"
     - request: 
         method: post
         uri: "https://ec2.sa-east-1.amazonaws.com/"
         body: 
           encoding: UTF-8
-          string: "AWSAccessKeyId=&Action=RunInstances&ImageId=ami-67a60d7a&InstanceType=t1.micro&MaxCount=1&MinCount=1&Monitoring.Enabled=false&Placement.AvailabilityZone=sa-east-1a&SecurityGroupId.1=sg-8d3d1e90&Signature=&SignatureVersion=2&Timestamp=2014-10-22T10%3A21%3A40Z&UserData=&Version=2014-06-15"
+          string: "AWSAccessKeyId=&Action=AttachInternetGateway&InternetGatewayId=igw-22edf640&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-17T13%3A19%3A05Z&Version=2014-06-15&VpcId=vpc-6853ea0d"
         headers: 
           Content-Type: 
             - "application/x-www-form-urlencoded; charset=utf-8"
@@ -105,7 +117,7 @@
           User-Agent: 
             - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
           Content-Length: 
-            - "380"
+            - "277"
           Accept: 
             - "*/*"
       response: 
@@ -120,23 +132,25 @@
           Vary: 
             - Accept-Encoding
           Date: 
-            - "Wed, 22 Oct 2014 10:21:42 GMT"
+            - "Fri, 17 Oct 2014 13:19:06 GMT"
           Server: 
             - AmazonEC2
         body: 
           encoding: UTF-8
           string: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <RunInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
-            </RunInstancesResponse>
+            <AttachInternetGatewayResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>985b5c1c-392d-4579-8d0f-545ff1408e67</requestId>
+                <return>true</return>
+            </AttachInternetGatewayResponse>
         http_version: 
-      recorded_at: "Wed, 22 Oct 2014 10:21:42 GMT"
+      recorded_at: "Fri, 17 Oct 2014 13:19:06 GMT"
     - request: 
         method: post
         uri: "https://ec2.sa-east-1.amazonaws.com/"
         body: 
           encoding: UTF-8
-          string: "AWSAccessKeyId=&Action=CreateTags&ResourceId.1=i-9f67f78a&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Tag.1.Key=Name&Tag.1.Value=web-15&Timestamp=2014-10-22T10%3A21%3A42Z&Version=2014-06-15"
+          string: "AWSAccessKeyId=Action=CreateTags&ResourceId.1=igw-22edf640&Signature=SignatureMethod=HmacSHA256&SignatureVersion=2&Tag.1.Key=Name&Tag.1.Value=test-gateway&Timestamp=2014-10-17T13%3A19%3A06Z&Version=2014-06-15"
         headers: 
           Content-Type: 
             - "application/x-www-form-urlencoded; charset=utf-8"
@@ -145,7 +159,7 @@
           User-Agent: 
             - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
           Content-Length: 
-            - "274"
+            - "280"
           Accept: 
             - "*/*"
       response: 
@@ -160,7 +174,7 @@
           Vary: 
             - Accept-Encoding
           Date: 
-            - "Wed, 22 Oct 2014 10:21:43 GMT"
+            - "Fri, 17 Oct 2014 13:19:07 GMT"
           Server: 
             - AmazonEC2
         body: 
@@ -168,9 +182,9 @@
           string: |-
             <?xml version="1.0" encoding="UTF-8"?>
             <CreateTagsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
-                <requestId>124148b5-2804-433f-be8c-90becbed3d2e</requestId>
+                <requestId>3cfc33ef-6ad7-4400-9d0f-09026cb9339c</requestId>
                 <return>true</return>
             </CreateTagsResponse>
         http_version: 
-      recorded_at: "Wed, 22 Oct 2014 10:21:43 GMT"
+      recorded_at: "Fri, 17 Oct 2014 13:19:07 GMT"
   recorded_with: "VCR 2.9.3"

--- a/fixtures/vcr_cassettes/create-route-table.yml
+++ b/fixtures/vcr_cassettes/create-route-table.yml
@@ -1,0 +1,158 @@
+--- 
+  http_interactions: 
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=DescribeVpcs&Filter.1.Name=tag%3AName&Filter.1.Value.1=test-vpc&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-17T13%3A42%3A40Z&Version=2014-06-15"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "265"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Fri, 17 Oct 2014 13:42:41 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>158c8f06-acb1-4501-96ea-114e40fcf8b2</requestId>
+                <vpcSet>
+                    <item>
+                        <vpcId>vpc-6853ea0d</vpcId>
+                        <state>available</state>
+                        <cidrBlock>10.0.0.0/16</cidrBlock>
+                        <dhcpOptionsId>dopt-e5edfb87</dhcpOptionsId>
+                        <tagSet>
+                            <item>
+                                <key>Name</key>
+                                <value>test-vpc</value>
+                            </item>
+                        </tagSet>
+                        <instanceTenancy>default</instanceTenancy>
+                        <isDefault>false</isDefault>
+                    </item>
+                </vpcSet>
+            </DescribeVpcsResponse>
+        http_version: 
+      recorded_at: "Fri, 17 Oct 2014 13:42:41 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=CreateRouteTable&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-17T13%3A42%3A41Z&Version=2014-06-15&VpcId=vpc-6853ea0d"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "235"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Fri, 17 Oct 2014 13:42:42 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <CreateRouteTableResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>aa6e4da6-8e09-4438-90a0-645227995753</requestId>
+                <routeTable>
+                    <routeTableId>rtb-843fcee1</routeTableId>
+                    <vpcId>vpc-6853ea0d</vpcId>
+                    <routeSet>
+                        <item>
+                            <destinationCidrBlock>10.0.0.0/16</destinationCidrBlock>
+                            <gatewayId>local</gatewayId>
+                            <state>active</state>
+                            <origin>CreateRouteTable</origin>
+                        </item>
+                    </routeSet>
+                    <associationSet/>
+                    <propagatingVgwSet/>
+                    <tagSet/>
+                </routeTable>
+            </CreateRouteTableResponse>
+        http_version: 
+      recorded_at: "Fri, 17 Oct 2014 13:42:42 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=CreateTags&ResourceId.1=rtb-843fcee1&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Tag.1.Key=Name&Tag.1.Value=test-route-table&Timestamp=2014-10-17T13%3A42%3A42Z&Version=2014-06-15"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "282"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Fri, 17 Oct 2014 13:42:43 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <CreateTagsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>bbb43be9-60ae-4d8d-becd-2fa7c20ff312</requestId>
+                <return>true</return>
+            </CreateTagsResponse>
+        http_version: 
+      recorded_at: "Fri, 17 Oct 2014 13:42:43 GMT"
+  recorded_with: "VCR 2.9.3"

--- a/fixtures/vcr_cassettes/create-subnet.yml
+++ b/fixtures/vcr_cassettes/create-subnet.yml
@@ -1,0 +1,150 @@
+--- 
+  http_interactions: 
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=DescribeVpcs&Filter.1.Name=tag%3AName&Filter.1.Value.1=test-vpc&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-17T11%3A32%3A43Z&Version=2014-06-15"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "265"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Fri, 17 Oct 2014 11:32:44 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>5e3e12f9-ebae-4cc7-87be-143cbe0c617b</requestId>
+                <vpcSet>
+                    <item>
+                        <vpcId>vpc-6853ea0d</vpcId>
+                        <state>available</state>
+                        <cidrBlock>10.0.0.0/16</cidrBlock>
+                        <tagSet>
+                            <item>
+                                <key>Name</key>
+                                <value>test-vpc</value>
+                            </item>
+                        </tagSet>
+                        <instanceTenancy>default</instanceTenancy>
+                        <isDefault>false</isDefault>
+                    </item>
+                </vpcSet>
+            </DescribeVpcsResponse>
+        http_version: 
+      recorded_at: "Fri, 17 Oct 2014 11:32:44 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=CreateSubnet&AvailabilityZone=sa-east-1a&CidrBlock=10.0.0.0%2F24&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-17T11%3A32%3A44Z&Version=2014-06-15&VpcId=vpc-6853ea0d"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "287"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Fri, 17 Oct 2014 11:32:46 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <CreateSubnetResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>cddd0de5-128d-423a-8df4-6249df6e354a</requestId>
+                <subnet>
+                    <subnetId>subnet-105c9475</subnetId>
+                    <state>pending</state>
+                    <vpcId>vpc-6853ea0d</vpcId>
+                    <cidrBlock>10.0.0.0/24</cidrBlock>
+                    <availableIpAddressCount>251</availableIpAddressCount>
+                    <availabilityZone>sa-east-1a</availabilityZone>
+                </subnet>
+            </CreateSubnetResponse>
+        http_version: 
+      recorded_at: "Fri, 17 Oct 2014 11:32:46 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=CreateTags&ResourceId.1=subnet-105c9475&Signature=SignatureMethod=HmacSHA256&SignatureVersion=2&Tag.1.Key=Name&Tag.1.Value=test-subnet&Timestamp=2014-10-17T11%3A32%3A46Z&Version=2014-06-15"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "282"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Fri, 17 Oct 2014 11:32:47 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <CreateTagsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>e02543e1-7b93-41a0-bdf8-8405cb09fe36</requestId>
+                <return>true</return>
+            </CreateTagsResponse>
+        http_version: 
+      recorded_at: "Fri, 17 Oct 2014 11:32:47 GMT"
+  recorded_with: "VCR 2.9.3"

--- a/fixtures/vcr_cassettes/create-vpc.yml
+++ b/fixtures/vcr_cassettes/create-vpc.yml
@@ -1,0 +1,157 @@
+--- 
+  http_interactions: 
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=CreateVpc&CidrBlock=10.0.0.0%2F16&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-13T15%3A14%3A24Z&Version=2014-06-15"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "235"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Mon, 13 Oct 2014 15:14:25 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <CreateVpcResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>ff6c7586-b2c9-42c6-a9b3-03a2640bd795</requestId>
+                <vpc>
+                    <vpcId>vpc-63e15806</vpcId>
+                    <state>pending</state>
+                    <cidrBlock>10.0.0.0/16</cidrBlock>
+                    <dhcpOptionsId>dopt-e5edfb87</dhcpOptionsId>
+                    <instanceTenancy>default</instanceTenancy>
+                </vpc>
+            </CreateVpcResponse>
+        http_version: 
+      recorded_at: "Mon, 13 Oct 2014 15:14:26 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=DescribeRouteTables&Filter.1.Name=vpc-id&Filter.1.Value.1=vpc-63e15806&Filter.2.Name=association.main&Filter.2.Value.1=true&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-13T15%3A14%3A26Z&Version=2014-06-15"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "327"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Mon, 13 Oct 2014 15:14:26 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeRouteTablesResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>8e65ddd5-d675-4041-a807-8aa6007bd544</requestId>
+                <routeTableSet>
+                    <item>
+                        <routeTableId>rtb-215aac44</routeTableId>
+                        <vpcId>vpc-63e15806</vpcId>
+                        <routeSet>
+                            <item>
+                                <destinationCidrBlock>10.0.0.0/16</destinationCidrBlock>
+                                <gatewayId>local</gatewayId>
+                                <state>active</state>
+                                <origin>CreateRouteTable</origin>
+                            </item>
+                        </routeSet>
+                        <associationSet>
+                            <item>
+                                <routeTableAssociationId>rtbassoc-d4d120b1</routeTableAssociationId>
+                                <routeTableId>rtb-215aac44</routeTableId>
+                                <main>true</main>
+                            </item>
+                        </associationSet>
+                        <propagatingVgwSet/>
+                        <tagSet/>
+                    </item>
+                </routeTableSet>
+            </DescribeRouteTablesResponse>
+        http_version: 
+      recorded_at: "Mon, 13 Oct 2014 15:14:27 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=CreateTags&ResourceId.1=rtb-215aac44&ResourceId.2=vpc-63e15806&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Tag.1.Key=Name&Tag.1.Value=test-vpc&Timestamp=2014-10-13T15%3A14%3A27Z&Version=2014-06-15"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "298"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Mon, 13 Oct 2014 15:14:27 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <CreateTagsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>619f1736-eade-4766-a3a8-143a014fe453</requestId>
+                <return>true</return>
+            </CreateTagsResponse>
+        http_version: 
+      recorded_at: "Mon, 13 Oct 2014 15:14:28 GMT"
+  recorded_with: "VCR 2.9.3"

--- a/fixtures/vcr_cassettes/destroy-gateway.yml
+++ b/fixtures/vcr_cassettes/destroy-gateway.yml
@@ -1,0 +1,145 @@
+--- 
+  http_interactions: 
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=DescribeInternetGateways&Filter.1.Name=tag%3AName&Filter.1.Value.1=test-gateway&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-17T13%3A18%3A29Z&Version=2014-06-15"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "279"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Fri, 17 Oct 2014 13:18:30 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeInternetGatewaysResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>e9bf364c-ccaf-47b8-a364-6c242843ee07</requestId>
+                <internetGatewaySet>
+                    <item>
+                        <internetGatewayId>igw-59edf63b</internetGatewayId>
+                        <attachmentSet>
+                            <item>
+                                <vpcId>vpc-6853ea0d</vpcId>
+                                <state>available</state>
+                            </item>
+                        </attachmentSet>
+                        <tagSet>
+                            <item>
+                                <key>Name</key>
+                                <value>test-gateway</value>
+                            </item>
+                        </tagSet>
+                    </item>
+                </internetGatewaySet>
+            </DescribeInternetGatewaysResponse>
+        http_version: 
+      recorded_at: "Fri, 17 Oct 2014 13:18:30 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=DetachInternetGateway&InternetGatewayId=igw-59edf63b&Signature=SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-17T13%3A18%3A30Z&Version=2014-06-15&VpcId=vpc-6853ea0d"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "271"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Fri, 17 Oct 2014 13:18:31 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DetachInternetGatewayResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>1b73b46a-1b5b-4f1b-a134-fb1fb8bb0ab4</requestId>
+                <return>true</return>
+            </DetachInternetGatewayResponse>
+        http_version: 
+      recorded_at: "Fri, 17 Oct 2014 13:18:31 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=DeleteInternetGateway&InternetGatewayId=igw-59edf63b&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-17T13%3A18%3A31Z&Version=2014-06-15"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "254"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Fri, 17 Oct 2014 13:18:31 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DeleteInternetGatewayResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>490ffa16-e549-4dbc-ba78-9a1c3d36668f</requestId>
+                <return>true</return>
+            </DeleteInternetGatewayResponse>
+        http_version: 
+      recorded_at: "Fri, 17 Oct 2014 13:18:33 GMT"
+  recorded_with: "VCR 2.9.3"

--- a/fixtures/vcr_cassettes/destroy-route-table.yml
+++ b/fixtures/vcr_cassettes/destroy-route-table.yml
@@ -1,0 +1,108 @@
+--- 
+  http_interactions: 
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=DescribeRouteTables&Filter.1.Name=tag%3AName&Filter.1.Value.1=test-route-table&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-17T13%3A40%3A00Z&Version=2014-06-15"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "280"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Fri, 17 Oct 2014 13:40:01 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeRouteTablesResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>404f9554-ca74-4e1d-af4f-110d2bcf6738</requestId>
+                <routeTableSet>
+                    <item>
+                        <routeTableId>rtb-b43fced1</routeTableId>
+                        <vpcId>vpc-6853ea0d</vpcId>
+                        <routeSet>
+                            <item>
+                                <destinationCidrBlock>10.0.0.0/16</destinationCidrBlock>
+                                <gatewayId>local</gatewayId>
+                                <state>active</state>
+                                <origin>CreateRouteTable</origin>
+                            </item>
+                        </routeSet>
+                        <associationSet/>
+                        <propagatingVgwSet/>
+                        <tagSet>
+                            <item>
+                                <key>Name</key>
+                                <value>test-route-table</value>
+                            </item>
+                        </tagSet>
+                    </item>
+                </routeTableSet>
+            </DescribeRouteTablesResponse>
+        http_version: 
+      recorded_at: "Fri, 17 Oct 2014 13:40:01 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=DeleteRouteTable&RouteTableId=rtb-b43fced1&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-17T13%3A40%3A01Z&Version=2014-06-15"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "244"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Fri, 17 Oct 2014 13:40:02 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DeleteRouteTableResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>71f0133b-eb97-405e-86b1-9dd638f5a967</requestId>
+                <return>true</return>
+            </DeleteRouteTableResponse>
+        http_version: 
+      recorded_at: "Fri, 17 Oct 2014 13:40:02 GMT"
+  recorded_with: "VCR 2.9.3"

--- a/fixtures/vcr_cassettes/destroy-subnet.yml
+++ b/fixtures/vcr_cassettes/destroy-subnet.yml
@@ -1,0 +1,104 @@
+--- 
+  http_interactions: 
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=DescribeSubnets&Filter.1.Name=tag%3AName&Filter.1.Value.1=test-subnet&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-17T11%3A35%3A10Z&Version=2014-06-15"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "271"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Fri, 17 Oct 2014 11:35:11 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeSubnetsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>0e1156b6-3772-408c-b5b5-c602ce4ce849</requestId>
+                <subnetSet>
+                    <item>
+                        <subnetId>subnet-105c9475</subnetId>
+                        <state>available</state>
+                        <vpcId>vpc-6853ea0d</vpcId>
+                        <cidrBlock>10.0.0.0/24</cidrBlock>
+                        <availableIpAddressCount>251</availableIpAddressCount>
+                        <availabilityZone>sa-east-1a</availabilityZone>
+                        <defaultForAz>false</defaultForAz>
+                        <mapPublicIpOnLaunch>false</mapPublicIpOnLaunch>
+                        <tagSet>
+                            <item>
+                                <key>Name</key>
+                                <value>test-subnet</value>
+                            </item>
+                        </tagSet>
+                    </item>
+                </subnetSet>
+            </DescribeSubnetsResponse>
+        http_version: 
+      recorded_at: "Fri, 17 Oct 2014 11:35:11 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=Del&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&SubnetId=subnet-105c9475&Timestamp=2014-10-17T11%3A35%3A11Z&Version=2014-06-15"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "241"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Fri, 17 Oct 2014 11:35:12 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DeleteSubnetResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>073c4d18-b2a8-45fc-b1a6-d504f78a2d10</requestId>
+                <return>true</return>
+            </DeleteSubnetResponse>
+        http_version: 
+      recorded_at: "Fri, 17 Oct 2014 11:35:12 GMT"
+  recorded_with: "VCR 2.9.3"

--- a/fixtures/vcr_cassettes/destroy-vpc.yml
+++ b/fixtures/vcr_cassettes/destroy-vpc.yml
@@ -1,0 +1,102 @@
+--- 
+  http_interactions: 
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=redacted&Action=DescribeVpcs&Filter.1.Name=tag%3AName&Filter.1.Value.1=test-vpc&Signature=redacted&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-13T12%3A53%3A44Z&Version=2014-06-15"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "265"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Mon, 13 Oct 2014 12:53:44 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>f520d16a-2426-4284-a551-c3acd8a1a977</requestId>
+                <vpcSet>
+                    <item>
+                        <vpcId>vpc-a7ed54c2</vpcId>
+                        <state>available</state>
+                        <cidrBlock>10.0.0.0/16</cidrBlock>
+                        <dhcpOptionsId>dopt-e5edfb87</dhcpOptionsId>
+                        <tagSet>
+                            <item>
+                                <key>Name</key>
+                                <value>test-vpc</value>
+                            </item>
+                        </tagSet>
+                        <instanceTenancy>default</instanceTenancy>
+                        <isDefault>false</isDefault>
+                    </item>
+                </vpcSet>
+            </DescribeVpcsResponse>
+        http_version: 
+      recorded_at: "Mon, 13 Oct 2014 12:53:45 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=redacted&Action=DeleteVpc&Signature=redacted&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-13T12%3A53%3A45Z&Version=2014-06-15&VpcId=vpc-a7ed54c2"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "232"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Mon, 13 Oct 2014 12:53:46 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DeleteVpcResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>ea40e888-3b87-4b3c-b622-db1892b78e6f</requestId>
+                <return>true</return>
+            </DeleteVpcResponse>
+        http_version: 
+      recorded_at: "Mon, 13 Oct 2014 12:53:46 GMT"
+  recorded_with: "VCR 2.9.3"

--- a/fixtures/vcr_cassettes/gateway-named-test.yml
+++ b/fixtures/vcr_cassettes/gateway-named-test.yml
@@ -1,0 +1,179 @@
+--- 
+  http_interactions: 
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=DescribeInternetGateways&Signature=SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-17T13%3A19%3A23Z&Version=2014-06-15"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "224"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Fri, 17 Oct 2014 13:19:24 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeInternetGatewaysResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>9561dbcc-82d0-4733-adf0-452b9b4de401</requestId>
+                <internetGatewaySet>
+                    <item>
+                        <internetGatewayId>igw-300a1352</internetGatewayId>
+                        <attachmentSet>
+                            <item>
+                                <vpcId>vpc-9204b9f7</vpcId>
+                                <state>available</state>
+                            </item>
+                        </attachmentSet>
+                        <tagSet/>
+                    </item>
+                    <item>
+                        <internetGatewayId>igw-22edf640</internetGatewayId>
+                        <attachmentSet>
+                            <item>
+                                <vpcId>vpc-6853ea0d</vpcId>
+                                <state>available</state>
+                            </item>
+                        </attachmentSet>
+                        <tagSet>
+                            <item>
+                                <key>Name</key>
+                                <value>test-gateway</value>
+                            </item>
+                        </tagSet>
+                    </item>
+                </internetGatewaySet>
+            </DescribeInternetGatewaysResponse>
+        http_version: 
+      recorded_at: "Fri, 17 Oct 2014 13:19:24 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=DescribeVpcs&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-17T13%3A19%3A25Z&Version=2014-06-15&VpcId.1=vpc-9204b9f7"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "237"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Fri, 17 Oct 2014 13:19:25 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>13f9443a-49c0-49fd-b85f-2d4ed6ff223b</requestId>
+                <vpcSet>
+                    <item>
+                        <vpcId>vpc-9204b9f7</vpcId>
+                        <state>available</state>
+                        <cidrBlock>172.30.0.0/16</cidrBlock>
+                        <dhcpOptionsId>dopt-e5edfb87</dhcpOptionsId>
+                        <instanceTenancy>default</instanceTenancy>
+                        <isDefault>false</isDefault>
+                    </item>
+                </vpcSet>
+            </DescribeVpcsResponse>
+        http_version: 
+      recorded_at: "Fri, 17 Oct 2014 13:19:26 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=DescribeVpcs&Signature=estamp=2014-10-17T13%3A19%3A26Z&Version=2014-06-15&VpcId.1=vpc-6853ea0d"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "235"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Fri, 17 Oct 2014 13:19:26 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>692b351a-e8c7-47fb-913c-600da57e1d07</requestId>
+                <vpcSet>
+                    <item>
+                        <vpcId>vpc-6853ea0d</vpcId>
+                        <state>available</state>
+                        <cidrBlock>10.0.0.0/16</cidrBlock>
+                        <dhcpOptionsId>dopt-e5edfb87</dhcpOptionsId>
+                        <tagSet>
+                            <item>
+                                <key>Name</key>
+                                <value>test-vpc</value>
+                            </item>
+                        </tagSet>
+                        <instanceTenancy>default</instanceTenancy>
+                        <isDefault>false</isDefault>
+                    </item>
+                </vpcSet>
+            </DescribeVpcsResponse>
+        http_version: 
+      recorded_at: "Fri, 17 Oct 2014 13:19:27 GMT"
+  recorded_with: "VCR 2.9.3"

--- a/fixtures/vcr_cassettes/gateway-setup.yml
+++ b/fixtures/vcr_cassettes/gateway-setup.yml
@@ -5,7 +5,7 @@
         uri: "https://ec2.sa-east-1.amazonaws.com/"
         body: 
           encoding: UTF-8
-          string: "AWSAccessKeyId=&Action=DescribeSecurityGroups&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-16T12%3A21%3A12Z&Version=2014-06-15"
+          string: "AWSAccessKeyId=&Action=DescribeInternetGateways&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-17T13%3A18%3A14Z&Version=2014-06-15"
         headers: 
           Content-Type: 
             - "application/x-www-form-urlencoded; charset=utf-8"
@@ -14,7 +14,7 @@
           User-Agent: 
             - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
           Content-Length: 
-            - "222"
+            - "224"
           Accept: 
             - "*/*"
       response: 
@@ -29,29 +29,140 @@
           Vary: 
             - Accept-Encoding
           Date: 
-            - "Thu, 16 Oct 2014 12:21:12 GMT"
+            - "Fri, 17 Oct 2014 13:18:15 GMT"
           Server: 
             - AmazonEC2
         body: 
           encoding: UTF-8
           string: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <DescribeSecurityGroupsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
-                <securityGroupInfo>
+            <DescribeInternetGatewaysResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>35edab49-9f0c-417c-8af8-37d60738c1b7</requestId>
+                <internetGatewaySet>
                     <item>
-                        <groupName>default</groupName>
-                        <groupDescription>default VPC security group</groupDescription>
+                        <internetGatewayId>igw-300a1352</internetGatewayId>
+                        <attachmentSet>
+                            <item>
+                                <vpcId>vpc-9204b9f7</vpcId>
+                                <state>available</state>
+                            </item>
+                        </attachmentSet>
+                        <tagSet/>
                     </item>
-                </securityGroupInfo>
-            </DescribeSecurityGroupsResponse>
+                </internetGatewaySet>
+            </DescribeInternetGatewaysResponse>
         http_version: 
-      recorded_at: "Thu, 16 Oct 2014 12:21:14 GMT"
+      recorded_at: "Fri, 17 Oct 2014 13:18:15 GMT"
     - request: 
         method: post
         uri: "https://ec2.sa-east-1.amazonaws.com/"
         body: 
           encoding: UTF-8
-          string: "AWSAccessKeyId=&Action=DescribeVpcs&Signature=SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-16T12%3A21%3A14Z&Version=2014-06-15&VpcId.1=vpc-10c17875"
+          string: "AWSAccessKeyId=&Action=DescribeVpcs&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-17T13%3A18%3A15Z&Version=2014-06-15&VpcId.1=vpc-9204b9f7"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "239"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Fri, 17 Oct 2014 13:18:16 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>93fb5a1a-6368-40ad-a468-2a1f7e67ca05</requestId>
+                <vpcSet>
+                    <item>
+                        <vpcId>vpc-9204b9f7</vpcId>
+                        <state>available</state>
+                        <cidrBlock>172.30.0.0/16</cidrBlock>
+                        <dhcpOptionsId>dopt-e5edfb87</dhcpOptionsId>
+                        <instanceTenancy>default</instanceTenancy>
+                        <isDefault>false</isDefault>
+                    </item>
+                </vpcSet>
+            </DescribeVpcsResponse>
+        http_version: 
+      recorded_at: "Fri, 17 Oct 2014 13:18:16 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=DescribeInternetGateways&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-17T13%3A18%3A16Z&Version=2014-06-15"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "226"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Fri, 17 Oct 2014 13:18:16 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeInternetGatewaysResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>e47deb3d-6fa8-4884-b9a9-74b0992b03ed</requestId>
+                <internetGatewaySet>
+                    <item>
+                        <internetGatewayId>igw-300a1352</internetGatewayId>
+                        <attachmentSet>
+                            <item>
+                                <vpcId>vpc-9204b9f7</vpcId>
+                                <state>available</state>
+                            </item>
+                        </attachmentSet>
+                        <tagSet/>
+                    </item>
+                </internetGatewaySet>
+            </DescribeInternetGatewaysResponse>
+        http_version: 
+      recorded_at: "Fri, 17 Oct 2014 13:18:17 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=DescribeVpcs&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-17T13%3A18%3A17Z&Version=2014-06-15&VpcId.1=vpc-9204b9f7"
         headers: 
           Content-Type: 
             - "application/x-www-form-urlencoded; charset=utf-8"
@@ -75,7 +186,7 @@
           Vary: 
             - Accept-Encoding
           Date: 
-            - "Thu, 16 Oct 2014 12:21:13 GMT"
+            - "Fri, 17 Oct 2014 13:18:17 GMT"
           Server: 
             - AmazonEC2
         body: 
@@ -83,96 +194,18 @@
           string: |-
             <?xml version="1.0" encoding="UTF-8"?>
             <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
-                <requestId>752020ab-e8e8-4545-a8d0-112c3bae88ae</requestId>
+                <requestId>ea55cafd-73b9-4344-8a5a-b3829b094d5b</requestId>
                 <vpcSet>
+                    <item>
+                        <vpcId>vpc-9204b9f7</vpcId>
+                        <state>available</state>
+                        <cidrBlock>172.30.0.0/16</cidrBlock>
+                        <dhcpOptionsId>dopt-e5edfb87</dhcpOptionsId>
+                        <instanceTenancy>default</instanceTenancy>
+                        <isDefault>false</isDefault>
+                    </item>
                 </vpcSet>
             </DescribeVpcsResponse>
         http_version: 
-      recorded_at: "Thu, 16 Oct 2014 12:21:15 GMT"
-    - request: 
-        method: post
-        uri: "https://ec2.sa-east-1.amazonaws.com/"
-        body: 
-          encoding: UTF-8
-          string: "AWSAccessKeyId=&Action=DescribeVpcs&Signature=SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-16T12%3A21%3A15Z&Version=2014-06-15&VpcId.1=vpc-9204b9f7"
-        headers: 
-          Content-Type: 
-            - "application/x-www-form-urlencoded; charset=utf-8"
-          Accept-Encoding: 
-            - ""
-          User-Agent: 
-            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
-          Content-Length: 
-            - "233"
-          Accept: 
-            - "*/*"
-      response: 
-        status: 
-          code: 200
-          message: OK
-        headers: 
-          Content-Type: 
-            - "text/xml;charset=UTF-8"
-          Transfer-Encoding: 
-            - chunked
-          Vary: 
-            - Accept-Encoding
-          Date: 
-            - "Thu, 16 Oct 2014 12:21:14 GMT"
-          Server: 
-            - AmazonEC2
-        body: 
-          encoding: UTF-8
-          string: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
-                <requestId>e12dbf7c-10ac-4845-9093-869116a03066</requestId>
-                <vpcSet>
-                </vpcSet>
-            </DescribeVpcsResponse>
-        http_version: 
-      recorded_at: "Thu, 16 Oct 2014 12:21:16 GMT"
-    - request: 
-        method: post
-        uri: "https://ec2.sa-east-1.amazonaws.com/"
-        body: 
-          encoding: UTF-8
-          string: "AWSAccessKeyId=&Action=DescribeVpcs&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-16T12%3A21%3A16Z&Version=2014-06-15&VpcId.1=vpc-10c17875"
-        headers: 
-          Content-Type: 
-            - "application/x-www-form-urlencoded; charset=utf-8"
-          Accept-Encoding: 
-            - ""
-          User-Agent: 
-            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
-          Content-Length: 
-            - "233"
-          Accept: 
-            - "*/*"
-      response: 
-        status: 
-          code: 200
-          message: OK
-        headers: 
-          Content-Type: 
-            - "text/xml;charset=UTF-8"
-          Transfer-Encoding: 
-            - chunked
-          Vary: 
-            - Accept-Encoding
-          Date: 
-            - "Thu, 16 Oct 2014 12:21:15 GMT"
-          Server: 
-            - AmazonEC2
-        body: 
-          encoding: UTF-8
-          string: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
-                <requestId>75b60256-c788-4791-8e94-545bace9d879</requestId>
-                <vpcSet>
-                </vpcSet>
-            </DescribeVpcsResponse>
-        http_version: 
-      recorded_at: "Thu, 16 Oct 2014 12:21:17 GMT"
+      recorded_at: "Fri, 17 Oct 2014 13:18:18 GMT"
   recorded_with: "VCR 2.9.3"

--- a/fixtures/vcr_cassettes/route-table-named-test.yml
+++ b/fixtures/vcr_cassettes/route-table-named-test.yml
@@ -1,0 +1,260 @@
+--- 
+  http_interactions: 
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=DescribeRouteTables&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-17T13%3A39%3A53Z&Version=2014-06-15"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "219"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Fri, 17 Oct 2014 13:39:54 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeRouteTablesResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>bf00af54-7e2e-41fe-bec7-161de7ad03e9</requestId>
+                <routeTableSet>
+                    <item>
+                        <routeTableId>rtb-1e3acb7b</routeTableId>
+                        <vpcId>vpc-6853ea0d</vpcId>
+                        <routeSet>
+                            <item>
+                                <destinationCidrBlock>10.0.0.0/16</destinationCidrBlock>
+                                <gatewayId>local</gatewayId>
+                                <state>active</state>
+                                <origin>CreateRouteTable</origin>
+                            </item>
+                        </routeSet>
+                        <associationSet>
+                            <item>
+                                <routeTableAssociationId>rtbassoc-66bc4c03</routeTableAssociationId>
+                                <routeTableId>rtb-1e3acb7b</routeTableId>
+                                <main>true</main>
+                            </item>
+                        </associationSet>
+                        <propagatingVgwSet/>
+                        <tagSet>
+                            <item>
+                                <key>Name</key>
+                                <value>test-vpc</value>
+                            </item>
+                        </tagSet>
+                    </item>
+                    <item>
+                        <routeTableId>rtb-18c83d7d</routeTableId>
+                        <vpcId>vpc-9204b9f7</vpcId>
+                        <routeSet>
+                            <item>
+                                <destinationCidrBlock>172.30.0.0/16</destinationCidrBlock>
+                                <gatewayId>local</gatewayId>
+                                <state>active</state>
+                                <origin>CreateRouteTable</origin>
+                            </item>
+                            <item>
+                                <destinationCidrBlock>0.0.0.0/0</destinationCidrBlock>
+                                <gatewayId>igw-300a1352</gatewayId>
+                                <state>active</state>
+                                <origin>CreateRoute</origin>
+                            </item>
+                        </routeSet>
+                        <associationSet>
+                            <item>
+                                <routeTableAssociationId>rtbassoc-3f50a55a</routeTableAssociationId>
+                                <routeTableId>rtb-18c83d7d</routeTableId>
+                                <main>true</main>
+                            </item>
+                        </associationSet>
+                        <propagatingVgwSet/>
+                        <tagSet/>
+                    </item>
+                </routeTableSet>
+            </DescribeRouteTablesResponse>
+        http_version: 
+      recorded_at: "Fri, 17 Oct 2014 13:39:54 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=DescribeVpcs&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-17T13%3A39%3A54Z&Version=2014-06-15&VpcId.1=vpc-6853ea0d"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "235"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Fri, 17 Oct 2014 13:39:55 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>a6cb754a-2a92-4ebf-8ae2-9fe1a0d001b0</requestId>
+                <vpcSet>
+                    <item>
+                        <vpcId>vpc-6853ea0d</vpcId>
+                        <state>available</state>
+                        <cidrBlock>10.0.0.0/16</cidrBlock>
+                        <dhcpOptionsId>dopt-e5edfb87</dhcpOptionsId>
+                        <tagSet>
+                            <item>
+                                <key>Name</key>
+                                <value>test-vpc</value>
+                            </item>
+                        </tagSet>
+                        <instanceTenancy>default</instanceTenancy>
+                        <isDefault>false</isDefault>
+                    </item>
+                </vpcSet>
+            </DescribeVpcsResponse>
+        http_version: 
+      recorded_at: "Fri, 17 Oct 2014 13:39:55 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=DescribeVpcs&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-17T13%3A39%3A55Z&Version=2014-06-15&VpcId.1=vpc-9204b9f7"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "235"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Fri, 17 Oct 2014 13:39:55 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>8b2cc91c-d0dc-4ada-a108-98205cf82797</requestId>
+                <vpcSet>
+                    <item>
+                        <vpcId>vpc-9204b9f7</vpcId>
+                        <state>available</state>
+                        <cidrBlock>172.30.0.0/16</cidrBlock>
+                        <dhcpOptionsId>dopt-e5edfb87</dhcpOptionsId>
+                        <instanceTenancy>default</instanceTenancy>
+                        <isDefault>false</isDefault>
+                    </item>
+                </vpcSet>
+            </DescribeVpcsResponse>
+        http_version: 
+      recorded_at: "Fri, 17 Oct 2014 13:39:56 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=DescribeInternetGateways&InternetGatewayId.1=igw-300a1352&Signature=SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-17T13%3A39%3A56Z&Version=2014-06-15"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "259"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Fri, 17 Oct 2014 13:39:56 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeInternetGatewaysResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>a27941d9-e184-42dc-a048-e2085c2332cd</requestId>
+                <internetGatewaySet>
+                    <item>
+                        <internetGatewayId>igw-300a1352</internetGatewayId>
+                        <attachmentSet>
+                            <item>
+                                <vpcId>vpc-9204b9f7</vpcId>
+                                <state>available</state>
+                            </item>
+                        </attachmentSet>
+                        <tagSet/>
+                    </item>
+                </internetGatewaySet>
+            </DescribeInternetGatewaysResponse>
+        http_version: 
+      recorded_at: "Fri, 17 Oct 2014 13:39:57 GMT"
+  recorded_with: "VCR 2.9.3"

--- a/fixtures/vcr_cassettes/route-table-setup.yml
+++ b/fixtures/vcr_cassettes/route-table-setup.yml
@@ -1,0 +1,517 @@
+--- 
+  http_interactions: 
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=DescribeRouteTables&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-17T13%3A39%3A40Z&Version=2014-06-15"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "219"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Fri, 17 Oct 2014 13:39:42 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeRouteTablesResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>9cdaf804-d78d-4932-bd08-7f837e571ff0</requestId>
+                <routeTableSet>
+                    <item>
+                        <routeTableId>rtb-1e3acb7b</routeTableId>
+                        <vpcId>vpc-6853ea0d</vpcId>
+                        <routeSet>
+                            <item>
+                                <destinationCidrBlock>10.0.0.0/16</destinationCidrBlock>
+                                <gatewayId>local</gatewayId>
+                                <state>active</state>
+                                <origin>CreateRouteTable</origin>
+                            </item>
+                        </routeSet>
+                        <associationSet>
+                            <item>
+                                <routeTableAssociationId>rtbassoc-66bc4c03</routeTableAssociationId>
+                                <routeTableId>rtb-1e3acb7b</routeTableId>
+                                <main>true</main>
+                            </item>
+                        </associationSet>
+                        <propagatingVgwSet/>
+                        <tagSet>
+                            <item>
+                                <key>Name</key>
+                                <value>test-vpc</value>
+                            </item>
+                        </tagSet>
+                    </item>
+                    <item>
+                        <routeTableId>rtb-18c83d7d</routeTableId>
+                        <vpcId>vpc-9204b9f7</vpcId>
+                        <routeSet>
+                            <item>
+                                <destinationCidrBlock>172.30.0.0/16</destinationCidrBlock>
+                                <gatewayId>local</gatewayId>
+                                <state>active</state>
+                                <origin>CreateRouteTable</origin>
+                            </item>
+                            <item>
+                                <destinationCidrBlock>0.0.0.0/0</destinationCidrBlock>
+                                <gatewayId>igw-300a1352</gatewayId>
+                                <state>active</state>
+                                <origin>CreateRoute</origin>
+                            </item>
+                        </routeSet>
+                        <associationSet>
+                            <item>
+                                <routeTableAssociationId>rtbassoc-3f50a55a</routeTableAssociationId>
+                                <routeTableId>rtb-18c83d7d</routeTableId>
+                                <main>true</main>
+                            </item>
+                        </associationSet>
+                        <propagatingVgwSet/>
+                        <tagSet/>
+                    </item>
+                </routeTableSet>
+            </DescribeRouteTablesResponse>
+        http_version: 
+      recorded_at: "Fri, 17 Oct 2014 13:39:43 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=DescribeVpcs&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-17T13%3A39%3A43Z&Version=2014-06-15&VpcId.1=vpc-6853ea0d"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "237"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Fri, 17 Oct 2014 13:39:44 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>29b4d89f-5d6d-444a-bb97-6db62cc30193</requestId>
+                <vpcSet>
+                    <item>
+                        <vpcId>vpc-6853ea0d</vpcId>
+                        <state>available</state>
+                        <cidrBlock>10.0.0.0/16</cidrBlock>
+                        <dhcpOptionsId>dopt-e5edfb87</dhcpOptionsId>
+                        <tagSet>
+                            <item>
+                                <key>Name</key>
+                                <value>test-vpc</value>
+                            </item>
+                        </tagSet>
+                        <instanceTenancy>default</instanceTenancy>
+                        <isDefault>false</isDefault>
+                    </item>
+                </vpcSet>
+            </DescribeVpcsResponse>
+        http_version: 
+      recorded_at: "Fri, 17 Oct 2014 13:39:45 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=DescribeVpcs&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-17T13%3A39%3A45Z&Version=2014-06-15&VpcId.1=vpc-9204b9f7"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "235"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Fri, 17 Oct 2014 13:39:45 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>7fc98072-9362-4667-80ce-64c63b5e6582</requestId>
+                <vpcSet>
+                    <item>
+                        <vpcId>vpc-9204b9f7</vpcId>
+                        <state>available</state>
+                        <cidrBlock>172.30.0.0/16</cidrBlock>
+                        <dhcpOptionsId>dopt-e5edfb87</dhcpOptionsId>
+                        <instanceTenancy>default</instanceTenancy>
+                        <isDefault>false</isDefault>
+                    </item>
+                </vpcSet>
+            </DescribeVpcsResponse>
+        http_version: 
+      recorded_at: "Fri, 17 Oct 2014 13:39:46 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=DescribeInternetGateways&InternetGatewayId.1=igw-300a1352&Signature=SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-17T13%3A39%3A46Z&Version=2014-06-15"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "259"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Fri, 17 Oct 2014 13:39:48 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeInternetGatewaysResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>bdd72d6b-fc0a-4b2d-9e0b-97df4880eadd</requestId>
+                <internetGatewaySet>
+                    <item>
+                        <internetGatewayId>igw-300a1352</internetGatewayId>
+                        <attachmentSet>
+                            <item>
+                                <vpcId>vpc-9204b9f7</vpcId>
+                                <state>available</state>
+                            </item>
+                        </attachmentSet>
+                        <tagSet/>
+                    </item>
+                </internetGatewaySet>
+            </DescribeInternetGatewaysResponse>
+        http_version: 
+      recorded_at: "Fri, 17 Oct 2014 13:39:49 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=DescribeRouteTables&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-17T13%3A39%3A49Z&Version=2014-06-15"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "221"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Fri, 17 Oct 2014 13:39:50 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeRouteTablesResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>c11c986e-0ce8-4c1b-8ab0-bcab0c9aded8</requestId>
+                <routeTableSet>
+                    <item>
+                        <routeTableId>rtb-1e3acb7b</routeTableId>
+                        <vpcId>vpc-6853ea0d</vpcId>
+                        <routeSet>
+                            <item>
+                                <destinationCidrBlock>10.0.0.0/16</destinationCidrBlock>
+                                <gatewayId>local</gatewayId>
+                                <state>active</state>
+                                <origin>CreateRouteTable</origin>
+                            </item>
+                        </routeSet>
+                        <associationSet>
+                            <item>
+                                <routeTableAssociationId>rtbassoc-66bc4c03</routeTableAssociationId>
+                                <routeTableId>rtb-1e3acb7b</routeTableId>
+                                <main>true</main>
+                            </item>
+                        </associationSet>
+                        <propagatingVgwSet/>
+                        <tagSet>
+                            <item>
+                                <key>Name</key>
+                                <value>test-vpc</value>
+                            </item>
+                        </tagSet>
+                    </item>
+                    <item>
+                        <routeTableId>rtb-18c83d7d</routeTableId>
+                        <vpcId>vpc-9204b9f7</vpcId>
+                        <routeSet>
+                            <item>
+                                <destinationCidrBlock>172.30.0.0/16</destinationCidrBlock>
+                                <gatewayId>local</gatewayId>
+                                <state>active</state>
+                                <origin>CreateRouteTable</origin>
+                            </item>
+                            <item>
+                                <destinationCidrBlock>0.0.0.0/0</destinationCidrBlock>
+                                <gatewayId>igw-300a1352</gatewayId>
+                                <state>active</state>
+                                <origin>CreateRoute</origin>
+                            </item>
+                        </routeSet>
+                        <associationSet>
+                            <item>
+                                <routeTableAssociationId>rtbassoc-3f50a55a</routeTableAssociationId>
+                                <routeTableId>rtb-18c83d7d</routeTableId>
+                                <main>true</main>
+                            </item>
+                        </associationSet>
+                        <propagatingVgwSet/>
+                        <tagSet/>
+                    </item>
+                </routeTableSet>
+            </DescribeRouteTablesResponse>
+        http_version: 
+      recorded_at: "Fri, 17 Oct 2014 13:39:50 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=DescribeVpcs&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-17T13%3A39%3A50Z&Version=2014-06-15&VpcId.1=vpc-6853ea0d"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "237"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Fri, 17 Oct 2014 13:39:51 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>a53fc8ff-9c8c-4f89-be66-975466003d34</requestId>
+                <vpcSet>
+                    <item>
+                        <vpcId>vpc-6853ea0d</vpcId>
+                        <state>available</state>
+                        <cidrBlock>10.0.0.0/16</cidrBlock>
+                        <dhcpOptionsId>dopt-e5edfb87</dhcpOptionsId>
+                        <tagSet>
+                            <item>
+                                <key>Name</key>
+                                <value>test-vpc</value>
+                            </item>
+                        </tagSet>
+                        <instanceTenancy>default</instanceTenancy>
+                        <isDefault>false</isDefault>
+                    </item>
+                </vpcSet>
+            </DescribeVpcsResponse>
+        http_version: 
+      recorded_at: "Fri, 17 Oct 2014 13:39:51 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=DescribeVpcs&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-17T13%3A39%3A51Z&Version=2014-06-15&VpcId.1=vpc-9204b9f7"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "237"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Fri, 17 Oct 2014 13:39:51 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>dd632db1-c5d4-4c02-9b54-a5bf8f33e015</requestId>
+                <vpcSet>
+                    <item>
+                        <vpcId>vpc-9204b9f7</vpcId>
+                        <state>available</state>
+                        <cidrBlock>172.30.0.0/16</cidrBlock>
+                        <dhcpOptionsId>dopt-e5edfb87</dhcpOptionsId>
+                        <instanceTenancy>default</instanceTenancy>
+                        <isDefault>false</isDefault>
+                    </item>
+                </vpcSet>
+            </DescribeVpcsResponse>
+        http_version: 
+      recorded_at: "Fri, 17 Oct 2014 13:39:52 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=DescribeInternetGateways&InternetGatewayId.1=igw-300a1352&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-17T13%3A39%3A52Z&Version=2014-06-15"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "257"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Fri, 17 Oct 2014 13:39:52 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeInternetGatewaysResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>471cd100-e991-49c7-a133-7579416a59b6</requestId>
+                <internetGatewaySet>
+                    <item>
+                        <internetGatewayId>igw-300a1352</internetGatewayId>
+                        <attachmentSet>
+                            <item>
+                                <vpcId>vpc-9204b9f7</vpcId>
+                                <state>available</state>
+                            </item>
+                        </attachmentSet>
+                        <tagSet/>
+                    </item>
+                </internetGatewaySet>
+            </DescribeInternetGatewaysResponse>
+        http_version: 
+      recorded_at: "Fri, 17 Oct 2014 13:39:53 GMT"
+  recorded_with: "VCR 2.9.3"

--- a/fixtures/vcr_cassettes/subnet-named-test.yml
+++ b/fixtures/vcr_cassettes/subnet-named-test.yml
@@ -1,0 +1,241 @@
+--- 
+  http_interactions: 
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=DescribeSubnets&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-17T11%3A34%3A44Z&Version=2014-06-15"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "221"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Fri, 17 Oct 2014 11:34:47 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeSubnetsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>3f4f179d-6f07-4a08-be4c-9cfabe3cb768</requestId>
+                <subnetSet>
+                    <item>
+                        <subnetId>subnet-5d13d138</subnetId>
+                        <state>available</state>
+                        <vpcId>vpc-9204b9f7</vpcId>
+                        <cidrBlock>172.30.0.0/24</cidrBlock>
+                        <availableIpAddressCount>251</availableIpAddressCount>
+                        <availabilityZone>sa-east-1a</availabilityZone>
+                        <defaultForAz>false</defaultForAz>
+                        <mapPublicIpOnLaunch>true</mapPublicIpOnLaunch>
+                    </item>
+                    <item>
+                        <subnetId>subnet-105c9475</subnetId>
+                        <state>available</state>
+                        <vpcId>vpc-6853ea0d</vpcId>
+                        <cidrBlock>10.0.0.0/24</cidrBlock>
+                        <availableIpAddressCount>251</availableIpAddressCount>
+                        <availabilityZone>sa-east-1a</availabilityZone>
+                        <defaultForAz>false</defaultForAz>
+                        <mapPublicIpOnLaunch>false</mapPublicIpOnLaunch>
+                        <tagSet>
+                            <item>
+                                <key>Name</key>
+                                <value>test-subnet</value>
+                            </item>
+                        </tagSet>
+                    </item>
+                    <item>
+                        <subnetId>subnet-16c32261</subnetId>
+                        <state>available</state>
+                        <vpcId>vpc-9204b9f7</vpcId>
+                        <cidrBlock>172.30.1.0/24</cidrBlock>
+                        <availableIpAddressCount>251</availableIpAddressCount>
+                        <availabilityZone>sa-east-1b</availabilityZone>
+                        <defaultForAz>false</defaultForAz>
+                        <mapPublicIpOnLaunch>true</mapPublicIpOnLaunch>
+                    </item>
+                </subnetSet>
+            </DescribeSubnetsResponse>
+        http_version: 
+      recorded_at: "Fri, 17 Oct 2014 11:34:48 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=DescribeVpcs&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-17T11%3A34%3A48Z&Version=2014-06-15&VpcId.1=vpc-9204b9f7"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "235"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Fri, 17 Oct 2014 11:34:48 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>f7e8a520-4a7f-4b89-9f00-471b4d519427</requestId>
+                <vpcSet>
+                    <item>
+                        <vpcId>vpc-9204b9f7</vpcId>
+                        <state>available</state>
+                        <cidrBlock>172.30.0.0/16</cidrBlock>
+                        <dhcpOptionsId>dopt-e5edfb87</dhcpOptionsId>
+                        <instanceTenancy>default</instanceTenancy>
+                        <isDefault>false</isDefault>
+                    </item>
+                </vpcSet>
+            </DescribeVpcsResponse>
+        http_version: 
+      recorded_at: "Fri, 17 Oct 2014 11:34:49 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=DescribeVpcs&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-17T11%3A34%3A49Z&Version=2014-06-15&VpcId.1=vpc-6853ea0d"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "237"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Fri, 17 Oct 2014 11:34:50 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>111ac7ec-4c7d-49c1-a699-9236721e232d</requestId>
+                <vpcSet>
+                    <item>
+                        <vpcId>vpc-6853ea0d</vpcId>
+                        <state>available</state>
+                        <cidrBlock>10.0.0.0/16</cidrBlock>
+                        <dhcpOptionsId>dopt-e5edfb87</dhcpOptionsId>
+                        <tagSet>
+                            <item>
+                                <key>Name</key>
+                                <value>test-vpc</value>
+                            </item>
+                        </tagSet>
+                        <instanceTenancy>default</instanceTenancy>
+                        <isDefault>false</isDefault>
+                    </item>
+                </vpcSet>
+            </DescribeVpcsResponse>
+        http_version: 
+      recorded_at: "Fri, 17 Oct 2014 11:34:50 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=DescribeVpcs&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-17T11%3A34%3A50Z&Version=2014-06-15&VpcId.1=vpc-9204b9f7"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "235"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Fri, 17 Oct 2014 11:34:50 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>8e18270f-519c-4d9d-b15d-a62dbd32e39e</requestId>
+                <vpcSet>
+                    <item>
+                        <vpcId>vpc-9204b9f7</vpcId>
+                        <state>available</state>
+                        <cidrBlock>172.30.0.0/16</cidrBlock>
+                        <dhcpOptionsId>dopt-e5edfb87</dhcpOptionsId>
+                        <instanceTenancy>default</instanceTenancy>
+                        <isDefault>false</isDefault>
+                    </item>
+                </vpcSet>
+            </DescribeVpcsResponse>
+        http_version: 
+      recorded_at: "Fri, 17 Oct 2014 11:34:51 GMT"
+  recorded_with: "VCR 2.9.3"

--- a/fixtures/vcr_cassettes/vpc-named-test.yml
+++ b/fixtures/vcr_cassettes/vpc-named-test.yml
@@ -2,10 +2,10 @@
   http_interactions: 
     - request: 
         method: post
-        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        uri: "https://ec2.eu-west-1.amazonaws.com/"
         body: 
           encoding: UTF-8
-          string: "AWSAccessKeyId=&Action=DescribeSecurityGroups&Signature=SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-16T12%3A20%3A26Z&Version=2014-06-15"
+          string: "AWSAccessKeyId=redacted&Action=DescribeRegions&Signature=redacted&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-13T13%3A07%3A01Z&Version=2014-06-15"
         headers: 
           Content-Type: 
             - "application/x-www-form-urlencoded; charset=utf-8"
@@ -14,7 +14,7 @@
           User-Agent: 
             - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
           Content-Length: 
-            - "228"
+            - "219"
           Accept: 
             - "*/*"
       response: 
@@ -29,26 +29,58 @@
           Vary: 
             - Accept-Encoding
           Date: 
-            - "Thu, 16 Oct 2014 12:20:26 GMT"
+            - "Mon, 13 Oct 2014 13:07:01 GMT"
           Server: 
             - AmazonEC2
         body: 
           encoding: UTF-8
           string: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <DescribeSecurityGroupsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
-                <requestId>a58e7965-5364-49b2-995a-33bc802b9e3c</requestId>
-                <securityGroupInfo>
-                </securityGroupInfo>
-            </DescribeSecurityGroupsResponse>
+            <DescribeRegionsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>f6e58f24-7bcd-47cd-bbff-9b8288879bde</requestId>
+                <regionInfo>
+                    <item>
+                        <regionName>eu-west-1</regionName>
+                        <regionEndpoint>ec2.eu-west-1.amazonaws.com</regionEndpoint>
+                    </item>
+                    <item>
+                        <regionName>sa-east-1</regionName>
+                        <regionEndpoint>ec2.sa-east-1.amazonaws.com</regionEndpoint>
+                    </item>
+                    <item>
+                        <regionName>us-east-1</regionName>
+                        <regionEndpoint>ec2.us-east-1.amazonaws.com</regionEndpoint>
+                    </item>
+                    <item>
+                        <regionName>ap-northeast-1</regionName>
+                        <regionEndpoint>ec2.ap-northeast-1.amazonaws.com</regionEndpoint>
+                    </item>
+                    <item>
+                        <regionName>us-west-2</regionName>
+                        <regionEndpoint>ec2.us-west-2.amazonaws.com</regionEndpoint>
+                    </item>
+                    <item>
+                        <regionName>us-west-1</regionName>
+                        <regionEndpoint>ec2.us-west-1.amazonaws.com</regionEndpoint>
+                    </item>
+                    <item>
+                        <regionName>ap-southeast-1</regionName>
+                        <regionEndpoint>ec2.ap-southeast-1.amazonaws.com</regionEndpoint>
+                    </item>
+                    <item>
+                        <regionName>ap-southeast-2</regionName>
+                        <regionEndpoint>ec2.ap-southeast-2.amazonaws.com</regionEndpoint>
+                    </item>
+                </regionInfo>
+            </DescribeRegionsResponse>
         http_version: 
-      recorded_at: "Thu, 16 Oct 2014 12:20:28 GMT"
+      recorded_at: "Mon, 13 Oct 2014 13:07:02 GMT"
     - request: 
         method: post
-        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        uri: "https://ec2.eu-west-1.amazonaws.com/"
         body: 
           encoding: UTF-8
-          string: "AWSAccessKeyId=&Action=DescribeVpcs&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-16T12%3A20%3A28Z&Version=2014-06-15&VpcId.1=vpc-10c17875"
+          string: "AWSAccessKeyId=redacted&Action=DescribeVpcs&Signature=redacted&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-13T13%3A07%3A02Z&Version=2014-06-15"
         headers: 
           Content-Type: 
             - "application/x-www-form-urlencoded; charset=utf-8"
@@ -57,7 +89,7 @@
           User-Agent: 
             - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
           Content-Length: 
-            - "237"
+            - "212"
           Accept: 
             - "*/*"
       response: 
@@ -72,7 +104,7 @@
           Vary: 
             - Accept-Encoding
           Date: 
-            - "Thu, 16 Oct 2014 12:20:27 GMT"
+            - "Mon, 13 Oct 2014 13:07:02 GMT"
           Server: 
             - AmazonEC2
         body: 
@@ -80,18 +112,18 @@
           string: |-
             <?xml version="1.0" encoding="UTF-8"?>
             <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
-                <requestId>5d0337f3-cd29-4236-a2c7-7cbb7fb74c71</requestId>
+                <requestId>4f5afabb-fa8a-4958-b9ca-21dd34b617be</requestId>
                 <vpcSet>
-                </vpcSet>
+               </vpcSet>
             </DescribeVpcsResponse>
         http_version: 
-      recorded_at: "Thu, 16 Oct 2014 12:20:29 GMT"
+      recorded_at: "Mon, 13 Oct 2014 13:07:02 GMT"
     - request: 
         method: post
         uri: "https://ec2.sa-east-1.amazonaws.com/"
         body: 
           encoding: UTF-8
-          string: "AWSAccessKeyId=&Action=DescribeVpcs&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-16T12%3A20%3A29Z&Version=2014-06-15&VpcId.1=vpc-9204b9f7"
+          string: "AWSAccessKeyId=redacted&Action=DescribeVpcs&Signature=redacted&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-13T13%3A07%3A02Z&Version=2014-06-15"
         headers: 
           Content-Type: 
             - "application/x-www-form-urlencoded; charset=utf-8"
@@ -100,7 +132,7 @@
           User-Agent: 
             - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
           Content-Length: 
-            - "239"
+            - "214"
           Accept: 
             - "*/*"
       response: 
@@ -115,7 +147,7 @@
           Vary: 
             - Accept-Encoding
           Date: 
-            - "Thu, 16 Oct 2014 12:20:29 GMT"
+            - "Mon, 13 Oct 2014 13:07:02 GMT"
           Server: 
             - AmazonEC2
         body: 
@@ -123,18 +155,32 @@
           string: |-
             <?xml version="1.0" encoding="UTF-8"?>
             <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
-                <requestId>7d0f3032-e48d-4f5d-9060-73e6a5d979e3</requestId>
+                <requestId>62a112d9-0c78-4245-bfb7-fcc9977cdf98</requestId>
                 <vpcSet>
+                    <item>
+                        <vpcId>vpc-82ed54e7</vpcId>
+                        <state>available</state>
+                        <cidrBlock>10.0.0.0/16</cidrBlock>
+                        <dhcpOptionsId>dopt-e5edfb87</dhcpOptionsId>
+                        <tagSet>
+                            <item>
+                                <key>Name</key>
+                                <value>test-vpc</value>
+                            </item>
+                        </tagSet>
+                        <instanceTenancy>default</instanceTenancy>
+                        <isDefault>false</isDefault>
+                    </item>
                 </vpcSet>
             </DescribeVpcsResponse>
         http_version: 
-      recorded_at: "Thu, 16 Oct 2014 12:20:31 GMT"
+      recorded_at: "Mon, 13 Oct 2014 13:07:03 GMT"
     - request: 
         method: post
-        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        uri: "https://ec2.us-east-1.amazonaws.com/"
         body: 
           encoding: UTF-8
-          string: "AWSAccessKeyId=&Action=DescribeVpcs&Signature=SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-16T12%3A20%3A31Z&Version=2014-06-15&VpcId.1=vpc-10c17875"
+          string: "AWSAccessKeyId=redacted&Action=DescribeVpcs&Signature=redacted&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-13T13%3A07%3A03Z&Version=2014-06-15"
         headers: 
           Content-Type: 
             - "application/x-www-form-urlencoded; charset=utf-8"
@@ -143,7 +189,7 @@
           User-Agent: 
             - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
           Content-Length: 
-            - "235"
+            - "214"
           Accept: 
             - "*/*"
       response: 
@@ -158,7 +204,7 @@
           Vary: 
             - Accept-Encoding
           Date: 
-            - "Thu, 16 Oct 2014 12:20:30 GMT"
+            - "Mon, 13 Oct 2014 13:07:03 GMT"
           Server: 
             - AmazonEC2
         body: 
@@ -166,18 +212,18 @@
           string: |-
             <?xml version="1.0" encoding="UTF-8"?>
             <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
-                <requestId>0ed9df51-e89c-43e7-865d-19a1fe44eb9a</requestId>
+                <requestId>90353d27-21fe-4d18-8815-55315187c9ce</requestId>
                 <vpcSet>
                 </vpcSet>
             </DescribeVpcsResponse>
         http_version: 
-      recorded_at: "Thu, 16 Oct 2014 12:20:32 GMT"
+      recorded_at: "Mon, 13 Oct 2014 13:07:04 GMT"
     - request: 
         method: post
-        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        uri: "https://ec2.ap-northeast-1.amazonaws.com/"
         body: 
           encoding: UTF-8
-          string: "AWSAccessKeyId=&Action=DescribeSecurityGroups&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-16T12%3A20%3A32Z&Version=2014-06-15"
+          string: "AWSAccessKeyId=&Action=DescribeVpcs&Signature=redacted%3D&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-13T13%3A07%3A04Z&Version=2014-06-15"
         headers: 
           Content-Type: 
             - "application/x-www-form-urlencoded; charset=utf-8"
@@ -186,7 +232,7 @@
           User-Agent: 
             - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
           Content-Length: 
-            - "224"
+            - "212"
           Accept: 
             - "*/*"
       response: 
@@ -201,50 +247,7 @@
           Vary: 
             - Accept-Encoding
           Date: 
-            - "Thu, 16 Oct 2014 12:20:31 GMT"
-          Server: 
-            - AmazonEC2
-        body: 
-          encoding: UTF-8
-          string: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <DescribeSecurityGroupsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
-                <requestId>1d0aa100-cc9d-447a-81d8-074a2afe9fe5</requestId>
-                <securityGroupInfo>
-                </securityGroupInfo>
-            </DescribeSecurityGroupsResponse>
-        http_version: 
-      recorded_at: "Thu, 16 Oct 2014 12:20:37 GMT"
-    - request: 
-        method: post
-        uri: "https://ec2.sa-east-1.amazonaws.com/"
-        body: 
-          encoding: UTF-8
-          string: "AWSAccessKeyId=&Action=DescribeVpcs&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-16T12%3A20%3A37Z&Version=2014-06-15&VpcId.1=vpc-10c17875"
-        headers: 
-          Content-Type: 
-            - "application/x-www-form-urlencoded; charset=utf-8"
-          Accept-Encoding: 
-            - ""
-          User-Agent: 
-            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
-          Content-Length: 
-            - "235"
-          Accept: 
-            - "*/*"
-      response: 
-        status: 
-          code: 200
-          message: OK
-        headers: 
-          Content-Type: 
-            - "text/xml;charset=UTF-8"
-          Transfer-Encoding: 
-            - chunked
-          Vary: 
-            - Accept-Encoding
-          Date: 
-            - "Thu, 16 Oct 2014 12:20:36 GMT"
+            - "Mon, 13 Oct 2014 13:07:04 GMT"
           Server: 
             - AmazonEC2
         body: 
@@ -252,18 +255,17 @@
           string: |-
             <?xml version="1.0" encoding="UTF-8"?>
             <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
-                <requestId>78c34b0a-35dd-486c-afc1-720f3aec375f</requestId>
-                <vpcSet>
-                </vpcSet>
+                <requestId>724ebc35-2e7c-4954-b64c-7212cfab1de1</requestId>
+                <vpcSet/>
             </DescribeVpcsResponse>
         http_version: 
-      recorded_at: "Thu, 16 Oct 2014 12:20:38 GMT"
+      recorded_at: "Mon, 13 Oct 2014 13:07:06 GMT"
     - request: 
         method: post
-        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        uri: "https://ec2.us-west-2.amazonaws.com/"
         body: 
           encoding: UTF-8
-          string: "AWSAccessKeyId=&Action=DescribeVpcs&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-16T12%3A20%3A38Z&Version=2014-06-15&VpcId.1=vpc-9204b9f7"
+          string: "AWSAccessKeyId=&Action=DescribeVpcs&Signature=redacted&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-13T13%3A07%3A06Z&Version=2014-06-15"
         headers: 
           Content-Type: 
             - "application/x-www-form-urlencoded; charset=utf-8"
@@ -272,7 +274,7 @@
           User-Agent: 
             - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
           Content-Length: 
-            - "233"
+            - "212"
           Accept: 
             - "*/*"
       response: 
@@ -287,7 +289,7 @@
           Vary: 
             - Accept-Encoding
           Date: 
-            - "Thu, 16 Oct 2014 12:20:37 GMT"
+            - "Mon, 13 Oct 2014 13:07:05 GMT"
           Server: 
             - AmazonEC2
         body: 
@@ -295,18 +297,18 @@
           string: |-
             <?xml version="1.0" encoding="UTF-8"?>
             <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
-                <requestId>c032a2da-144a-4f85-9e13-42707449a98c</requestId>
+                <requestId>184b5139-e20e-4e3a-8807-13a51634d434</requestId>
                 <vpcSet>
                 </vpcSet>
             </DescribeVpcsResponse>
         http_version: 
-      recorded_at: "Thu, 16 Oct 2014 12:20:39 GMT"
+      recorded_at: "Mon, 13 Oct 2014 13:07:06 GMT"
     - request: 
         method: post
-        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        uri: "https://ec2.us-west-1.amazonaws.com/"
         body: 
           encoding: UTF-8
-          string: "AWSAccessKeyId=&Action=DescribeVpcs&Signature=SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-16T12%3A20%3A39Z&Version=2014-06-15&VpcId.1=vpc-10c17875"
+          string: "AWSAccessKeyId=&Action=DescribeVpcs&Signature=redacted&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-13T13%3A07%3A06Z&Version=2014-06-15"
         headers: 
           Content-Type: 
             - "application/x-www-form-urlencoded; charset=utf-8"
@@ -315,7 +317,7 @@
           User-Agent: 
             - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
           Content-Length: 
-            - "235"
+            - "216"
           Accept: 
             - "*/*"
       response: 
@@ -330,7 +332,7 @@
           Vary: 
             - Accept-Encoding
           Date: 
-            - "Thu, 16 Oct 2014 12:20:39 GMT"
+            - "Mon, 13 Oct 2014 13:07:07 GMT"
           Server: 
             - AmazonEC2
         body: 
@@ -338,10 +340,94 @@
           string: |-
             <?xml version="1.0" encoding="UTF-8"?>
             <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
-                <requestId>495a2ea5-1b6a-4c79-ba79-84fea12c1ea7</requestId>
+                <requestId>26a6e8ed-9b26-4e63-9bb5-72b60cb58349</requestId>
+                <vpcSet/>
+            </DescribeVpcsResponse>
+        http_version: 
+      recorded_at: "Mon, 13 Oct 2014 13:07:08 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.ap-southeast-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=DescribeVpcs&Signature=redacted&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-13T13%3A07%3A08Z&Version=2014-06-15"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "214"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Mon, 13 Oct 2014 13:07:09 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>0cc8e825-c31c-46de-9136-4c37221f5450</requestId>
+                <vpcSet/>
+            </DescribeVpcsResponse>
+        http_version: 
+      recorded_at: "Mon, 13 Oct 2014 13:07:11 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.ap-southeast-2.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=DescribeVpcs&Signature=redacted&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-13T13%3A07%3A11Z&Version=2014-06-15"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "216"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Mon, 13 Oct 2014 13:07:12 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>81d0b47d-7521-41ae-8d0c-d5fb4aeeb2f5</requestId>
                 <vpcSet>
                 </vpcSet>
             </DescribeVpcsResponse>
         http_version: 
-      recorded_at: "Thu, 16 Oct 2014 12:20:40 GMT"
+      recorded_at: "Mon, 13 Oct 2014 13:07:13 GMT"
   recorded_with: "VCR 2.9.3"

--- a/fixtures/vcr_cassettes/vpc-setup.yml
+++ b/fixtures/vcr_cassettes/vpc-setup.yml
@@ -1,0 +1,835 @@
+--- 
+  http_interactions: 
+    - request: 
+        method: post
+        uri: "https://ec2.eu-west-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=DescribeRegions&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-13T12%3A51%3A50Z&Version=2014-06-15"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "217"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Mon, 13 Oct 2014 12:51:49 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeRegionsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>7a1e0154-5f45-4278-b733-e6dce00d3f4b</requestId>
+                <regionInfo>
+                    <item>
+                        <regionName>eu-west-1</regionName>
+                        <regionEndpoint>ec2.eu-west-1.amazonaws.com</regionEndpoint>
+                    </item>
+                    <item>
+                        <regionName>sa-east-1</regionName>
+                        <regionEndpoint>ec2.sa-east-1.amazonaws.com</regionEndpoint>
+                    </item>
+                    <item>
+                        <regionName>us-east-1</regionName>
+                        <regionEndpoint>ec2.us-east-1.amazonaws.com</regionEndpoint>
+                    </item>
+                    <item>
+                        <regionName>ap-northeast-1</regionName>
+                        <regionEndpoint>ec2.ap-northeast-1.amazonaws.com</regionEndpoint>
+                    </item>
+                    <item>
+                        <regionName>us-west-2</regionName>
+                        <regionEndpoint>ec2.us-west-2.amazonaws.com</regionEndpoint>
+                    </item>
+                    <item>
+                        <regionName>us-west-1</regionName>
+                        <regionEndpoint>ec2.us-west-1.amazonaws.com</regionEndpoint>
+                    </item>
+                    <item>
+                        <regionName>ap-southeast-1</regionName>
+                        <regionEndpoint>ec2.ap-southeast-1.amazonaws.com</regionEndpoint>
+                    </item>
+                    <item>
+                        <regionName>ap-southeast-2</regionName>
+                        <regionEndpoint>ec2.ap-southeast-2.amazonaws.com</regionEndpoint>
+                    </item>
+                </regionInfo>
+            </DescribeRegionsResponse>
+        http_version: 
+      recorded_at: "Mon, 13 Oct 2014 12:51:50 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.eu-west-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=DescribeVpcs&Signature=SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-13T12%3A51%3A50Z&Version=2014-06-15"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "220"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Mon, 13 Oct 2014 12:51:50 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>2d2d3c3f-f66e-48d2-93da-599f54437ae5</requestId>
+                <vpcSet>
+                </vpcSet>
+            </DescribeVpcsResponse>
+        http_version: 
+      recorded_at: "Mon, 13 Oct 2014 12:51:50 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=DescribeVpcs&Signature=SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-13T12%3A51%3A50Z&Version=2014-06-15"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "220"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Mon, 13 Oct 2014 12:51:50 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>d8cedb3b-4f20-4791-b311-b3bfe74e6ef9</requestId>
+                <vpcSet>
+                </vpcSet>
+            </DescribeVpcsResponse>
+        http_version: 
+      recorded_at: "Mon, 13 Oct 2014 12:51:52 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.us-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=DescribeVpcs&Signature=SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-13T12%3A51%3A52Z&Version=2014-06-15"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "214"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Mon, 13 Oct 2014 12:51:52 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>7a7172dc-37ab-4116-a1d4-4870cbdd6aea</requestId>
+                <vpcSet>
+                </vpcSet>
+            </DescribeVpcsResponse>
+        http_version: 
+      recorded_at: "Mon, 13 Oct 2014 12:51:53 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.ap-northeast-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=DescribeVpcs&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-13T12%3A51%3A53Z&Version=2014-06-15"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "214"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Mon, 13 Oct 2014 12:51:54 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>518c170a-a560-4304-9ce3-350fc664bb96</requestId>
+                <vpcSet/>
+            </DescribeVpcsResponse>
+        http_version: 
+      recorded_at: "Mon, 13 Oct 2014 12:51:54 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.us-west-2.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=DescribeVpcs&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-13T12%3A51%3A54Z&Version=2014-06-15"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "214"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Mon, 13 Oct 2014 12:51:55 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>ce2eabeb-932f-4633-9ab7-8e360414f042</requestId>
+                <vpcSet>
+                </vpcSet>
+            </DescribeVpcsResponse>
+        http_version: 
+      recorded_at: "Mon, 13 Oct 2014 12:51:55 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.us-west-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=DescribeVpcs&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-13T12%3A51%3A55Z&Version=2014-06-15"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "212"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Mon, 13 Oct 2014 12:51:56 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>9de686b6-98e1-4958-acaa-9b5105020fed</requestId>
+                <vpcSet/>
+            </DescribeVpcsResponse>
+        http_version: 
+      recorded_at: "Mon, 13 Oct 2014 12:51:56 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.ap-southeast-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=DescribeVpcs&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-13T12%3A51%3A56Z&Version=2014-06-15"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "212"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Mon, 13 Oct 2014 12:51:57 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>6053adb3-0978-4818-a640-4d067cd2623a</requestId>
+                <vpcSet/>
+            </DescribeVpcsResponse>
+        http_version: 
+      recorded_at: "Mon, 13 Oct 2014 12:51:58 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.ap-southeast-2.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=DescribeVpcs&Signature=SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-13T12%3A51%3A58Z&Version=2014-06-15"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "214"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Mon, 13 Oct 2014 12:51:59 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>6f3dd1f0-9d74-4cf6-b974-0e912c372d60</requestId>
+                <vpcSet>
+                </vpcSet>
+            </DescribeVpcsResponse>
+        http_version: 
+      recorded_at: "Mon, 13 Oct 2014 12:51:59 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.eu-west-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=DescribeRegions&Signature=SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-13T12%3A51%3A59Z&Version=2014-06-15"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "219"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Mon, 13 Oct 2014 12:51:59 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeRegionsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>db48740e-19bf-4dcc-8a90-25bfc4635b5e</requestId>
+                <regionInfo>
+                    <item>
+                        <regionName>eu-west-1</regionName>
+                        <regionEndpoint>ec2.eu-west-1.amazonaws.com</regionEndpoint>
+                    </item>
+                    <item>
+                        <regionName>sa-east-1</regionName>
+                        <regionEndpoint>ec2.sa-east-1.amazonaws.com</regionEndpoint>
+                    </item>
+                    <item>
+                        <regionName>us-east-1</regionName>
+                        <regionEndpoint>ec2.us-east-1.amazonaws.com</regionEndpoint>
+                    </item>
+                    <item>
+                        <regionName>ap-northeast-1</regionName>
+                        <regionEndpoint>ec2.ap-northeast-1.amazonaws.com</regionEndpoint>
+                    </item>
+                    <item>
+                        <regionName>us-west-2</regionName>
+                        <regionEndpoint>ec2.us-west-2.amazonaws.com</regionEndpoint>
+                    </item>
+                    <item>
+                        <regionName>us-west-1</regionName>
+                        <regionEndpoint>ec2.us-west-1.amazonaws.com</regionEndpoint>
+                    </item>
+                    <item>
+                        <regionName>ap-southeast-1</regionName>
+                        <regionEndpoint>ec2.ap-southeast-1.amazonaws.com</regionEndpoint>
+                    </item>
+                    <item>
+                        <regionName>ap-southeast-2</regionName>
+                        <regionEndpoint>ec2.ap-southeast-2.amazonaws.com</regionEndpoint>
+                    </item>
+                </regionInfo>
+            </DescribeRegionsResponse>
+        http_version: 
+      recorded_at: "Mon, 13 Oct 2014 12:52:00 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.eu-west-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=DescribeVpcs&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-13T12%3A52%3A00Z&Version=2014-06-15"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "214"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Mon, 13 Oct 2014 12:51:59 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>f5a4ef63-3d8a-4ff1-a7ff-fed1a4ff8e34</requestId>
+                <vpcSet>
+                </vpcSet>
+            </DescribeVpcsResponse>
+        http_version: 
+      recorded_at: "Mon, 13 Oct 2014 12:52:00 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=DescribeVpcs&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-13T12%3A52%3A00Z&Version=2014-06-15"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "214"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Mon, 13 Oct 2014 12:52:01 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>2b222e0f-0fd0-4b34-945c-761b230d13a3</requestId>
+                <vpcSet>
+                </vpcSet>
+            </DescribeVpcsResponse>
+        http_version: 
+      recorded_at: "Mon, 13 Oct 2014 12:52:01 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.us-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=DescribeVpcs&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-13T12%3A52%3A01Z&Version=2014-06-15"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "214"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Mon, 13 Oct 2014 12:52:01 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>60f7c214-7f3c-4fd2-89d3-2cf14a5e0120</requestId>
+                <vpcSet>
+                </vpcSet>
+            </DescribeVpcsResponse>
+        http_version: 
+      recorded_at: "Mon, 13 Oct 2014 12:52:01 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.ap-northeast-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=DescribeVpcs&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-13T12%3A52%3A01Z&Version=2014-06-15"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "216"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Mon, 13 Oct 2014 12:52:02 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>21a36234-706a-4934-8d16-c4a6eb77c992</requestId>
+                <vpcSet/>
+            </DescribeVpcsResponse>
+        http_version: 
+      recorded_at: "Mon, 13 Oct 2014 12:52:03 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.us-west-2.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=DescribeVpcs&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-13T12%3A52%3A03Z&Version=2014-06-15"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "214"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Mon, 13 Oct 2014 12:52:03 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>2cda97e3-fc4e-4aa4-b5f8-50a9692915b1</requestId>
+                <vpcSet>
+                </vpcSet>
+            </DescribeVpcsResponse>
+        http_version: 
+      recorded_at: "Mon, 13 Oct 2014 12:52:04 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.us-west-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=DescribeVpcs&Signature=SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-13T12%3A52%3A04Z&Version=2014-06-15"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "216"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Mon, 13 Oct 2014 12:52:03 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>d018038e-5554-4770-adbf-70c19f4797c6</requestId>
+                <vpcSet/>
+            </DescribeVpcsResponse>
+        http_version: 
+      recorded_at: "Mon, 13 Oct 2014 12:52:04 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.ap-southeast-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=DescribeVpcs&Signature=SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-13T12%3A52%3A04Z&Version=2014-06-15"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "216"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Mon, 13 Oct 2014 12:52:05 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>c41979e1-7775-48c3-8f36-534f491605e2</requestId>
+                <vpcSet/>
+            </DescribeVpcsResponse>
+        http_version: 
+      recorded_at: "Mon, 13 Oct 2014 12:52:06 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.ap-southeast-2.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=DescribeVpcs&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-13T12%3A52%3A06Z&Version=2014-06-15"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "218"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Mon, 13 Oct 2014 12:52:07 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>8c716e76-3e8e-4c89-b2dd-40cfdfd55716</requestId>
+                <vpcSet>
+                </vpcSet>
+            </DescribeVpcsResponse>
+        http_version: 
+      recorded_at: "Mon, 13 Oct 2014 12:52:07 GMT"
+  recorded_with: "VCR 2.9.3"

--- a/fixtures/vcr_cassettes/vpc-subnet-setup.yml
+++ b/fixtures/vcr_cassettes/vpc-subnet-setup.yml
@@ -5,7 +5,7 @@
         uri: "https://ec2.sa-east-1.amazonaws.com/"
         body: 
           encoding: UTF-8
-          string: "AWSAccessKeyId=&Action=DescribeSecurityGroups&Signature=SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-16T12%3A20%3A26Z&Version=2014-06-15"
+          string: "AWSAccessKeyId=&Action=DescribeSubnets&Signature=Ch7hbu5Uaf9bUf3wLOmgW0xfhPgaytTXQfHpliWSQ6s%3D&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-17T11%3A33%3A59Z&Version=2014-06-15"
         headers: 
           Content-Type: 
             - "application/x-www-form-urlencoded; charset=utf-8"
@@ -14,7 +14,7 @@
           User-Agent: 
             - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
           Content-Length: 
-            - "228"
+            - "215"
           Accept: 
             - "*/*"
       response: 
@@ -29,26 +29,109 @@
           Vary: 
             - Accept-Encoding
           Date: 
-            - "Thu, 16 Oct 2014 12:20:26 GMT"
+            - "Fri, 17 Oct 2014 11:34:01 GMT"
           Server: 
             - AmazonEC2
         body: 
           encoding: UTF-8
           string: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <DescribeSecurityGroupsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
-                <requestId>a58e7965-5364-49b2-995a-33bc802b9e3c</requestId>
-                <securityGroupInfo>
-                </securityGroupInfo>
-            </DescribeSecurityGroupsResponse>
+            <DescribeSubnetsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+            </DescribeSubnetsResponse>
         http_version: 
-      recorded_at: "Thu, 16 Oct 2014 12:20:28 GMT"
+      recorded_at: "Fri, 17 Oct 2014 11:34:03 GMT"
     - request: 
         method: post
         uri: "https://ec2.sa-east-1.amazonaws.com/"
         body: 
           encoding: UTF-8
-          string: "AWSAccessKeyId=&Action=DescribeVpcs&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-16T12%3A20%3A28Z&Version=2014-06-15&VpcId.1=vpc-10c17875"
+          string: "AWSAccessKeyId=&Action=DescribeVpcs&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-17T11%3A34%3A03Z&Version=2014-06-15&VpcId.1=vpc-9204b9f7"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "241"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Fri, 17 Oct 2014 11:34:03 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>068924e1-0c03-45b5-8dbd-c71003851990</requestId>
+                <vpcSet>
+                </vpcSet>
+            </DescribeVpcsResponse>
+        http_version: 
+      recorded_at: "Fri, 17 Oct 2014 11:34:04 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=DescribeVpcs&Signature=SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-17T11%3A34%3A04Z&Version=2014-06-15&VpcId.1=vpc-6853ea0d"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+          Content-Length: 
+            - "235"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Fri, 17 Oct 2014 11:34:04 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>c23e9b79-fc30-466c-93d6-f000e096c67e</requestId>
+                <vpcSet>
+                </vpcSet>
+            </DescribeVpcsResponse>
+        http_version: 
+      recorded_at: "Fri, 17 Oct 2014 11:34:05 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "AWSAccessKeyId=&Action=DescribeVpcs&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-17T11%3A34%3A05Z&Version=2014-06-15&VpcId.1=vpc-9204b9f7"
         headers: 
           Content-Type: 
             - "application/x-www-form-urlencoded; charset=utf-8"
@@ -72,7 +155,7 @@
           Vary: 
             - Accept-Encoding
           Date: 
-            - "Thu, 16 Oct 2014 12:20:27 GMT"
+            - "Fri, 17 Oct 2014 11:34:05 GMT"
           Server: 
             - AmazonEC2
         body: 
@@ -80,18 +163,18 @@
           string: |-
             <?xml version="1.0" encoding="UTF-8"?>
             <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
-                <requestId>5d0337f3-cd29-4236-a2c7-7cbb7fb74c71</requestId>
+                <requestId>3e7ac2a6-e8f0-44ba-8575-dd6a69dc6977</requestId>
                 <vpcSet>
                 </vpcSet>
             </DescribeVpcsResponse>
         http_version: 
-      recorded_at: "Thu, 16 Oct 2014 12:20:29 GMT"
+      recorded_at: "Fri, 17 Oct 2014 11:34:06 GMT"
     - request: 
         method: post
         uri: "https://ec2.sa-east-1.amazonaws.com/"
         body: 
           encoding: UTF-8
-          string: "AWSAccessKeyId=&Action=DescribeVpcs&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-16T12%3A20%3A29Z&Version=2014-06-15&VpcId.1=vpc-9204b9f7"
+          string: "AWSAccessKeyId=&Action=DescribeSubnets&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-17T11%3A34%3A06Z&Version=2014-06-15"
         headers: 
           Content-Type: 
             - "application/x-www-form-urlencoded; charset=utf-8"
@@ -100,7 +183,7 @@
           User-Agent: 
             - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
           Content-Length: 
-            - "239"
+            - "217"
           Accept: 
             - "*/*"
       response: 
@@ -115,26 +198,26 @@
           Vary: 
             - Accept-Encoding
           Date: 
-            - "Thu, 16 Oct 2014 12:20:29 GMT"
+            - "Fri, 17 Oct 2014 11:34:07 GMT"
           Server: 
             - AmazonEC2
         body: 
           encoding: UTF-8
           string: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
-                <requestId>7d0f3032-e48d-4f5d-9060-73e6a5d979e3</requestId>
-                <vpcSet>
-                </vpcSet>
-            </DescribeVpcsResponse>
+            <DescribeSubnetsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+                <requestId>af8f3aed-e569-4fd7-859a-7ace68311214</requestId>
+                <subnetSet>
+                </subnetSet>
+            </DescribeSubnetsResponse>
         http_version: 
-      recorded_at: "Thu, 16 Oct 2014 12:20:31 GMT"
+      recorded_at: "Fri, 17 Oct 2014 11:34:07 GMT"
     - request: 
         method: post
         uri: "https://ec2.sa-east-1.amazonaws.com/"
         body: 
           encoding: UTF-8
-          string: "AWSAccessKeyId=&Action=DescribeVpcs&Signature=SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-16T12%3A20%3A31Z&Version=2014-06-15&VpcId.1=vpc-10c17875"
+          string: "AWSAccessKeyId=&Action=DescribeVpcs&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-17T11%3A34%3A07Z&Version=2014-06-15&VpcId.1=vpc-9204b9f7"
         headers: 
           Content-Type: 
             - "application/x-www-form-urlencoded; charset=utf-8"
@@ -143,7 +226,7 @@
           User-Agent: 
             - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
           Content-Length: 
-            - "235"
+            - "237"
           Accept: 
             - "*/*"
       response: 
@@ -158,7 +241,7 @@
           Vary: 
             - Accept-Encoding
           Date: 
-            - "Thu, 16 Oct 2014 12:20:30 GMT"
+            - "Fri, 17 Oct 2014 11:34:07 GMT"
           Server: 
             - AmazonEC2
         body: 
@@ -166,61 +249,18 @@
           string: |-
             <?xml version="1.0" encoding="UTF-8"?>
             <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
-                <requestId>0ed9df51-e89c-43e7-865d-19a1fe44eb9a</requestId>
+                <requestId>5538e567-6788-44c3-835e-f701854a3b70</requestId>
                 <vpcSet>
                 </vpcSet>
             </DescribeVpcsResponse>
         http_version: 
-      recorded_at: "Thu, 16 Oct 2014 12:20:32 GMT"
+      recorded_at: "Fri, 17 Oct 2014 11:34:08 GMT"
     - request: 
         method: post
         uri: "https://ec2.sa-east-1.amazonaws.com/"
         body: 
           encoding: UTF-8
-          string: "AWSAccessKeyId=&Action=DescribeSecurityGroups&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-16T12%3A20%3A32Z&Version=2014-06-15"
-        headers: 
-          Content-Type: 
-            - "application/x-www-form-urlencoded; charset=utf-8"
-          Accept-Encoding: 
-            - ""
-          User-Agent: 
-            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
-          Content-Length: 
-            - "224"
-          Accept: 
-            - "*/*"
-      response: 
-        status: 
-          code: 200
-          message: OK
-        headers: 
-          Content-Type: 
-            - "text/xml;charset=UTF-8"
-          Transfer-Encoding: 
-            - chunked
-          Vary: 
-            - Accept-Encoding
-          Date: 
-            - "Thu, 16 Oct 2014 12:20:31 GMT"
-          Server: 
-            - AmazonEC2
-        body: 
-          encoding: UTF-8
-          string: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <DescribeSecurityGroupsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
-                <requestId>1d0aa100-cc9d-447a-81d8-074a2afe9fe5</requestId>
-                <securityGroupInfo>
-                </securityGroupInfo>
-            </DescribeSecurityGroupsResponse>
-        http_version: 
-      recorded_at: "Thu, 16 Oct 2014 12:20:37 GMT"
-    - request: 
-        method: post
-        uri: "https://ec2.sa-east-1.amazonaws.com/"
-        body: 
-          encoding: UTF-8
-          string: "AWSAccessKeyId=&Action=DescribeVpcs&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-16T12%3A20%3A37Z&Version=2014-06-15&VpcId.1=vpc-10c17875"
+          string: "AWSAccessKeyId=&Action=DescribeVpcs&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-17T11%3A34%3A08Z&Version=2014-06-15&VpcId.1=vpc-6853ea0d"
         headers: 
           Content-Type: 
             - "application/x-www-form-urlencoded; charset=utf-8"
@@ -244,7 +284,7 @@
           Vary: 
             - Accept-Encoding
           Date: 
-            - "Thu, 16 Oct 2014 12:20:36 GMT"
+            - "Fri, 17 Oct 2014 11:34:08 GMT"
           Server: 
             - AmazonEC2
         body: 
@@ -252,18 +292,18 @@
           string: |-
             <?xml version="1.0" encoding="UTF-8"?>
             <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
-                <requestId>78c34b0a-35dd-486c-afc1-720f3aec375f</requestId>
+                <requestId>450b0e1c-65ab-4fed-affd-a444d9fa6dd0</requestId>
                 <vpcSet>
                 </vpcSet>
             </DescribeVpcsResponse>
         http_version: 
-      recorded_at: "Thu, 16 Oct 2014 12:20:38 GMT"
+      recorded_at: "Fri, 17 Oct 2014 11:34:08 GMT"
     - request: 
         method: post
         uri: "https://ec2.sa-east-1.amazonaws.com/"
         body: 
           encoding: UTF-8
-          string: "AWSAccessKeyId=&Action=DescribeVpcs&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-16T12%3A20%3A38Z&Version=2014-06-15&VpcId.1=vpc-9204b9f7"
+          string: "AWSAccessKeyId=&Action=DescribeVpcs&Signature=SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-17T11%3A34%3A08Z&Version=2014-06-15&VpcId.1=vpc-9204b9f7"
         headers: 
           Content-Type: 
             - "application/x-www-form-urlencoded; charset=utf-8"
@@ -287,7 +327,7 @@
           Vary: 
             - Accept-Encoding
           Date: 
-            - "Thu, 16 Oct 2014 12:20:37 GMT"
+            - "Fri, 17 Oct 2014 11:34:09 GMT"
           Server: 
             - AmazonEC2
         body: 
@@ -295,53 +335,10 @@
           string: |-
             <?xml version="1.0" encoding="UTF-8"?>
             <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
-                <requestId>c032a2da-144a-4f85-9e13-42707449a98c</requestId>
+                <requestId>9535b46b-c70c-4b14-9caf-e8453a4e5ca0</requestId>
                 <vpcSet>
                 </vpcSet>
             </DescribeVpcsResponse>
         http_version: 
-      recorded_at: "Thu, 16 Oct 2014 12:20:39 GMT"
-    - request: 
-        method: post
-        uri: "https://ec2.sa-east-1.amazonaws.com/"
-        body: 
-          encoding: UTF-8
-          string: "AWSAccessKeyId=&Action=DescribeVpcs&Signature=SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-16T12%3A20%3A39Z&Version=2014-06-15&VpcId.1=vpc-10c17875"
-        headers: 
-          Content-Type: 
-            - "application/x-www-form-urlencoded; charset=utf-8"
-          Accept-Encoding: 
-            - ""
-          User-Agent: 
-            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
-          Content-Length: 
-            - "235"
-          Accept: 
-            - "*/*"
-      response: 
-        status: 
-          code: 200
-          message: OK
-        headers: 
-          Content-Type: 
-            - "text/xml;charset=UTF-8"
-          Transfer-Encoding: 
-            - chunked
-          Vary: 
-            - Accept-Encoding
-          Date: 
-            - "Thu, 16 Oct 2014 12:20:39 GMT"
-          Server: 
-            - AmazonEC2
-        body: 
-          encoding: UTF-8
-          string: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
-                <requestId>495a2ea5-1b6a-4c79-ba79-84fea12c1ea7</requestId>
-                <vpcSet>
-                </vpcSet>
-            </DescribeVpcsResponse>
-        http_version: 
-      recorded_at: "Thu, 16 Oct 2014 12:20:40 GMT"
+      recorded_at: "Fri, 17 Oct 2014 11:34:09 GMT"
   recorded_with: "VCR 2.9.3"

--- a/lib/puppet/provider/ec2_vpc/v2.rb
+++ b/lib/puppet/provider/ec2_vpc/v2.rb
@@ -1,0 +1,75 @@
+require_relative '../../../puppet_x/puppetlabs/aws.rb'
+
+Puppet::Type.type(:ec2_vpc).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) do
+  confine feature: :aws
+
+  mk_resource_methods
+
+  def self.instances
+    regions.collect do |region|
+      response = ec2_client(region).describe_vpcs()
+      vpcs = []
+        response.data.vpcs.each do |vpc|
+        hash = vpc_to_hash(region, vpc)
+        vpcs << new(hash) if hash[:name]
+      end
+      vpcs
+    end.flatten
+  end
+
+  read_only(:cidr_block)
+
+  def self.prefetch(resources)
+    instances.each do |prov|
+      if resource = resources[prov.name] # rubocop:disable Lint/AssignmentInCondition
+        resource.provider = prov if resource[:region] == prov.region
+      end
+    end
+  end
+
+  def self.vpc_to_hash(region, vpc)
+    name_tag = vpc.tags.detect { |tag| tag.key == 'Name' }
+    {
+      name: name_tag ? name_tag.value : nil,
+      cidr_block: vpc.cidr_block,
+      ensure: :present,
+      region: region,
+    }
+  end
+
+  def exists?
+    Puppet.info("Checking if VPC #{name} exists")
+    @property_hash[:ensure] == :present
+  end
+
+  def create
+    Puppet.info("Creating VPC #{name}")
+    ec2 = ec2_client(resource[:region])
+    response = ec2.create_vpc(
+      cidr_block: resource[:cidr_block]
+    )
+    route_response = ec2.describe_route_tables(filters: [
+      {name: 'vpc-id', values: [response.data.vpc.vpc_id]},
+      {name: 'association.main', values: ['true']},
+    ])
+    ec2.create_tags(
+      resources: [route_response.data.route_tables.first.route_table_id, response.data.vpc.vpc_id],
+      tags: [{key: 'Name', value: name}]
+    )
+  end
+
+  def destroy
+    Puppet.info("Deleting VPC #{name}}")
+    ec2 = ec2_client(resource[:region])
+    response = ec2.describe_vpcs(filters: [
+      {name: 'tag:Name', values: [name]},
+    ])
+    fail("Multiple VPCs with name #{name}. Not deleting.") if response.data.vpcs.count > 1
+    response.data.vpcs.each do |vpc|
+      ec2.delete_vpc(
+        vpc_id: vpc.vpc_id
+      )
+    end
+  end
+end
+

--- a/lib/puppet/provider/ec2_vpc_internet_gateway/v2.rb
+++ b/lib/puppet/provider/ec2_vpc_internet_gateway/v2.rb
@@ -1,0 +1,89 @@
+require_relative '../../../puppet_x/puppetlabs/aws.rb'
+
+Puppet::Type.type(:ec2_vpc_internet_gateway).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) do
+  confine feature: :aws
+
+  mk_resource_methods
+
+  def self.instances
+    regions.collect do |region|
+      response = ec2_client(region).describe_internet_gateways()
+      gateways = []
+      response.data.internet_gateways.each do |gateway|
+        hash = gateway_to_hash(region, gateway)
+        gateways << new(hash) if hash[:name]
+      end
+      gateways
+    end.flatten
+  end
+
+  read_only(:region, :vpcs)
+
+  def self.prefetch(resources)
+    instances.each do |prov|
+      if resource = resources[prov.name] # rubocop:disable Lint/AssignmentInCondition
+        resource.provider = prov if resource[:region] == prov.region
+      end
+    end
+  end
+
+  def self.gateway_to_hash(region, gateway)
+    vpc_response = ec2_client(region).describe_vpcs(vpc_ids: gateway.attachments.map(&:vpc_id))
+    vpcs = []
+    vpc_response.data.vpcs.each do |vpc|
+      vpc_name_tag = vpc.tags.detect { |tag| tag.key == 'Name' }
+      vpcs << vpc_name_tag.value if vpc_name_tag
+    end
+    name_tag = gateway.tags.detect { |tag| tag.key == 'Name' }
+    {
+      name: name_tag ? name_tag.value : nil,
+      vpcs: vpcs,
+      ensure: :present,
+      region: region,
+    }
+  end
+
+  def exists?
+    Puppet.info("Checking if internet gateway #{name} exists")
+    @property_hash[:ensure] == :present
+  end
+
+  def create
+    Puppet.info("Creating internet gateway #{name}")
+    ec2 = ec2_client(resource[:region])
+    vpc_response = ec2.describe_vpcs(filters: [
+      {name: "tag:Name", values: resource[:vpcs]},
+    ])
+    response = ec2.create_internet_gateway()
+    id = response.data.internet_gateway.internet_gateway_id
+    vpc_response.data.vpcs.each do |vpc|
+      ec2.attach_internet_gateway(
+        internet_gateway_id: id,
+        vpc_id: vpc.vpc_id,
+      )
+    end
+    ec2.create_tags(
+      resources: [id],
+      tags: [{key: 'Name', value: name}]
+    )
+  end
+
+  def destroy
+    Puppet.info("Deleting internet gateway #{name}")
+    ec2 = ec2_client(resource[:region])
+    response = ec2.describe_internet_gateways(filters: [
+      {name: 'tag:Name', values: [name]},
+    ])
+    fail("Multiple gateways with name #{name}. Not deleting.") if response.data.internet_gateways.count > 1
+    response.data.internet_gateways.each do |gateway|
+      gateway.attachments.each do |vpc|
+        ec2.detach_internet_gateway(
+          internet_gateway_id: gateway.internet_gateway_id,
+          vpc_id: vpc.vpc_id,
+        )
+      end
+      ec2.delete_internet_gateway(internet_gateway_id: gateway.internet_gateway_id)
+    end
+  end
+end
+

--- a/lib/puppet/provider/ec2_vpc_route_table/v2.rb
+++ b/lib/puppet/provider/ec2_vpc_route_table/v2.rb
@@ -1,0 +1,109 @@
+require_relative '../../../puppet_x/puppetlabs/aws.rb'
+
+Puppet::Type.type(:ec2_vpc_route_table).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) do
+  confine feature: :aws
+
+  mk_resource_methods
+
+  def self.instances
+    regions.collect do |region|
+      response = ec2_client(region).describe_route_tables()
+      tables = []
+      response.data.route_tables.each do |table|
+        hash = route_table_to_hash(region, table)
+        tables << new(hash) if hash[:name]
+      end
+      tables
+    end.flatten
+  end
+
+  read_only(:region, :vpc, :routes)
+
+  def self.prefetch(resources)
+    instances.each do |prov|
+      if resource = resources[prov.name] # rubocop:disable Lint/AssignmentInCondition
+        resource.provider = prov if resource[:region] == prov.region
+      end
+    end
+  end
+
+  def self.route_to_hash(region, route)
+    ec2 = ec2_client(region)
+    if route.gateway_id == 'local'
+      gateway = 'local'
+    else
+      igw_response = ec2.describe_internet_gateways(internet_gateway_ids: [route.gateway_id])
+      igw_name_tag = igw_response.data.internet_gateways.first.tags.detect { |tag| tag.key == 'Name' }
+      gateway = igw_name_tag ? igw_name_tag.value : nil
+    end
+    {
+      'destination_cidr_block' => route.destination_cidr_block,
+      'gateway' => gateway,
+    }
+  end
+
+  def self.route_table_to_hash(region, table)
+    ec2 = ec2_client(region)
+    vpc_response = ec2.describe_vpcs(vpc_ids: [table.vpc_id])
+    vpc_name_tag = vpc_response.data.vpcs.first.tags.detect { |tag| tag.key == 'Name' }
+    name_tag = table.tags.detect { |tag| tag.key == 'Name' }
+
+    routes = []
+    table.routes.each do |route|
+      routes << route_to_hash(region, route)
+    end
+
+    {
+      name: name_tag ? name_tag.value : nil,
+      id: table.route_table_id,
+      vpc: vpc_name_tag ? vpc_name_tag.value : nil,
+      ensure: :present,
+      routes: routes,
+      region: region,
+    }
+  end
+
+  def exists?
+    Puppet.info("Checking if route table #{name} exists")
+    @property_hash[:ensure] == :present
+  end
+
+  def create
+    Puppet.info("Creating route table #{name}")
+    ec2 = ec2_client(resource[:region])
+    vpc_response = ec2.describe_vpcs(filters: [
+      {name: "tag:Name", values: [resource[:vpc]]},
+    ])
+    response = ec2.create_route_table(
+      vpc_id: vpc_response.data.vpcs.first.vpc_id,
+    )
+    id = response.data.route_table.route_table_id
+    ec2.create_tags(
+      resources: [id],
+      tags: [{key: 'Name', value: name}]
+    )
+    resource[:routes].each do |route|
+      gateway_response = ec2.describe_internet_gateways(filters: [
+        {name: "tag:Name", values: [route['gateway']]},
+      ])
+      ec2.create_route(
+        route_table_id: id,
+        destination_cidr_block: route['destination_cidr_block'],
+        gateway_id: gateway_response.data.internet_gateways.first.internet_gateway_id,
+      ) unless gateway_response.data.internet_gateways.empty?
+    end if resource[:routes]
+    @property_hash[:ensure] = :present
+  end
+
+  def destroy
+    Puppet.info("Deleting route table #{name}")
+    ec2 = ec2_client(resource[:region])
+    response = ec2.describe_route_tables(filters: [
+      {name: 'tag:Name', values: [name]},
+    ])
+    fail("Multiple route tables with name #{name}. Not deleting.") if response.data.route_tables.count > 1
+    ec2.delete_route_table(route_table_id: response.data.route_tables.first.route_table_id)
+    @property_hash[:ensure] = :absent
+  end
+end
+

--- a/lib/puppet/provider/ec2_vpc_subnet/v2.rb
+++ b/lib/puppet/provider/ec2_vpc_subnet/v2.rb
@@ -1,0 +1,81 @@
+require_relative '../../../puppet_x/puppetlabs/aws.rb'
+
+Puppet::Type.type(:ec2_vpc_subnet).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) do
+  confine feature: :aws
+
+  mk_resource_methods
+
+  def self.instances
+    regions.collect do |region|
+      response = ec2_client(region).describe_subnets()
+      subnets = []
+      response.data.subnets.each do |subnet|
+        hash = subnet_to_hash(region, subnet)
+        subnets << new(hash) if hash[:name]
+      end
+      subnets
+    end.flatten
+  end
+
+  read_only(:cidr_block, :vpc)
+
+  def self.prefetch(resources)
+    instances.each do |prov|
+      if resource = resources[prov.name] # rubocop:disable Lint/AssignmentInCondition
+        resource.provider = prov if resource[:region] == prov.region
+      end
+    end
+  end
+
+  def self.subnet_to_hash(region, subnet)
+    vpc_response = ec2_client(region).describe_vpcs(vpc_ids: [subnet.vpc_id])
+    vpc_name_tag = vpc_response.data.vpcs.first.tags.detect { |tag| tag.key == 'Name' }
+    name_tag = subnet.tags.detect { |tag| tag.key == 'Name' }
+    {
+      name: name_tag ? name_tag.value : nil,
+      cidr_block: subnet.cidr_block,
+      availability_zone: subnet.availability_zone,
+      vpc: vpc_name_tag ? vpc_name_tag.value : nil,
+      ensure: :present,
+      region: region,
+    }
+  end
+
+  def exists?
+    Puppet.info("Checking if subnet #{name} exists")
+    @property_hash[:ensure] == :present
+  end
+
+  def create
+    Puppet.info("Creating subnet #{name}")
+    ec2 = ec2_client(resource[:region])
+    vpc_response = ec2.describe_vpcs(filters: [
+      {name: "tag:Name", values: [resource[:vpc]]},
+    ])
+    fail("Multiple VPCs with name #{resource[:vpc]}") if vpc_response.data.vpcs.count > 1
+    response = ec2.create_subnet(
+      cidr_block: resource[:cidr_block],
+      availability_zone: resource[:availability_zone],
+      vpc_id: vpc_response.data.vpcs.first.vpc_id,
+    )
+    ec2.create_tags(
+      resources: [response.data.subnet.subnet_id],
+      tags: [{key: 'Name', value: name}]
+    )
+  end
+
+  def destroy
+    Puppet.info("Deleting subnet #{name}")
+    ec2 = ec2_client(resource[:region])
+    response = ec2.describe_subnets(filters: [
+      {name: 'tag:Name', values: [name]},
+    ])
+    fail("Multiple subnets with name #{name}. Not deleting.") if response.data.subnets.count > 1
+    response.data.subnets.each do |subnet|
+      ec2.delete_subnet(
+        subnet_id: subnet.subnet_id
+      )
+    end
+  end
+end
+

--- a/lib/puppet/type/ec2_vpc.rb
+++ b/lib/puppet/type/ec2_vpc.rb
@@ -1,0 +1,21 @@
+Puppet::Type.newtype(:ec2_vpc) do
+  @doc = 'type representing an EC2 VPC'
+
+  ensurable
+
+  newparam(:name, namevar: true) do
+    desc 'the name of the VPC'
+    validate do |value|
+      fail Puppet::Error, 'Empty values are not allowed' if value == ''
+    end
+  end
+
+  newproperty(:cidr_block) do
+    desc 'the classless inter-domain routing block for this VPC'
+  end
+
+  newproperty(:region) do
+    desc 'the region in which to launch the VPC'
+  end
+
+end

--- a/lib/puppet/type/ec2_vpc_internet_gateway.rb
+++ b/lib/puppet/type/ec2_vpc_internet_gateway.rb
@@ -1,0 +1,26 @@
+Puppet::Type.newtype(:ec2_vpc_internet_gateway) do
+  @doc = 'type representing an EC2 VPC Internet Gateway'
+
+  ensurable
+
+  newparam(:name, namevar: true) do
+    desc 'the name of the internet gateway'
+    validate do |value|
+      fail Puppet::Error, 'Empty values are not allowed' if value == ''
+    end
+  end
+
+  newproperty(:region) do
+    desc 'the region in which to launch the subnet'
+  end
+
+  newproperty(:vpcs, :array_matching => :all) do
+    desc 'the vpc to assign this subnet to'
+  end
+
+  autorequire(:ec2_vpc) do
+    vpcs = self[:vpcs]
+    vpcs.is_a?(Array) ? vpcs : [vpcs]
+  end
+
+end

--- a/lib/puppet/type/ec2_vpc_route_table.rb
+++ b/lib/puppet/type/ec2_vpc_route_table.rb
@@ -1,0 +1,36 @@
+Puppet::Type.newtype(:ec2_vpc_route_table) do
+  @doc = 'type representing an EC2 VPC Route Table'
+
+  ensurable
+
+  newparam(:name, namevar: true) do
+    desc 'the name of the route table'
+    validate do |value|
+      fail Puppet::Error, 'Empty values are not allowed' if value == ''
+    end
+  end
+
+  newproperty(:region) do
+    desc 'the region in which to launch the route table'
+  end
+
+  newproperty(:vpc) do
+    desc 'the vpc to assign this route table to'
+  end
+
+  newproperty(:routes, :array_matching => :all) do
+    desc 'individual routes for the routing table'
+    def insync?(is)
+      is.sort_by { |route| route['gateway'] } == should.sort_by { |route| route['gateway'] }
+    end
+  end
+
+  autorequire(:ec2_vpc) do
+    self[:vpc]
+  end
+
+  autorequire(:ec2_vpc_internet_gateway) do
+    self[:routes].collect { |route| route['gateway'] }.reject(&:nil?)
+  end
+
+end

--- a/lib/puppet/type/ec2_vpc_subnet.rb
+++ b/lib/puppet/type/ec2_vpc_subnet.rb
@@ -1,0 +1,33 @@
+Puppet::Type.newtype(:ec2_vpc_subnet) do
+  @doc = 'type representing an EC2 VPC Subnet'
+
+  ensurable
+
+  newparam(:name, namevar: true) do
+    desc 'the name of the subnet'
+    validate do |value|
+      fail Puppet::Error, 'Empty values are not allowed' if value == ''
+    end
+  end
+
+  newproperty(:cidr_block) do
+    desc 'the classless inter-domain routing block for this subnet'
+  end
+
+  newproperty(:region) do
+    desc 'the region in which to launch the subnet'
+  end
+
+  newproperty(:availability_zone) do
+    desc 'the availability zone in which to create the subnet'
+  end
+
+  newproperty(:vpc) do
+    desc 'the vpc to assign this subnet to'
+  end
+
+  autorequire(:ec2_vpc) do
+    self[:vpc]
+  end
+
+end

--- a/spec/unit/provider/ec2_vpc/v2_spec.rb
+++ b/spec/unit/provider/ec2_vpc/v2_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+
+provider_class = Puppet::Type.type(:ec2_vpc).provider(:v2)
+
+ENV['AWS_ACCESS_KEY_ID'] = 'redacted'
+ENV['AWS_SECRET_ACCESS_KEY'] = 'redacted'
+ENV['AWS_REGION'] = 'sa-east-1'
+
+describe provider_class do
+
+  let(:resource) {
+    Puppet::Type.type(:ec2_vpc).new(
+      name: 'test-vpc',
+      cidr_block: '10.0.0.0/16',
+      region: 'sa-east-1',
+    )
+  }
+
+  let(:provider) { resource.provider }
+
+
+  it 'should be an instance of the ProviderV2' do
+    expect(provider).to be_an_instance_of Puppet::Type::Ec2_vpc::ProviderV2
+  end
+
+  describe 'self.prefetch' do
+    it 'should exist' do
+      VCR.use_cassette('vpc-setup') do
+        provider.class.instances
+        provider.class.prefetch({})
+      end
+    end
+  end
+
+  context 'with the minimum params' do
+
+    describe 'running exists?' do
+      it 'should correctly report non-existent VPC' do
+        VCR.use_cassette('no-vpc-named-test') do
+          expect(provider.exists?).to be_falsy
+        end
+      end
+
+      it 'should correctly find existing VPCs' do
+        VCR.use_cassette('vpc-named-test') do
+          instance = provider.class.instances.first
+          expect(instance.exists?).to be_truthy
+        end
+      end
+    end
+
+    describe 'running create' do
+      it 'should send a request to the EC2 API to create the VPC' do
+        VCR.use_cassette('create-vpc') do
+          expect(provider.create).to be_truthy
+        end
+      end
+    end
+
+    describe 'running destroy' do
+      it 'should send a request to the EC2 API to destroy the VPC' do
+        VCR.use_cassette('destroy-vpc') do
+          expect(provider.destroy).to be_truthy
+        end
+      end
+    end
+
+  end
+
+end

--- a/spec/unit/provider/ec2_vpc_internet_gateway/v2_spec.rb
+++ b/spec/unit/provider/ec2_vpc_internet_gateway/v2_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+
+provider_class = Puppet::Type.type(:ec2_vpc_internet_gateway).provider(:v2)
+
+#ENV['AWS_ACCESS_KEY_ID'] = 'redacted'
+#ENV['AWS_SECRET_ACCESS_KEY'] = 'redacted'
+ENV['AWS_REGION'] = 'sa-east-1'
+
+describe provider_class do
+
+  let(:resource) {
+    Puppet::Type.type(:ec2_vpc_internet_gateway).new(
+      name: 'test-gateway',
+      vpcs: ['test-vpc'],
+      region: 'sa-east-1',
+    )
+  }
+
+  let(:provider) { resource.provider }
+
+
+  it 'should be an instance of the ProviderV2' do
+    expect(provider).to be_an_instance_of Puppet::Type::Ec2_vpc_internet_gateway::ProviderV2
+  end
+
+  describe 'self.prefetch' do
+    it 'should exist' do
+      VCR.use_cassette('gateway-setup') do
+        provider.class.instances
+        provider.class.prefetch({})
+      end
+    end
+  end
+
+  context 'with the minimum params' do
+
+    describe 'running exists?' do
+      it 'should correctly report non-existent internet gateway' do
+        VCR.use_cassette('no-gateway-named-test') do
+          expect(provider.exists?).to be_falsy
+        end
+      end
+
+      it 'should correctly find existing internet gateways' do
+        VCR.use_cassette('gateway-named-test') do
+          instance = provider.class.instances.first
+          expect(instance.exists?).to be_truthy
+        end
+      end
+    end
+
+    describe 'running create' do
+      it 'should send a request to the EC2 API to create the internet gateway' do
+        VCR.use_cassette('create-gateway') do
+          expect(provider.create).to be_truthy
+        end
+      end
+    end
+
+    describe 'running destroy' do
+      it 'should send a request to the EC2 API to destroy the internet gateway' do
+        VCR.use_cassette('destroy-gateway') do
+          expect(provider.destroy).to be_truthy
+        end
+      end
+    end
+
+  end
+
+end

--- a/spec/unit/provider/ec2_vpc_route_table/v2_spec.rb
+++ b/spec/unit/provider/ec2_vpc_route_table/v2_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+
+provider_class = Puppet::Type.type(:ec2_vpc_route_table).provider(:v2)
+
+ENV['AWS_ACCESS_KEY_ID'] = 'redacted'
+ENV['AWS_SECRET_ACCESS_KEY'] = 'redacted'
+ENV['AWS_REGION'] = 'sa-east-1'
+
+describe provider_class do
+
+  let(:resource) {
+    Puppet::Type.type(:ec2_vpc_route_table).new(
+      name: 'test-route-table',
+      vpc: 'test-vpc',
+      region: 'sa-east-1',
+    )
+  }
+
+  let(:provider) { resource.provider }
+
+
+  it 'should be an instance of the ProviderV2' do
+    expect(provider).to be_an_instance_of Puppet::Type::Ec2_vpc_route_table::ProviderV2
+  end
+
+  describe 'self.prefetch' do
+    it 'should exist' do
+      VCR.use_cassette('route-table-setup') do
+        provider.class.instances
+        provider.class.prefetch({})
+      end
+    end
+  end
+
+  context 'with the minimum params' do
+
+    describe 'running exists?' do
+      it 'should correctly report non-existent route table' do
+        VCR.use_cassette('no-route-table-named-test') do
+          expect(provider.exists?).to be_falsy
+        end
+      end
+
+      it 'should correctly find existing route tables' do
+        VCR.use_cassette('route-table-named-test') do
+          instance = provider.class.instances.first
+          expect(instance.exists?).to be_truthy
+        end
+      end
+    end
+
+    describe 'running create' do
+      it 'should send a request to the EC2 API to create the route table' do
+        VCR.use_cassette('create-route-table') do
+          expect(provider.create).to be_truthy
+        end
+      end
+    end
+
+    describe 'running destroy' do
+      it 'should send a request to the EC2 API to destroy the route table' do
+        VCR.use_cassette('destroy-route-table') do
+          expect(provider.destroy).to be_truthy
+        end
+      end
+    end
+
+  end
+
+end

--- a/spec/unit/provider/ec2_vpc_subnet/v2_spec.rb
+++ b/spec/unit/provider/ec2_vpc_subnet/v2_spec.rb
@@ -1,0 +1,72 @@
+require 'spec_helper'
+
+provider_class = Puppet::Type.type(:ec2_vpc_subnet).provider(:v2)
+
+ENV['AWS_ACCESS_KEY_ID'] = 'redacted'
+ENV['AWS_SECRET_ACCESS_KEY'] = 'redacted'
+ENV['AWS_REGION'] = 'sa-east-1'
+
+describe provider_class do
+
+  let(:resource) {
+    Puppet::Type.type(:ec2_vpc_subnet).new(
+      name: 'test-subnet',
+      cidr_block: '10.0.0.0/24',
+      region: 'sa-east-1',
+      availability_zone: 'sa-east-1a',
+      vpc: 'test-vpc',
+    )
+  }
+
+  let(:provider) { resource.provider }
+
+
+  it 'should be an instance of the ProviderV2' do
+    expect(provider).to be_an_instance_of Puppet::Type::Ec2_vpc_subnet::ProviderV2
+  end
+
+  describe 'self.prefetch' do
+    it 'should exist' do
+      VCR.use_cassette('vpc-subnet-setup') do
+        provider.class.instances
+        provider.class.prefetch({})
+      end
+    end
+  end
+
+  context 'with the minimum params' do
+
+    describe 'running exists?' do
+      it 'should correctly report non-existent subnet' do
+        VCR.use_cassette('no-subnet-named-test') do
+          expect(provider.exists?).to be_falsy
+        end
+      end
+
+      it 'should correctly find existing subnets' do
+        VCR.use_cassette('subnet-named-test') do
+          instance = provider.class.instances.first
+          expect(instance.exists?).to be_truthy
+        end
+      end
+    end
+
+    describe 'running create' do
+      it 'should send a request to the EC2 API to create the subnet' do
+        VCR.use_cassette('create-subnet') do
+          expect(provider.create).to be_truthy
+        end
+      end
+    end
+
+    describe 'running destroy' do
+      it 'should send a request to the EC2 API to destroy the subnet' do
+        VCR.use_cassette('destroy-subnet') do
+          expect(provider.destroy).to be_truthy
+        end
+      end
+    end
+
+  end
+
+end

--- a/spec/unit/type/ec2_vpc_internet_gateway_spec.rb
+++ b/spec/unit/type/ec2_vpc_internet_gateway_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+type_class = Puppet::Type.type(:ec2_vpc_internet_gateway)
+
+describe type_class do
+
+  let :params do
+    [
+      :name,
+    ]
+  end
+
+  let :properties do
+    [
+      :ensure,
+      :vpcs,
+      :region,
+    ]
+  end
+
+  it 'should have expected properties' do
+    properties.each do |property|
+      expect(type_class.properties.map(&:name)).to be_include(property)
+    end
+  end
+
+  it 'should have expected parameters' do
+    params.each do |param|
+      expect(type_class.parameters).to be_include(param)
+    end
+  end
+end

--- a/spec/unit/type/ec2_vpc_route_table_spec.rb
+++ b/spec/unit/type/ec2_vpc_route_table_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+type_class = Puppet::Type.type(:ec2_vpc_route_table)
+
+describe type_class do
+
+  let :params do
+    [
+      :name,
+    ]
+  end
+
+  let :properties do
+    [
+      :ensure,
+      :vpc,
+      :region,
+      :routes,
+    ]
+  end
+
+  it 'should have expected properties' do
+    properties.each do |property|
+      expect(type_class.properties.map(&:name)).to be_include(property)
+    end
+  end
+
+  it 'should have expected parameters' do
+    params.each do |param|
+      expect(type_class.parameters).to be_include(param)
+    end
+  end
+end

--- a/spec/unit/type/ec2_vpc_spec.rb
+++ b/spec/unit/type/ec2_vpc_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+type_class = Puppet::Type.type(:ec2_vpc)
+
+describe type_class do
+
+  let :params do
+    [
+      :name,
+    ]
+  end
+
+  let :properties do
+    [
+      :ensure,
+      :cidr_block,
+      :region,
+    ]
+  end
+
+  it 'should have expected properties' do
+    properties.each do |property|
+      expect(type_class.properties.map(&:name)).to be_include(property)
+    end
+  end
+
+  it 'should have expected parameters' do
+    params.each do |param|
+      expect(type_class.parameters).to be_include(param)
+    end
+  end
+end

--- a/spec/unit/type/ec2_vpc_subnet_spec.rb
+++ b/spec/unit/type/ec2_vpc_subnet_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+type_class = Puppet::Type.type(:ec2_vpc_subnet)
+
+describe type_class do
+
+  let :params do
+    [
+      :name,
+    ]
+  end
+
+  let :properties do
+    [
+      :ensure,
+      :cidr_block,
+      :region,
+      :availability_zone,
+      :vpc,
+    ]
+  end
+
+  it 'should have expected properties' do
+    properties.each do |property|
+      expect(type_class.properties.map(&:name)).to be_include(property)
+    end
+  end
+
+  it 'should have expected parameters' do
+    params.each do |param|
+      expect(type_class.parameters).to be_include(param)
+    end
+  end
+end


### PR DESCRIPTION
* VPC
* Subnet
* Internet gateway
* Route table

Also includes modifications to instances and security groups to work
with VPC.

I've been using this scenario as a basis to get to the first working
version of this support:
http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_Scenario1.html

At this point it would be useful to review I think from a functionality
point of view. It's a bigger than ideal diff and it would be better to
get it in sooner rather than later.