### PR TITLE
fix bug with idempotent runs and multiple ingress rules 

### DIFF
--- a/lib/puppet/provider/ec2_securitygroup/v2.rb
+++ b/lib/puppet/provider/ec2_securitygroup/v2.rb
@@ -36,11 +36,13 @@ Puppet::Type.type(:ec2_securitygroup).provide(:v2, :parent => PuppetX::Puppetlab
           'cidr' => rule.ip_ranges.first.cidr_ip
         }
       else
-        {
-          'security_group' => rule.user_id_group_pairs.first.group_name
-        }
+        rule.user_id_group_pairs.collect do |security_group|
+          {
+            'security_group' => security_group.group_name
+          }
+        end
       end
-    end.uniq
+    end.flatten.uniq
   end
 
   def self.security_group_to_hash(region, group)
@@ -61,15 +63,16 @@ Puppet::Type.type(:ec2_securitygroup).provide(:v2, :parent => PuppetX::Puppetlab
 
   def create
     Puppet.info("Creating security group #{name} in region #{resource[:region]}")
+    ec2 = ec2_client(resource[:region])
     tags = resource[:tags] ? resource[:tags].map { |k,v| {key: k, value: v} } : []
-    response = ec2_client(resource[:region]).create_security_group(
+    response = ec2.create_security_group(
       group_name: name,
       description: resource[:description]
     )
 
     @property_hash[:ensure] = :present
 
-    ec2_client(resource[:region]).create_tags(
+    ec2.create_tags(
       resources: [response.group_id],
       tags: tags
     ) unless tags.empty?
@@ -79,12 +82,12 @@ Puppet::Type.type(:ec2_securitygroup).provide(:v2, :parent => PuppetX::Puppetlab
 
     rules.reject(&:nil?).each do |rule|
       if rule.key? 'security_group'
-        ec2_client(resource[:region]).authorize_security_group_ingress(
+        ec2.authorize_security_group_ingress(
           group_name: name,
           source_security_group_name: rule['security_group']
         )
       else
-        ec2_client(resource[:region]).authorize_security_group_ingress(
+        ec2.authorize_security_group_ingress(
           group_name: name,
           ip_permissions: [{
             ip_protocol: rule['protocol'],


### PR DESCRIPTION
- If you had more than one security group ingress rule the second run
  would fail
- For instance running tests/create.pp twice would fail for the
  puppet-sg group
- Rather than grabbing the first group lets loop over them. This runs
  for me for the create test
