### PR TITLE
Add route53 record support

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -3,6 +3,8 @@ infrastructure.
 
 * [Puppet Enterprise](puppet-enterprise/) - quickly startup a small
   Puppet Enterprise cluster using the AWS module
+* [Managing DNS](manage-dns/) - manage DNS records in Amazon Route53
+  using Puppet
 * [Data Driven Manifests](data-driven-manifests/) - use the future
   parser to automatically generate resources based on a data structure
 * [Hiera Example](hiera-example/) - store common information like region

--- a/examples/manage-dns/README.md
+++ b/examples/manage-dns/README.md
@@ -1,0 +1,72 @@
+# DNS
+
+This example demonstrates using the Route53 resources to manage DNS
+records.
+
+## What
+
+For this example we'll create a Zone, along with an A record. We'll also
+show how to list current records of the supported types.
+
+The Zone we're creating is for `puppetlabs.com`, although when you run
+the example you may want to change that to your own domain.
+
+## How
+
+With the module installed as described in the README, from this
+directory run:
+
+    puppet apply init.pp --test
+
+
+This should create a ROute53 zone and an A record for
+`local.puppetlabs.com` pointing to 127.0.0.1.
+
+You should be see the zone when you run:
+
+    puppet resource route53_zone
+
+This should output the following, maybe along with other domains you're
+already managing.
+
+```puppet
+route53_zone { 'puppetlabs.com.':
+  ensure => 'present',
+}
+```
+
+And to list the A records:
+
+    puppet resource route53_a_record
+
+Which should return:
+
+```puppet
+route53_a_record { 'local.puppetlabs.com.':
+  ensure => 'present',
+  ttl    => '3000',
+  values => ['127.0.0.1'],
+  zone   => 'puppetlabs.com.',
+}
+```
+
+We can also list the automatically created NS records with:
+
+    puppet resource route53_ns_record
+
+Which should output something like:
+
+```puppet
+route53_ns_record { 'puppetlabs.com.':
+  ensure => 'present',
+  ttl    => '172800',
+  values => ['ns-1254.awsdns-28.org.', 'ns-1922.awsdns-48.co.uk.', 'ns-806.awsdns-36.net.', 'ns-103.awsdns-12.com.'],
+  zone   => 'puppetlabs.com.',
+}
+```
+
+Finally we can delete the A record followed by the Zone:
+
+    puppet resource route53_a_record local.puppetlabs.com. zone=puppetlabs.com. values=127.0.0.1 ttl=3000 ensure=absent
+    puppet resource route53_zone puppetlabs.com. ensure=absent
+

--- a/examples/manage-dns/README.md
+++ b/examples/manage-dns/README.md
@@ -5,8 +5,8 @@ records.
 
 ## What
 
-For this example we'll create a Zone, along with an A record. We'll also
-show how to list current records of the supported types.
+For this example we'll create a Zone, along with an A record and a TXT
+record. We'll also show how to list current records of the supported types.
 
 The Zone we're creating is for `puppetlabs.com`, although when you run
 the example you may want to change that to your own domain.
@@ -18,9 +18,8 @@ directory run:
 
     puppet apply init.pp --test
 
-
-This should create a ROute53 zone and an A record for
-`local.puppetlabs.com` pointing to 127.0.0.1.
+This should create a Route53 zone, an A record for
+`local.puppetlabs.com` pointing to 127.0.0.1 and a TXT record.
 
 You should be see the zone when you run:
 
@@ -50,9 +49,10 @@ route53_a_record { 'local.puppetlabs.com.':
 }
 ```
 
-We can also list the automatically created NS records with:
+We can also list the automatically created NS record and a TXT record with:
 
     puppet resource route53_ns_record
+    puppet resource route53_txt_record
 
 Which should output something like:
 
@@ -65,8 +65,17 @@ route53_ns_record { 'puppetlabs.com.':
 }
 ```
 
-Finally we can delete the A record followed by the Zone:
+and:
 
-    puppet resource route53_a_record local.puppetlabs.com. zone=puppetlabs.com. values=127.0.0.1 ttl=3000 ensure=absent
-    puppet resource route53_zone puppetlabs.com. ensure=absent
+```puppet
+route53_txt_record { 'local.puppetlabs.com.':
+  ensure => 'present',
+  ttl    => '17200',
+  values => ['"message"'],
+  zone   => 'puppetlabs.com.',
+}
+```
 
+Finally we can delete all the records followed by the zone:
+
+    puppet apply delete.pp --test

--- a/examples/manage-dns/delete.pp
+++ b/examples/manage-dns/delete.pp
@@ -1,0 +1,13 @@
+route53_zone { 'puppetlabs.com.':
+  ensure => absent,
+}
+
+route53_a_record { 'local.puppetlabs.com.':
+  ensure => absent,
+  before => Route53_zone['puppetlabs.com.'],
+}
+
+route53_txt_record { 'local.puppetlabs.com.':
+  ensure => absent,
+  before => Route53_zone['puppetlabs.com.'],
+}

--- a/examples/manage-dns/init.pp
+++ b/examples/manage-dns/init.pp
@@ -1,0 +1,11 @@
+route53_zone { 'puppetlabs.com.':
+  ensure => present,
+}
+
+route53_a_record { 'local.puppetlabs.com.':
+  ensure => present,
+  zone   => 'puppetlabs.com.',
+  ttl    => 3000,
+  values => ['127.0.0.1'],
+}
+

--- a/examples/manage-dns/init.pp
+++ b/examples/manage-dns/init.pp
@@ -13,5 +13,5 @@ route53_txt_record { 'local.puppetlabs.com.':
   ensure => present,
   zone   => 'puppetlabs.com.',
   ttl    => 17200,
-  values => '"message"'
+  values => 'message'
 }

--- a/examples/manage-dns/init.pp
+++ b/examples/manage-dns/init.pp
@@ -9,3 +9,9 @@ route53_a_record { 'local.puppetlabs.com.':
   values => ['127.0.0.1'],
 }
 
+route53_txt_record { 'local.puppetlabs.com.':
+  ensure => present,
+  zone   => 'puppetlabs.com.',
+  ttl    => 17200,
+  values => '"message"'
+}

--- a/fixtures/vcr_cassettes/create-record.yml
+++ b/fixtures/vcr_cassettes/create-record.yml
@@ -1,0 +1,85 @@
+--- 
+  http_interactions: 
+    - request: 
+        method: get
+        uri: "https://route53.amazonaws.com/2013-04-01/hostedzone"
+        body: 
+          encoding: ASCII-8BIT
+          string: ""
+        headers: 
+          Content-Type: 
+            - ""
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.5 ruby/2.1.4 x86_64-darwin14.0"
+          Date: 
+            - "Mon, 01 Dec 2014 10:59:12 GMT"
+          X-Amzn-Authorization: 
+            - "AWS3-HTTPS AWSAccessKeyId=,Algorithm=HmacSHA256,Signature="
+          Content-Length: 
+            - "0"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          X-Amzn-Requestid: 
+            - "16dc09ec-7949-11e4-9d63-c1df0747cad1"
+          Content-Type: 
+            - text/xml
+          Content-Length: 
+            - "467"
+          Date: 
+            - "Mon, 01 Dec 2014 10:59:14 GMT"
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0"?>
+            <ListHostedZonesResponse xmlns="https://route53.amazonaws.com/doc/2013-04-01/"><HostedZones><HostedZone><Id>/hostedzone/Z11A654ME5UD0C</Id><Name>devopscentral.com.</Name><CallerReference>d29893c4732c33e760b3252b50690a4c</CallerReference><Config><PrivateZone>false</PrivateZone></Config><ResourceRecordSetCount>2</ResourceRecordSetCount></HostedZone></HostedZones><IsTruncated>false</IsTruncated><MaxItems>100</MaxItems></ListHostedZonesResponse>
+        http_version: 
+      recorded_at: "Mon, 01 Dec 2014 10:59:13 GMT"
+    - request: 
+        method: post
+        uri: "https://route53.amazonaws.com/2013-04-01/hostedzone/Z11A654ME5UD0C/rrset/"
+        body: 
+          encoding: UTF-8
+          string: "<ChangeResourceRecordSetsRequest xmlns=\x22https://route53.amazonaws.com/doc/2013-04-01/\x22>\n  <ChangeBatch>\n    <Changes>\n      <Change>\n        <Action>CREATE</Action>\n        <ResourceRecordSet>\n          <Name>local.devopscentral.com.</Name>\n          <Type>A</Type>\n          <TTL>3000</TTL>\n          <ResourceRecords>\n            <ResourceRecord>\n              <Value>127.0.0.1</Value>\n            </ResourceRecord>\n          </ResourceRecords>\n        </ResourceRecordSet>\n      </Change>\n    </Changes>\n  </ChangeBatch>\n</ChangeResourceRecordSetsRequest>\n"
+        headers: 
+          Content-Type: 
+            - ""
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.5 ruby/2.1.4 x86_64-darwin14.0"
+          Date: 
+            - "Mon, 01 Dec 2014 10:59:13 GMT"
+          X-Amzn-Authorization: 
+            - "AWS3-HTTPS AWSAccessKeyId=Algorithm=HmacSHA256,Signature="
+          Content-Length: 
+            - "559"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          X-Amzn-Requestid: 
+            - "171eb81d-7949-11e4-9502-db73aebf6864"
+          Content-Type: 
+            - text/xml
+          Content-Length: 
+            - "276"
+          Date: 
+            - "Mon, 01 Dec 2014 10:59:15 GMT"
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0"?>
+            <ChangeResourceRecordSetsResponse xmlns="https://route53.amazonaws.com/doc/2013-04-01/"><ChangeInfo><Id>/change/C1TBPW42RONBSK</Id><Status>PENDING</Status><SubmittedAt>2014-12-01T10:59:15.582Z</SubmittedAt></ChangeInfo></ChangeResourceRecordSetsResponse>
+        http_version: 
+      recorded_at: "Mon, 01 Dec 2014 10:59:13 GMT"
+  recorded_with: "VCR 2.9.3"

--- a/fixtures/vcr_cassettes/create-zone.yml
+++ b/fixtures/vcr_cassettes/create-zone.yml
@@ -1,0 +1,46 @@
+--- 
+  http_interactions: 
+    - request: 
+        method: post
+        uri: "https://route53.amazonaws.com/2013-04-01/hostedzone"
+        body: 
+          encoding: UTF-8
+          string: "<CreateHostedZoneRequest xmlns=\x22https://route53.amazonaws.com/doc/2013-04-01/\x22>\n  <Name>devopscentral.com</Name>\n  <CallerReference>e1277a98454434fa3b1926676a89f73a</CallerReference>\n</CreateHostedZoneRequest>\n"
+        headers: 
+          Content-Type: 
+            - ""
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.1 ruby/2.1.1 x86_64-darwin13.0"
+          Date: 
+            - "Tue, 07 Oct 2014 11:18:08 GMT"
+          X-Amzn-Authorization: 
+            - "AWS3-HTTPS AWSAccessKeyId=redacted,Algorithm=HmacSHA256,Signature=redacted"
+          Content-Length: 
+            - "210"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 201
+          message: Created
+        headers: 
+          X-Amzn-Requestid: 
+            - "9d3fda45-4e13-11e4-b329-1de520403147"
+          Location: 
+            - "https://route53.amazonaws.com/2013-04-01//hostedzone/Z1WG8P3OIYT9CD"
+          Content-Type: 
+            - text/xml
+          Content-Length: 
+            - "719"
+          Date: 
+            - "Tue, 07 Oct 2014 11:18:07 GMT"
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0"?>
+            <CreateHostedZoneResponse xmlns="https://route53.amazonaws.com/doc/2013-04-01/"><HostedZone><Id>/hostedzone/Z1WG8P3OIYT9CD</Id><Name>devopscentral.com.</Name><CallerReference>e1277a98454434fa3b1926676a89f73a</CallerReference><Config/><ResourceRecordSetCount>2</ResourceRecordSetCount></HostedZone><ChangeInfo><Id>/change/C373O1KYQE448G</Id><Status>PENDING</Status><SubmittedAt>2014-10-07T11:18:07.818Z</SubmittedAt></ChangeInfo><DelegationSet><NameServers><NameServer>ns-302.awsdns-37.com</NameServer><NameServer>ns-2003.awsdns-58.co.uk</NameServer><NameServer>ns-695.awsdns-22.net</NameServer><NameServer>ns-1045.awsdns-02.org</NameServer></NameServers></DelegationSet></CreateHostedZoneResponse>
+        http_version: 
+      recorded_at: "Tue, 07 Oct 2014 11:18:08 GMT"
+  recorded_with: "VCR 2.9.3"

--- a/fixtures/vcr_cassettes/destroy-record.yml
+++ b/fixtures/vcr_cassettes/destroy-record.yml
@@ -1,0 +1,85 @@
+--- 
+  http_interactions: 
+    - request: 
+        method: get
+        uri: "https://route53.amazonaws.com/2013-04-01/hostedzone"
+        body: 
+          encoding: ASCII-8BIT
+          string: ""
+        headers: 
+          Content-Type: 
+            - ""
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.5 ruby/2.1.4 x86_64-darwin14.0"
+          Date: 
+            - "Mon, 01 Dec 2014 10:57:41 GMT"
+          X-Amzn-Authorization: 
+            - "AWS3-HTTPS AWSAccessKeyId=,Algorithm=HmacSHA256,Signature="
+          Content-Length: 
+            - "0"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          X-Amzn-Requestid: 
+            - e05dd778-7948-11e4-9502-db73aebf6864
+          Content-Type: 
+            - text/xml
+          Content-Length: 
+            - "467"
+          Date: 
+            - "Mon, 01 Dec 2014 10:57:43 GMT"
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0"?>
+            <ListHostedZonesResponse xmlns="https://route53.amazonaws.com/doc/2013-04-01/"><HostedZones><HostedZone><Id>/hostedzone/Z11A654ME5UD0C</Id><Name>devopscentral.com.</Name><CallerReference>d29893c4732c33e760b3252b50690a4c</CallerReference><Config><PrivateZone>false</PrivateZone></Config><ResourceRecordSetCount>3</ResourceRecordSetCount></HostedZone></HostedZones><IsTruncated>false</IsTruncated><MaxItems>100</MaxItems></ListHostedZonesResponse>
+        http_version: 
+      recorded_at: "Mon, 01 Dec 2014 10:57:41 GMT"
+    - request: 
+        method: post
+        uri: "https://route53.amazonaws.com/2013-04-01/hostedzone/Z11A654ME5UD0C/rrset/"
+        body: 
+          encoding: UTF-8
+          string: "<ChangeResourceRecordSetsRequest xmlns=\x22https://route53.amazonaws.com/doc/2013-04-01/\x22>\n  <ChangeBatch>\n    <Changes>\n      <Change>\n        <Action>DELETE</Action>\n        <ResourceRecordSet>\n          <Name>local.devopscentral.com.</Name>\n          <Type>A</Type>\n          <TTL>3000</TTL>\n          <ResourceRecords>\n            <ResourceRecord>\n              <Value>127.0.0.1</Value>\n            </ResourceRecord>\n          </ResourceRecords>\n        </ResourceRecordSet>\n      </Change>\n    </Changes>\n  </ChangeBatch>\n</ChangeResourceRecordSetsRequest>\n"
+        headers: 
+          Content-Type: 
+            - ""
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.5 ruby/2.1.4 x86_64-darwin14.0"
+          Date: 
+            - "Mon, 01 Dec 2014 10:57:41 GMT"
+          X-Amzn-Authorization: 
+            - "AWS3-HTTPS AWSAccessKeyId=Algorithm=HmacSHA256,Signature="
+          Content-Length: 
+            - "559"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          X-Amzn-Requestid: 
+            - e090a75b-7948-11e4-9502-db73aebf6864
+          Content-Type: 
+            - text/xml
+          Content-Length: 
+            - "276"
+          Date: 
+            - "Mon, 01 Dec 2014 10:57:43 GMT"
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0"?>
+            <ChangeResourceRecordSetsResponse xmlns="https://route53.amazonaws.com/doc/2013-04-01/"><ChangeInfo><Id>/change/C2QST4U1MGFD2C</Id><Status>PENDING</Status><SubmittedAt>2014-12-01T10:57:44.048Z</SubmittedAt></ChangeInfo></ChangeResourceRecordSetsResponse>
+        http_version: 
+      recorded_at: "Mon, 01 Dec 2014 10:57:42 GMT"
+  recorded_with: "VCR 2.9.3"

--- a/fixtures/vcr_cassettes/destroy-zone.yml
+++ b/fixtures/vcr_cassettes/destroy-zone.yml
@@ -1,0 +1,85 @@
+--- 
+  http_interactions: 
+    - request: 
+        method: get
+        uri: "https://route53.amazonaws.com/2013-04-01/hostedzone"
+        body: 
+          encoding: ASCII-8BIT
+          string: ""
+        headers: 
+          Content-Type: 
+            - ""
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.1 ruby/2.1.1 x86_64-darwin13.0"
+          Date: 
+            - "Tue, 07 Oct 2014 11:14:32 GMT"
+          X-Amzn-Authorization: 
+            - "AWS3-HTTPS AWSAccessKeyId=redacted,Algorithm=HmacSHA256,Signature=redacted"
+          Content-Length: 
+            - "0"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          X-Amzn-Requestid: 
+            - "1c74a8fb-4e13-11e4-99af-4f00d7e73c16"
+          Content-Type: 
+            - text/xml
+          Content-Length: 
+            - "427"
+          Date: 
+            - "Tue, 07 Oct 2014 11:14:31 GMT"
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0"?>
+            <ListHostedZonesResponse xmlns="https://route53.amazonaws.com/doc/2013-04-01/"><HostedZones><HostedZone><Id>/hostedzone/Z3VO2BZMEQK733</Id><Name>devopscentral.com.</Name><CallerReference>652b4c6ed3a75cf27e37f5736d7bf77c</CallerReference><Config/><ResourceRecordSetCount>2</ResourceRecordSetCount></HostedZone></HostedZones><IsTruncated>false</IsTruncated><MaxItems>100</MaxItems></ListHostedZonesResponse>
+        http_version: 
+      recorded_at: "Tue, 07 Oct 2014 11:14:32 GMT"
+    - request: 
+        method: delete
+        uri: "https://route53.amazonaws.com/2013-04-01/hostedzone/Z3VO2BZMEQK733"
+        body: 
+          encoding: ASCII-8BIT
+          string: ""
+        headers: 
+          Content-Type: 
+            - ""
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.1 ruby/2.1.1 x86_64-darwin13.0"
+          Date: 
+            - "Tue, 07 Oct 2014 11:14:32 GMT"
+          X-Amzn-Authorization: 
+            - "AWS3-HTTPS AWSAccessKeyId=redacted,Algorithm=HmacSHA256,Signature=redacted"
+          Content-Length: 
+            - "0"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          X-Amzn-Requestid: 
+            - "1cc31742-4e13-11e4-87ed-e9f2af50b6a1"
+          Content-Type: 
+            - text/xml
+          Content-Length: 
+            - "260"
+          Date: 
+            - "Tue, 07 Oct 2014 11:14:32 GMT"
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0"?>
+            <DeleteHostedZoneResponse xmlns="https://route53.amazonaws.com/doc/2013-04-01/"><ChangeInfo><Id>/change/C2QMH6QN3T9U3P</Id><Status>PENDING</Status><SubmittedAt>2014-10-07T11:14:32.249Z</SubmittedAt></ChangeInfo></DeleteHostedZoneResponse>
+        http_version: 
+      recorded_at: "Tue, 07 Oct 2014 11:14:33 GMT"
+  recorded_with: "VCR 2.9.3"

--- a/fixtures/vcr_cassettes/record-named.yml
+++ b/fixtures/vcr_cassettes/record-named.yml
@@ -1,0 +1,85 @@
+--- 
+  http_interactions: 
+    - request: 
+        method: get
+        uri: "https://route53.amazonaws.com/2013-04-01/hostedzone"
+        body: 
+          encoding: ASCII-8BIT
+          string: ""
+        headers: 
+          Content-Type: 
+            - ""
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.5 ruby/2.1.4 x86_64-darwin14.0"
+          Date: 
+            - "Mon, 01 Dec 2014 10:59:21 GMT"
+          X-Amzn-Authorization: 
+            - "AWS3-HTTPS AWSAccessKeyId=Algorithm=HmacSHA256,Signature="
+          Content-Length: 
+            - "0"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          X-Amzn-Requestid: 
+            - "1c207501-7949-11e4-9d63-c1df0747cad1"
+          Content-Type: 
+            - text/xml
+          Content-Length: 
+            - "467"
+          Date: 
+            - "Mon, 01 Dec 2014 10:59:23 GMT"
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0"?>
+            <ListHostedZonesResponse xmlns="https://route53.amazonaws.com/doc/2013-04-01/"><HostedZones><HostedZone><Id>/hostedzone/Z11A654ME5UD0C</Id><Name>devopscentral.com.</Name><CallerReference>d29893c4732c33e760b3252b50690a4c</CallerReference><Config><PrivateZone>false</PrivateZone></Config><ResourceRecordSetCount>3</ResourceRecordSetCount></HostedZone></HostedZones><IsTruncated>false</IsTruncated><MaxItems>100</MaxItems></ListHostedZonesResponse>
+        http_version: 
+      recorded_at: "Mon, 01 Dec 2014 10:59:22 GMT"
+    - request: 
+        method: get
+        uri: "https://route53.amazonaws.com/2013-04-01/hostedzone/Z11A654ME5UD0C/rrset"
+        body: 
+          encoding: ASCII-8BIT
+          string: ""
+        headers: 
+          Content-Type: 
+            - ""
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.5 ruby/2.1.4 x86_64-darwin14.0"
+          Date: 
+            - "Mon, 01 Dec 2014 10:59:22 GMT"
+          X-Amzn-Authorization: 
+            - "AWS3-HTTPS AWSAccessKeyId=Algorithm=HmacSHA256,Signature="
+          Content-Length: 
+            - "0"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          X-Amzn-Requestid: 
+            - "1c693d6b-7949-11e4-9b24-b5e7f92f0bc4"
+          Content-Type: 
+            - text/xml
+          Content-Length: 
+            - "1111"
+          Date: 
+            - "Mon, 01 Dec 2014 10:59:23 GMT"
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0"?>
+            <ListResourceRecordSetsResponse xmlns="https://route53.amazonaws.com/doc/2013-04-01/"><ResourceRecordSets><ResourceRecordSet><Name>devopscentral.com.</Name><Type>NS</Type><TTL>172800</TTL><ResourceRecords><ResourceRecord><Value>ns-926.awsdns-51.net.</Value></ResourceRecord><ResourceRecord><Value>ns-174.awsdns-21.com.</Value></ResourceRecord><ResourceRecord><Value>ns-1087.awsdns-07.org.</Value></ResourceRecord><ResourceRecord><Value>ns-1866.awsdns-41.co.uk.</Value></ResourceRecord></ResourceRecords></ResourceRecordSet><ResourceRecordSet><Name>devopscentral.com.</Name><Type>SOA</Type><TTL>900</TTL><ResourceRecords><ResourceRecord><Value>ns-926.awsdns-51.net. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400</Value></ResourceRecord></ResourceRecords></ResourceRecordSet><ResourceRecordSet><Name>local.devopscentral.com.</Name><Type>A</Type><TTL>3000</TTL><ResourceRecords><ResourceRecord><Value>127.0.0.1</Value></ResourceRecord></ResourceRecords></ResourceRecordSet></ResourceRecordSets><IsTruncated>false</IsTruncated><MaxItems>100</MaxItems></ListResourceRecordSetsResponse>
+        http_version: 
+      recorded_at: "Mon, 01 Dec 2014 10:59:22 GMT"
+  recorded_with: "VCR 2.9.3"

--- a/fixtures/vcr_cassettes/record-setup.yml
+++ b/fixtures/vcr_cassettes/record-setup.yml
@@ -1,0 +1,167 @@
+--- 
+  http_interactions: 
+    - request: 
+        method: get
+        uri: "https://route53.amazonaws.com/2013-04-01/hostedzone"
+        body: 
+          encoding: ASCII-8BIT
+          string: ""
+        headers: 
+          Content-Type: 
+            - ""
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.5 ruby/2.1.4 x86_64-darwin14.0"
+          Date: 
+            - "Mon, 01 Dec 2014 10:57:38 GMT"
+          X-Amzn-Authorization: 
+            - "AWS3-HTTPS AWSAccessKeyId=Algorithm=HmacSHA256,Signature="
+          Content-Length: 
+            - "0"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          X-Amzn-Requestid: 
+            - de8965b3-7948-11e4-8bca-e107b0a9ebb7
+          Content-Type: 
+            - text/xml
+          Content-Length: 
+            - "467"
+          Date: 
+            - "Mon, 01 Dec 2014 10:57:40 GMT"
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0"?>
+            <ListHostedZonesResponse xmlns="https://route53.amazonaws.com/doc/2013-04-01/"><HostedZones><HostedZone><Id>/hostedzone/Z11A654ME5UD0C</Id><Name>devopscentral.com.</Name><CallerReference>d29893c4732c33e760b3252b50690a4c</CallerReference><Config><PrivateZone>false</PrivateZone></Config><ResourceRecordSetCount>2</ResourceRecordSetCount></HostedZone></HostedZones><IsTruncated>false</IsTruncated><MaxItems>100</MaxItems></ListHostedZonesResponse>
+        http_version: 
+      recorded_at: "Mon, 01 Dec 2014 10:57:38 GMT"
+    - request: 
+        method: get
+        uri: "https://route53.amazonaws.com/2013-04-01/hostedzone/Z11A654ME5UD0C/rrset"
+        body: 
+          encoding: ASCII-8BIT
+          string: ""
+        headers: 
+          Content-Type: 
+            - ""
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.5 ruby/2.1.4 x86_64-darwin14.0"
+          Date: 
+            - "Mon, 01 Dec 2014 10:57:38 GMT"
+          X-Amzn-Authorization: 
+            - "AWS3-HTTPS AWSAccessKeyId=,Algorithm=HmacSHA256,Signature="
+          Content-Length: 
+            - "0"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          X-Amzn-Requestid: 
+            - deccfe8d-7948-11e4-b71e-452ca4351c38
+          Content-Type: 
+            - text/xml
+          Content-Length: 
+            - "914"
+          Date: 
+            - "Mon, 01 Dec 2014 10:57:40 GMT"
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0"?>
+            <ListResourceRecordSetsResponse xmlns="https://route53.amazonaws.com/doc/2013-04-01/"><ResourceRecordSets><ResourceRecordSet><Name>devopscentral.com.</Name><Type>NS</Type><TTL>172800</TTL><ResourceRecords><ResourceRecord><Value>ns-926.awsdns-51.net.</Value></ResourceRecord><ResourceRecord><Value>ns-174.awsdns-21.com.</Value></ResourceRecord><ResourceRecord><Value>ns-1087.awsdns-07.org.</Value></ResourceRecord><ResourceRecord><Value>ns-1866.awsdns-41.co.uk.</Value></ResourceRecord></ResourceRecords></ResourceRecordSet><ResourceRecordSet><Name>devopscentral.com.</Name><Type>SOA</Type><TTL>900</TTL><ResourceRecords><ResourceRecord><Value>ns-926.awsdns-51.net. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400</Value></ResourceRecord></ResourceRecords></ResourceRecordSet></ResourceRecordSets><IsTruncated>false</IsTruncated><MaxItems>100</MaxItems></ListResourceRecordSetsResponse>
+        http_version: 
+      recorded_at: "Mon, 01 Dec 2014 10:57:39 GMT"
+    - request: 
+        method: get
+        uri: "https://route53.amazonaws.com/2013-04-01/hostedzone"
+        body: 
+          encoding: ASCII-8BIT
+          string: ""
+        headers: 
+          Content-Type: 
+            - ""
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.5 ruby/2.1.4 x86_64-darwin14.0"
+          Date: 
+            - "Mon, 01 Dec 2014 10:57:39 GMT"
+          X-Amzn-Authorization: 
+            - "AWS3-HTTPS AWSAccessKeyId=,Algorithm=HmacSHA256,Signature="
+          Content-Length: 
+            - "0"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          X-Amzn-Requestid: 
+            - df08f632-7948-11e4-b71e-452ca4351c38
+          Content-Type: 
+            - text/xml
+          Content-Length: 
+            - "467"
+          Date: 
+            - "Mon, 01 Dec 2014 10:57:41 GMT"
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0"?>
+            <ListHostedZonesResponse xmlns="https://route53.amazonaws.com/doc/2013-04-01/"><HostedZones><HostedZone><Id>/hostedzone/Z11A654ME5UD0C</Id><Name>devopscentral.com.</Name><CallerReference>d29893c4732c33e760b3252b50690a4c</CallerReference><Config><PrivateZone>false</PrivateZone></Config><ResourceRecordSetCount>2</ResourceRecordSetCount></HostedZone></HostedZones><IsTruncated>false</IsTruncated><MaxItems>100</MaxItems></ListHostedZonesResponse>
+        http_version: 
+      recorded_at: "Mon, 01 Dec 2014 10:57:39 GMT"
+    - request: 
+        method: get
+        uri: "https://route53.amazonaws.com/2013-04-01/hostedzone/Z11A654ME5UD0C/rrset"
+        body: 
+          encoding: ASCII-8BIT
+          string: ""
+        headers: 
+          Content-Type: 
+            - ""
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.5 ruby/2.1.4 x86_64-darwin14.0"
+          Date: 
+            - "Mon, 01 Dec 2014 10:57:39 GMT"
+          X-Amzn-Authorization: 
+            - "AWS3-HTTPS AWSAccessKeyId=Algorithm=HmacSHA256,Signature="
+          Content-Length: 
+            - "0"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          X-Amzn-Requestid: 
+            - df422eb4-7948-11e4-ad26-0338ecdf83e7
+          Content-Type: 
+            - text/xml
+          Content-Length: 
+            - "914"
+          Date: 
+            - "Mon, 01 Dec 2014 10:57:41 GMT"
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0"?>
+            <ListResourceRecordSetsResponse xmlns="https://route53.amazonaws.com/doc/2013-04-01/"><ResourceRecordSets><ResourceRecordSet><Name>devopscentral.com.</Name><Type>NS</Type><TTL>172800</TTL><ResourceRecords><ResourceRecord><Value>ns-926.awsdns-51.net.</Value></ResourceRecord><ResourceRecord><Value>ns-174.awsdns-21.com.</Value></ResourceRecord><ResourceRecord><Value>ns-1087.awsdns-07.org.</Value></ResourceRecord><ResourceRecord><Value>ns-1866.awsdns-41.co.uk.</Value></ResourceRecord></ResourceRecords></ResourceRecordSet><ResourceRecordSet><Name>devopscentral.com.</Name><Type>SOA</Type><TTL>900</TTL><ResourceRecords><ResourceRecord><Value>ns-926.awsdns-51.net. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400</Value></ResourceRecord></ResourceRecords></ResourceRecordSet></ResourceRecordSets><IsTruncated>false</IsTruncated><MaxItems>100</MaxItems></ListResourceRecordSetsResponse>
+        http_version: 
+      recorded_at: "Mon, 01 Dec 2014 10:57:39 GMT"
+  recorded_with: "VCR 2.9.3"

--- a/fixtures/vcr_cassettes/zone-named.yml
+++ b/fixtures/vcr_cassettes/zone-named.yml
@@ -1,0 +1,44 @@
+--- 
+  http_interactions: 
+    - request: 
+        method: get
+        uri: "https://route53.amazonaws.com/2013-04-01/hostedzone"
+        body: 
+          encoding: ASCII-8BIT
+          string: ""
+        headers: 
+          Content-Type: 
+            - ""
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.1 ruby/2.1.1 x86_64-darwin13.0"
+          Date: 
+            - "Tue, 07 Oct 2014 11:07:34 GMT"
+          X-Amzn-Authorization: 
+            - "AWS3-HTTPS AWSAccessKeyId=redacted,Algorithm=HmacSHA256,Signature=redacted"
+          Content-Length: 
+            - "0"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          X-Amzn-Requestid: 
+            - "236cfba5-4e12-11e4-99af-4f00d7e73c16"
+          Content-Type: 
+            - text/xml
+          Content-Length: 
+            - "861"
+          Date: 
+            - "Tue, 07 Oct 2014 11:07:33 GMT"
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0"?>
+            <ListHostedZonesResponse xmlns="https://route53.amazonaws.com/doc/2013-04-01/"><HostedZones><HostedZone><Id>/hostedzone/Z3VO2BZMEQK733</Id><Name>devopscentral.com.</Name><CallerReference>652b4c6ed3a75cf27e37f5736d7bf77c</CallerReference><Config/><ResourceRecordSetCount>2</ResourceRecordSetCount></HostedZone><HostedZone><Id>/hostedzone/Z2RX2I1471TBSU</Id><Name>devopscentral.com.</Name><CallerReference>a7780e6f63b5122a1fe576fbb43fce7f</CallerReference><Config/><ResourceRecordSetCount>2</ResourceRecordSetCount></HostedZone><HostedZone><Id>/hostedzone/Z2A78NH36PE988</Id><Name>devopscentral.com.</Name><CallerReference>dc3285d28b76e9b0bd176ae33cfdcda2</CallerReference><Config/><ResourceRecordSetCount>2</ResourceRecordSetCount></HostedZone></HostedZones><IsTruncated>false</IsTruncated><MaxItems>100</MaxItems></ListHostedZonesResponse>
+        http_version: 
+      recorded_at: "Tue, 07 Oct 2014 11:07:34 GMT"
+  recorded_with: "VCR 2.9.3"

--- a/fixtures/vcr_cassettes/zone-setup.yml
+++ b/fixtures/vcr_cassettes/zone-setup.yml
@@ -1,0 +1,85 @@
+--- 
+  http_interactions: 
+    - request: 
+        method: get
+        uri: "https://route53.amazonaws.com/2013-04-01/hostedzone"
+        body: 
+          encoding: ASCII-8BIT
+          string: ""
+        headers: 
+          Content-Type: 
+            - ""
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.1 ruby/2.1.1 x86_64-darwin13.0"
+          Date: 
+            - "Tue, 07 Oct 2014 11:07:33 GMT"
+          X-Amzn-Authorization: 
+            - "AWS3-HTTPS AWSAccessKeyId=redacted,Algorithm=HmacSHA256,Signature=redacted"
+          Content-Length: 
+            - "0"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          X-Amzn-Requestid: 
+            - "23007e4b-4e12-11e4-87ed-e9f2af50b6a1"
+          Content-Type: 
+            - text/xml
+          Content-Length: 
+            - "861"
+          Date: 
+            - "Tue, 07 Oct 2014 11:07:32 GMT"
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0"?>
+            <ListHostedZonesResponse xmlns="https://route53.amazonaws.com/doc/2013-04-01/"><HostedZones><HostedZone><Id>/hostedzone/Z3VO2BZMEQK733</Id><Name>devopscentral.com.</Name><CallerReference>652b4c6ed3a75cf27e37f5736d7bf77c</CallerReference><Config/><ResourceRecordSetCount>2</ResourceRecordSetCount></HostedZone><HostedZone><Id>/hostedzone/Z2RX2I1471TBSU</Id><Name>devopscentral.com.</Name><CallerReference>a7780e6f63b5122a1fe576fbb43fce7f</CallerReference><Config/><ResourceRecordSetCount>2</ResourceRecordSetCount></HostedZone><HostedZone><Id>/hostedzone/Z2A78NH36PE988</Id><Name>devopscentral.com.</Name><CallerReference>dc3285d28b76e9b0bd176ae33cfdcda2</CallerReference><Config/><ResourceRecordSetCount>2</ResourceRecordSetCount></HostedZone></HostedZones><IsTruncated>false</IsTruncated><MaxItems>100</MaxItems></ListHostedZonesResponse>
+        http_version: 
+      recorded_at: "Tue, 07 Oct 2014 11:07:34 GMT"
+    - request: 
+        method: get
+        uri: "https://route53.amazonaws.com/2013-04-01/hostedzone"
+        body: 
+          encoding: ASCII-8BIT
+          string: ""
+        headers: 
+          Content-Type: 
+            - ""
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.1 ruby/2.1.1 x86_64-darwin13.0"
+          Date: 
+            - "Tue, 07 Oct 2014 11:07:34 GMT"
+          X-Amzn-Authorization: 
+            - "AWS3-HTTPS AWSAccessKeyId=redacted,Algorithm=HmacSHA256,Signature=redacted"
+          Content-Length: 
+            - "0"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          X-Amzn-Requestid: 
+            - "2335be28-4e12-11e4-87ed-e9f2af50b6a1"
+          Content-Type: 
+            - text/xml
+          Content-Length: 
+            - "861"
+          Date: 
+            - "Tue, 07 Oct 2014 11:07:33 GMT"
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0"?>
+            <ListHostedZonesResponse xmlns="https://route53.amazonaws.com/doc/2013-04-01/"><HostedZones><HostedZone><Id>/hostedzone/Z3VO2BZMEQK733</Id><Name>devopscentral.com.</Name><CallerReference>652b4c6ed3a75cf27e37f5736d7bf77c</CallerReference><Config/><ResourceRecordSetCount>2</ResourceRecordSetCount></HostedZone><HostedZone><Id>/hostedzone/Z2RX2I1471TBSU</Id><Name>devopscentral.com.</Name><CallerReference>a7780e6f63b5122a1fe576fbb43fce7f</CallerReference><Config/><ResourceRecordSetCount>2</ResourceRecordSetCount></HostedZone><HostedZone><Id>/hostedzone/Z2A78NH36PE988</Id><Name>devopscentral.com.</Name><CallerReference>dc3285d28b76e9b0bd176ae33cfdcda2</CallerReference><Config/><ResourceRecordSetCount>2</ResourceRecordSetCount></HostedZone></HostedZones><IsTruncated>false</IsTruncated><MaxItems>100</MaxItems></ListHostedZonesResponse>
+        http_version: 
+      recorded_at: "Tue, 07 Oct 2014 11:07:34 GMT"
+  recorded_with: "VCR 2.9.3"

--- a/lib/puppet/provider/route53_a_record/v2.rb
+++ b/lib/puppet/provider/route53_a_record/v2.rb
@@ -9,8 +9,7 @@ Puppet::Type.type(:route53_a_record).provide(:v2, :parent => Puppet::Provider::R
     'A'
   end
 
-  [
-    :ttl=,
-    :values=,
-  ].each{ |method| alias_method method, :update }
+  def flush
+    update unless @property_hash[:ensure] == :absent
+  end
 end

--- a/lib/puppet/provider/route53_a_record/v2.rb
+++ b/lib/puppet/provider/route53_a_record/v2.rb
@@ -1,0 +1,16 @@
+require_relative '../route53_record'
+
+Puppet::Type.type(:route53_a_record).provide(:v2, :parent => Puppet::Provider::Route53Record) do
+  confine feature: :aws
+
+  mk_resource_methods
+
+  def self.record_type
+    'A'
+  end
+
+  [
+    :ttl=,
+    :values=,
+  ].each{ |method| alias_method method, :update }
+end

--- a/lib/puppet/provider/route53_ns_record/v2.rb
+++ b/lib/puppet/provider/route53_ns_record/v2.rb
@@ -1,0 +1,16 @@
+require_relative '../route53_record'
+
+Puppet::Type.type(:route53_ns_record).provide(:v2, :parent => Puppet::Provider::Route53Record) do
+  confine feature: :aws
+
+  mk_resource_methods
+
+  def self.record_type
+    'NS'
+  end
+
+  [
+    :ttl=,
+    :values=,
+  ].each{ |method| alias_method method, :update }
+end

--- a/lib/puppet/provider/route53_ns_record/v2.rb
+++ b/lib/puppet/provider/route53_ns_record/v2.rb
@@ -9,8 +9,7 @@ Puppet::Type.type(:route53_ns_record).provide(:v2, :parent => Puppet::Provider::
     'NS'
   end
 
-  [
-    :ttl=,
-    :values=,
-  ].each{ |method| alias_method method, :update }
+  def flush
+    update unless @property_hash[:ensure] == :absent
+  end
 end

--- a/lib/puppet/provider/route53_record.rb
+++ b/lib/puppet/provider/route53_record.rb
@@ -1,0 +1,83 @@
+require_relative '../../puppet_x/puppetlabs/aws'
+
+class Puppet::Provider::Route53Record < PuppetX::Puppetlabs::Aws
+
+  def self.instances
+    zones_response = route53_client.list_hosted_zones()
+    records = []
+    zones_response.data.hosted_zones.each do |zone|
+      records_response = route53_client.list_resource_record_sets(hosted_zone_id: zone.id)
+      records_response.data.resource_record_sets.each do |record|
+        records << new({
+          name: record.name,
+          ensure: :present,
+          zone: zone.name,
+          ttl: record.ttl,
+          values: record.resource_records.map(&:value),
+        }) if record.type == record_type
+      end
+    end
+    records
+  end
+
+  def self.prefetch(resources)
+    instances.each do |prov|
+      if resource = resources[prov.name]
+        resource.provider = prov
+      end
+    end
+  end
+
+  def exists?
+    Puppet.info("Checking if #{self.class.record_type} record #{name} exists")
+    @property_hash[:ensure] == :present
+  end
+
+  def record_hash(action)
+    records = resource[:values] ? resource[:values].map { |v| {value: v} } : []
+    {
+      hosted_zone_id: zone_id,
+      change_batch: {
+        changes: [{
+          action: action,
+          resource_record_set: {
+            name: resource[:name],
+            type: self.class.record_type,
+            ttl: resource[:ttl],
+            resource_records: records,
+          }
+        }]
+      }
+    }
+  end
+
+  def zone_id
+    zones = route53_client.list_hosted_zones.data.hosted_zones.select { |zone| zone.name == resource[:zone] }
+    fail "No Zone named #{resource[:zone]}" if zones.count < 1
+    fail "Multiple Zone records found for #{resource[:zone]}" if zones.count > 1
+    zones.first.id
+  end
+
+  def update(*args)
+    Puppet.info("Updating #{self.class.record_type} record #{name}")
+    route53_client.change_resource_record_sets(
+      record_hash('UPSERT')
+    )
+  end
+
+  def create
+    Puppet.info("Creating #{self.class.record_type} record #{name}")
+    route53_client.change_resource_record_sets(
+      record_hash('CREATE')
+    )
+    @property_hash[:ensure] = :present
+  end
+
+  def destroy
+    Puppet.info("Deleting #{self.class.record_type} record #{name}")
+    route53_client.change_resource_record_sets(
+      record_hash('DELETE')
+    )
+    @property_hash[:ensure] = :absent
+  end
+end

--- a/lib/puppet/provider/route53_record.rb
+++ b/lib/puppet/provider/route53_record.rb
@@ -58,7 +58,7 @@ class Puppet::Provider::Route53Record < PuppetX::Puppetlabs::Aws
     zones.first.id
   end
 
-  def update(*args)
+  def update
     Puppet.info("Updating #{self.class.record_type} record #{name}")
     route53_client.change_resource_record_sets(
       record_hash('UPSERT')

--- a/lib/puppet/provider/route53_txt_record/v2.rb
+++ b/lib/puppet/provider/route53_txt_record/v2.rb
@@ -1,0 +1,16 @@
+require_relative '../route53_record'
+
+Puppet::Type.type(:route53_txt_record).provide(:v2, :parent => Puppet::Provider::Route53Record) do
+  confine feature: :aws
+
+  mk_resource_methods
+
+  def self.record_type
+    'TXT'
+  end
+
+  [
+    :ttl=,
+    :values=,
+  ].each{ |method| alias_method method, :update }
+end

--- a/lib/puppet/provider/route53_txt_record/v2.rb
+++ b/lib/puppet/provider/route53_txt_record/v2.rb
@@ -9,8 +9,7 @@ Puppet::Type.type(:route53_txt_record).provide(:v2, :parent => Puppet::Provider:
     'TXT'
   end
 
-  [
-    :ttl=,
-    :values=,
-  ].each{ |method| alias_method method, :update }
+  def flush
+    update unless @property_hash[:ensure] == :absent
+  end
 end

--- a/lib/puppet/provider/route53_zone/v2.rb
+++ b/lib/puppet/provider/route53_zone/v2.rb
@@ -1,0 +1,50 @@
+require_relative '../../../puppet_x/puppetlabs/aws.rb'
+require 'securerandom'
+
+Puppet::Type.type(:route53_zone).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) do
+  confine feature: :aws
+
+  mk_resource_methods
+
+  def self.instances
+    response = route53_client.list_hosted_zones()
+    response.data.hosted_zones.collect do |zone|
+      new({
+        name: zone.name,
+        ensure: :present,
+      })
+    end
+  end
+
+  def self.prefetch(resources)
+    instances.each do |prov|
+      if resource = resources[prov.name]
+        resource.provider = prov
+      end
+    end
+  end
+
+  def exists?
+    Puppet.info("Checking if zone #{name} exists")
+    @property_hash[:ensure] == :present
+  end
+
+  def create
+    reference = SecureRandom.hex
+    Puppet.info("Creating zone #{name} with #{reference}")
+    route53_client.create_hosted_zone(
+      name: name,
+      caller_reference: reference,
+    )
+  end
+
+  def destroy
+    Puppet.info("Deleting zone #{name}")
+    zones = route53_client.list_hosted_zones.data.hosted_zones.select { |zone| zone.name == "#{name}" }
+    if zones
+      zones.each do |zone|
+        route53_client.delete_hosted_zone(id: zone.id)
+      end
+    end
+  end
+end

--- a/lib/puppet/provider/route53_zone/v2.rb
+++ b/lib/puppet/provider/route53_zone/v2.rb
@@ -41,7 +41,7 @@ Puppet::Type.type(:route53_zone).provide(:v2, :parent => PuppetX::Puppetlabs::Aw
 
   def destroy
     Puppet.info("Deleting zone #{name}")
-    zones = route53_client.list_hosted_zones.data.hosted_zones.select { |zone| zone.name == "#{name}" }
+    zones = route53_client.list_hosted_zones.data.hosted_zones.select { |zone| zone.name == name }
     if zones
       zones.each do |zone|
         route53_client.delete_hosted_zone(id: zone.id)

--- a/lib/puppet/provider/route53_zone/v2.rb
+++ b/lib/puppet/provider/route53_zone/v2.rb
@@ -36,6 +36,7 @@ Puppet::Type.type(:route53_zone).provide(:v2, :parent => PuppetX::Puppetlabs::Aw
       name: name,
       caller_reference: reference,
     )
+    @property_hash[:ensure] = :present
   end
 
   def destroy
@@ -46,5 +47,6 @@ Puppet::Type.type(:route53_zone).provide(:v2, :parent => PuppetX::Puppetlabs::Aw
         route53_client.delete_hosted_zone(id: zone.id)
       end
     end
+    @property_hash[:ensure] = :absent
   end
 end

--- a/lib/puppet/type/route53_a_record.rb
+++ b/lib/puppet/type/route53_a_record.rb
@@ -1,0 +1,8 @@
+require_relative '../../puppet_x/puppetlabs/route53_record'
+
+Puppet::Type.newtype(:route53_a_record) do
+  extend PuppetX::Puppetlabs::Route53Record
+  @doc = 'type representing a Route53 DNS record'
+  create_properties_and_params()
+end
+

--- a/lib/puppet/type/route53_a_record.rb
+++ b/lib/puppet/type/route53_a_record.rb
@@ -2,7 +2,7 @@ require_relative '../../puppet_x/puppetlabs/route53_record'
 
 Puppet::Type.newtype(:route53_a_record) do
   extend PuppetX::Puppetlabs::Route53Record
-  @doc = 'type representing a Route53 DNS record'
+  @doc = 'Type representing a Route53 DNS record.'
   create_properties_and_params()
 end
 

--- a/lib/puppet/type/route53_ns_record.rb
+++ b/lib/puppet/type/route53_ns_record.rb
@@ -1,0 +1,8 @@
+require_relative '../../puppet_x/puppetlabs/route53_record'
+
+Puppet::Type.newtype(:route53_ns_record) do
+  extend PuppetX::Puppetlabs::Route53Record
+  @doc = 'type representing a Route53 DNS record'
+  create_properties_and_params()
+end
+

--- a/lib/puppet/type/route53_ns_record.rb
+++ b/lib/puppet/type/route53_ns_record.rb
@@ -2,7 +2,7 @@ require_relative '../../puppet_x/puppetlabs/route53_record'
 
 Puppet::Type.newtype(:route53_ns_record) do
   extend PuppetX::Puppetlabs::Route53Record
-  @doc = 'type representing a Route53 DNS record'
+  @doc = 'Type representing a Route53 DNS record.'
   create_properties_and_params()
 end
 

--- a/lib/puppet/type/route53_txt_record.rb
+++ b/lib/puppet/type/route53_txt_record.rb
@@ -2,7 +2,7 @@ require_relative '../../puppet_x/puppetlabs/route53_record'
 
 Puppet::Type.newtype(:route53_txt_record) do
   extend PuppetX::Puppetlabs::Route53Record
-  @doc = 'Type representing a Route53 DNS record.'
+  @doc = 'Type representing a Route53 TXT record.'
   create_properties_and_params()
 end
 

--- a/lib/puppet/type/route53_txt_record.rb
+++ b/lib/puppet/type/route53_txt_record.rb
@@ -2,7 +2,7 @@ require_relative '../../puppet_x/puppetlabs/route53_record'
 
 Puppet::Type.newtype(:route53_txt_record) do
   extend PuppetX::Puppetlabs::Route53Record
-  @doc = 'type representing a Route53 DNS record'
+  @doc = 'Type representing a Route53 DNS record.'
   create_properties_and_params()
 end
 

--- a/lib/puppet/type/route53_txt_record.rb
+++ b/lib/puppet/type/route53_txt_record.rb
@@ -4,5 +4,12 @@ Puppet::Type.newtype(:route53_txt_record) do
   extend PuppetX::Puppetlabs::Route53Record
   @doc = 'Type representing a Route53 TXT record.'
   create_properties_and_params()
+
+  # TXT records should always be wrapped in double quotes
+  # this minge avoids the need to pass in a '"value"' to Puppet
+  values_property = self.properties.find { |item| item == Puppet::Type::Route53_txt_record::Values }
+  values_property.munge do |value|
+    value =~ /^".+"$/ ? value : "\"#{value}\""
+  end
 end
 

--- a/lib/puppet/type/route53_txt_record.rb
+++ b/lib/puppet/type/route53_txt_record.rb
@@ -1,0 +1,8 @@
+require_relative '../../puppet_x/puppetlabs/route53_record'
+
+Puppet::Type.newtype(:route53_txt_record) do
+  extend PuppetX::Puppetlabs::Route53Record
+  @doc = 'type representing a Route53 DNS record'
+  create_properties_and_params()
+end
+

--- a/lib/puppet/type/route53_zone.rb
+++ b/lib/puppet/type/route53_zone.rb
@@ -1,0 +1,13 @@
+Puppet::Type.newtype(:route53_zone) do
+  @doc = 'type representing an Route53 DNS zone'
+
+  ensurable
+
+  newparam(:name, namevar: true) do
+    desc 'the name of DNS zone group'
+    validate do |value|
+      fail Puppet::Error, 'Empty values are not allowed' if value == ''
+    end
+  end
+
+end

--- a/lib/puppet/type/route53_zone.rb
+++ b/lib/puppet/type/route53_zone.rb
@@ -1,10 +1,10 @@
 Puppet::Type.newtype(:route53_zone) do
-  @doc = 'type representing an Route53 DNS zone'
+  @doc = 'Type representing an Route53 DNS zone.'
 
   ensurable
 
   newparam(:name, namevar: true) do
-    desc 'the name of DNS zone group'
+    desc 'The name of DNS zone group.'
     validate do |value|
       fail Puppet::Error, 'Empty values are not allowed' if value == ''
     end

--- a/lib/puppet_x/puppetlabs/aws.rb
+++ b/lib/puppet_x/puppetlabs/aws.rb
@@ -47,8 +47,6 @@ module PuppetX
         self.class.elb_client(region)
       end
 
-<<<<<<< HEAD
-<<<<<<< HEAD
       def self.autoscaling_client(region = default_region)
         ::Aws::AutoScaling::Client.new({region: region})
       end

--- a/lib/puppet_x/puppetlabs/aws.rb
+++ b/lib/puppet_x/puppetlabs/aws.rb
@@ -47,6 +47,7 @@ module PuppetX
         self.class.elb_client(region)
       end
 
+<<<<<<< HEAD
       def self.autoscaling_client(region = default_region)
         ::Aws::AutoScaling::Client.new({region: region})
       end
@@ -62,6 +63,15 @@ module PuppetX
       def cloudwatch_client(region = default_region)
         self.class.cloudwatch_client(region)
       end
+
+      def self.route53_client(region: default_region)
+        ::Aws::Route53::Client.new(region: region)
+      end
+
+      def route53_client(region: default_region)
+        self.class.route53_client(region: region)
+      end
+
     end
   end
 end

--- a/lib/puppet_x/puppetlabs/aws.rb
+++ b/lib/puppet_x/puppetlabs/aws.rb
@@ -48,6 +48,7 @@ module PuppetX
       end
 
 <<<<<<< HEAD
+<<<<<<< HEAD
       def self.autoscaling_client(region = default_region)
         ::Aws::AutoScaling::Client.new({region: region})
       end
@@ -64,12 +65,12 @@ module PuppetX
         self.class.cloudwatch_client(region)
       end
 
-      def self.route53_client(region: default_region)
-        ::Aws::Route53::Client.new(region: region)
+      def self.route53_client(region = default_region)
+        ::Aws::Route53::Client.new({region: region})
       end
 
-      def route53_client(region: default_region)
-        self.class.route53_client(region: region)
+      def route53_client(region = default_region)
+        self.class.route53_client(region)
       end
 
     end

--- a/lib/puppet_x/puppetlabs/route53_record.rb
+++ b/lib/puppet_x/puppetlabs/route53_record.rb
@@ -1,0 +1,43 @@
+module PuppetX
+  module Puppetlabs
+    module Route53Record
+      def create_properties_and_params
+        ensurable
+        newproperty(:zone) do
+          desc 'the zone associated with this record'
+          validate do |value|
+            fail 'The name of the zone must not be blank' if value.empty?
+            fail 'Zone names must end with a .' if value[-1] != '.'
+          end
+        end
+
+        newparam(:name) do
+          desc 'the name of DNS record'
+          isnamevar
+          validate do |value|
+            fail 'The name of the record must not be blank' if value.empty?
+            fail 'Record names must end with a .' if value[-1] != '.'
+          end
+        end
+
+        newproperty(:ttl) do
+          desc 'the time to live for the record'
+          def insync?(is)
+            is.to_i == should.to_i
+          end
+        end
+
+        newproperty(:values, :array_matching => :all) do
+          desc 'the values of the record'
+          validate do |value|
+            fail 'The value of the record must not be blank' if value.empty?
+          end
+        end
+
+        autorequire(:route53_zone) do
+          self[:zone]
+        end
+      end
+    end
+  end
+end

--- a/lib/puppet_x/puppetlabs/route53_record.rb
+++ b/lib/puppet_x/puppetlabs/route53_record.rb
@@ -4,7 +4,7 @@ module PuppetX
       def create_properties_and_params
         ensurable
         newproperty(:zone) do
-          desc 'the zone associated with this record'
+          desc 'The zone associated with this record.'
           validate do |value|
             fail 'The name of the zone must not be blank' if value.empty?
             fail 'Zone names must end with a .' if value[-1] != '.'
@@ -12,7 +12,7 @@ module PuppetX
         end
 
         newparam(:name) do
-          desc 'the name of DNS record'
+          desc 'The name of DNS record.'
           isnamevar
           validate do |value|
             fail 'The name of the record must not be blank' if value.empty?
@@ -21,14 +21,14 @@ module PuppetX
         end
 
         newproperty(:ttl) do
-          desc 'the time to live for the record'
+          desc 'The time to live for the record.'
           munge do |value|
             value.to_i
           end
         end
 
         newproperty(:values, :array_matching => :all) do
-          desc 'the values of the record'
+          desc 'The values of the record.'
           validate do |value|
             fail 'The value of the record must not be blank' if value.empty?
           end

--- a/lib/puppet_x/puppetlabs/route53_record.rb
+++ b/lib/puppet_x/puppetlabs/route53_record.rb
@@ -22,8 +22,8 @@ module PuppetX
 
         newproperty(:ttl) do
           desc 'the time to live for the record'
-          def insync?(is)
-            is.to_i == should.to_i
+          munge do |value|
+            value.to_i
           end
         end
 

--- a/lib/puppet_x/puppetlabs/route53_record.rb
+++ b/lib/puppet_x/puppetlabs/route53_record.rb
@@ -25,6 +25,9 @@ module PuppetX
           munge do |value|
             value.to_i
           end
+          validate do |value|
+            fail 'TTL values must be integers' unless value.to_i.to_s == value.to_s
+          end
         end
 
         newproperty(:values, :array_matching => :all) do

--- a/spec/acceptance/fixtures/route53_create.pp.tmpl
+++ b/spec/acceptance/fixtures/route53_create.pp.tmpl
@@ -2,9 +2,16 @@ route53_zone { '{{name}}':
   ensure => present,
 }
 
-route53_a_record { '{{record_name}}':
+route53_a_record { '{{a_record_name}}':
   ensure => present,
   zone   => '{{name}}',
-  ttl    => {{ttl}},
-  values => [{{#values}}'{{.}}',{{/values}}],
+  ttl    => {{a_ttl}},
+  values => [{{#a_values}}'{{.}}',{{/a_values}}],
+}
+
+route53_txt_record { '{{txt_record_name}}':
+  ensure => present,
+  zone   => '{{name}}',
+  ttl    => {{txt_ttl}},
+  values => '{{txt_value}}',
 }

--- a/spec/acceptance/fixtures/route53_create.pp.tmpl
+++ b/spec/acceptance/fixtures/route53_create.pp.tmpl
@@ -1,0 +1,10 @@
+route53_zone { '{{name}}':
+  ensure => present,
+}
+
+route53_a_record { '{{record_name}}':
+  ensure => present,
+  zone   => '{{name}}',
+  ttl    => {{ttl}},
+  values => [{{#values}}'{{.}}',{{/values}}],
+}

--- a/spec/acceptance/fixtures/route53_delete.pp.tmpl
+++ b/spec/acceptance/fixtures/route53_delete.pp.tmpl
@@ -1,0 +1,12 @@
+route53_a_record { '{{record_name}}':
+  ensure => absent,
+  zone   => '{{name}}',
+  ttl    => {{ttl}},
+  values => [{{#values}}'{{.}}',{{/values}}],
+} ~>
+
+route53_zone { '{{name}}':
+  ensure => absent,
+}
+
+

--- a/spec/acceptance/fixtures/route53_delete.pp.tmpl
+++ b/spec/acceptance/fixtures/route53_delete.pp.tmpl
@@ -1,12 +1,15 @@
-route53_a_record { '{{record_name}}':
+route53_a_record { '{{a_record_name}}':
   ensure => absent,
   zone   => '{{name}}',
-  ttl    => {{ttl}},
-  values => [{{#values}}'{{.}}',{{/values}}],
-} ~>
+  before => Route53_zone['{{name}}'],
+}
+
+route53_txt_record { '{{txt_record_name}}':
+  ensure => absent,
+  zone   => '{{name}}',
+  before => Route53_zone['{{name}}'],
+}
 
 route53_zone { '{{name}}':
   ensure => absent,
 }
-
-

--- a/spec/acceptance/route53_spec.rb
+++ b/spec/acceptance/route53_spec.rb
@@ -5,7 +5,7 @@ describe "route53_zone" do
 
   before(:all) do
     @default_region = 'sa-east-1'
-    @aws = Ec2Helper.new(@default_region)
+    @aws = AwsHelper.new(@default_region)
   end
 
   def find_zone(name)

--- a/spec/acceptance/route53_spec.rb
+++ b/spec/acceptance/route53_spec.rb
@@ -20,22 +20,27 @@ describe "route53_zone" do
     records.first
   end
 
-
-  describe 'should create a new zone and A record' do
+  describe 'should create a new zone and some DNS record' do
 
     before(:all) do
       @name = "#{SecureRandom.uuid}.com."
       @config = {
         :name => @name,
-        :record_name => "local.#{@name}",
-        :ttl => 3000,
-        :values => ['127.0.0.1'],
+        :a_record_name => "local.#{@name}",
+        :a_ttl => 3000,
+        :a_values => ['127.0.0.1'],
+        :txt_record_name => "local.#{@name}",
+        :txt_ttl => 17000,
+        :txt_value => 'message',
       }
 
       @template = 'route53_create.pp.tmpl'
       PuppetManifest.new(@template, @config).apply
       @zone = find_zone(@name)
-      @record = find_record(@config[:record_name], @zone, 'A')
+      @a_record = find_record(@config[:a_record_name], @zone, 'A')
+      @ns_record = find_record(@config[:name], @zone, 'NS')
+      @soa_record = find_record(@config[:name], @zone, 'SOA')
+      @txt_record = find_record(@config[:txt_record_name], @zone, 'TXT')
     end
 
     after(:all) do
@@ -53,28 +58,97 @@ describe "route53_zone" do
       expect(@zone.name).to eq(@name)
     end
 
+    it 'should automatically create an NS record for the zone' do
+      expect(@ns_record).not_to be_nil
+    end
+
+    it 'should automatically create an SOA record for the zone' do
+      expect(@soa_record).not_to be_nil
+    end
+
     it 'should create an A record with the relevant ttl' do
-      expect(@record.ttl).to eq(@config[:ttl])
+      expect(@a_record.ttl).to eq(@config[:a_ttl])
     end
 
     it 'should create an A record with the relevant values' do
-      expect(@record.resource_records.map(&:value)).to eq(@config[:values])
+      expect(@a_record.resource_records.map(&:value)).to eq(@config[:a_values])
     end
 
-    it 'should allow the ttl to be changed' do
-      new_config = @config.update({:ttl => 4000})
+    describe 'using puppet resource on the A record' do
+      before(:all) do
+        ENV['AWS_REGION'] = @default_region
+        options = {:name => @config[:a_record_name]}
+        @result = TestExecutor.puppet_resource('route53_a_record', options, '--modulepath ../')
+      end
+
+      it 'should show the correct TTL' do
+        regex = /ttl\s*=>\s*'#{@config[:a_ttl]}'/
+        expect(@result.stdout).to match(regex)
+      end
+
+      it 'should show the correct zone' do
+        regex = /zone\s*=>\s*'#{@config[:name]}'/
+        expect(@result.stdout).to match(regex)
+      end
+
+      it 'should show the correct values' do
+        regex = /values\s*=>\s*#{@config[:a_values]}/
+        expect(@result.stdout).to match(regex)
+      end
+    end
+
+    describe 'using puppet resource on the TXT record' do
+      before(:all) do
+        ENV['AWS_REGION'] = @default_region
+        options = {:name => @config[:txt_record_name]}
+        @result = TestExecutor.puppet_resource('route53_txt_record', options, '--modulepath ../')
+      end
+
+      it 'should show the correct TTL' do
+        regex = /ttl\s*=>\s*'#{@config[:txt_ttl]}'/
+        expect(@result.stdout).to match(regex)
+      end
+
+      it 'should show the correct zone' do
+        regex = /zone\s*=>\s*'#{@config[:name]}'/
+        expect(@result.stdout).to match(regex)
+      end
+    end
+
+    describe 'using puppet resource on the auto generted NS record' do
+      before(:all) do
+        ENV['AWS_REGION'] = @default_region
+        options = {:name => @config[:name]}
+        @result = TestExecutor.puppet_resource('route53_ns_record', options, '--modulepath ../')
+      end
+
+      it 'should show the correct zone' do
+        regex = /zone\s*=>\s*'#{@config[:name]}'/
+        expect(@result.stdout).to match(regex)
+      end
+    end
+
+    it 'should create an TXT record with the relevant ttl' do
+      expect(@txt_record.ttl).to eq(@config[:txt_ttl])
+    end
+
+    it 'should create an TXT record with the relevant value' do
+      expect(@txt_record.resource_records.map(&:value)).to eq(["\"message\""])
+    end
+
+    it 'should allow the ttl to be changed on the A record' do
+      new_config = @config.update({:a_ttl => 4000})
       PuppetManifest.new(@template, new_config).apply
-      record = find_record(@config[:record_name], @zone, 'A')
-      expect(record.ttl).to eq(new_config[:ttl])
+      record = find_record(@config[:a_record_name], @zone, 'A')
+      expect(record.ttl).to eq(new_config[:a_ttl])
     end
 
-    it 'should allow the value to be changed' do
-      new_config = @config.update({:values => ['127.0.0.2', '127.0.0.3']})
+    it 'should allow the value to be changed on the A record' do
+      new_config = @config.update({:a_values => ['127.0.0.2', '127.0.0.3']})
       PuppetManifest.new(@template, new_config).apply
-      record = find_record(@config[:record_name], @zone, 'A')
-      expect(record.resource_records.map(&:value)).to eq(new_config[:values])
+      record = find_record(@config[:a_record_name], @zone, 'A')
+      expect(record.resource_records.map(&:value)).to eq(new_config[:a_values])
     end
-
   end
 
 end

--- a/spec/acceptance/route53_spec.rb
+++ b/spec/acceptance/route53_spec.rb
@@ -44,6 +44,11 @@ describe "route53_zone" do
       expect(@aws.get_dns_zones(@name)).to be_empty
     end
 
+    it 'should run idempotently' do
+      success = PuppetManifest.new(@template, @config).apply[:exit_status].success?
+      expect(success).to eq(true)
+    end
+
     it 'should create a DNS zone with the correct name' do
       expect(@zone.name).to eq(@name)
     end

--- a/spec/acceptance/route53_spec.rb
+++ b/spec/acceptance/route53_spec.rb
@@ -1,0 +1,75 @@
+require 'spec_helper_acceptance'
+require 'securerandom'
+
+describe "route53_zone" do
+
+  before(:all) do
+    @default_region = 'sa-east-1'
+    @aws = Ec2Helper.new(@default_region)
+  end
+
+  def find_zone(name)
+    zones = @aws.get_dns_zones(name)
+    expect(zones.count).to eq(1)
+    zones.first
+  end
+
+  def find_record(name, zone, type)
+    records = @aws.get_dns_records(name, zone, type)
+    expect(records.count).to eq(1)
+    records.first
+  end
+
+
+  describe 'should create a new zone and A record' do
+
+    before(:all) do
+      @name = "#{SecureRandom.uuid}.com."
+      @config = {
+        :name => @name,
+        :record_name => "local.#{@name}",
+        :ttl => 3000,
+        :values => ['127.0.0.1'],
+      }
+
+      @template = 'route53_create.pp.tmpl'
+      PuppetManifest.new(@template, @config).apply
+      @zone = find_zone(@name)
+      @record = find_record(@config[:record_name], @zone, 'A')
+    end
+
+    after(:all) do
+      template = 'route53_delete.pp.tmpl'
+      PuppetManifest.new(template, @config).apply
+      expect(@aws.get_dns_zones(@name)).to be_empty
+    end
+
+    it 'should create a DNS zone with the correct name' do
+      expect(@zone.name).to eq(@name)
+    end
+
+    it 'should create an A record with the relevant ttl' do
+      expect(@record.ttl).to eq(@config[:ttl])
+    end
+
+    it 'should create an A record with the relevant values' do
+      expect(@record.resource_records.map(&:value)).to eq(@config[:values])
+    end
+
+    it 'should allow the ttl to be changed' do
+      new_config = @config.update({:ttl => 4000})
+      PuppetManifest.new(@template, new_config).apply
+      record = find_record(@config[:record_name], @zone, 'A')
+      expect(record.ttl).to eq(new_config[:ttl])
+    end
+
+    it 'should allow the value to be changed' do
+      new_config = @config.update({:values => ['127.0.0.2', '127.0.0.3']})
+      PuppetManifest.new(@template, new_config).apply
+      record = find_record(@config[:record_name], @zone, 'A')
+      expect(record.resource_records.map(&:value)).to eq(new_config[:values])
+    end
+
+  end
+
+end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -82,6 +82,7 @@ class AwsHelper
     @elb_client = ::Aws::ElasticLoadBalancing::Client.new({region: region})
     @autoscaling_client = ::Aws::AutoScaling::Client.new({region: region})
     @cloudwatch_client = ::Aws::CloudWatch::Client.new({region: region})
+    @route53_client = ::Aws::Route53::Client.new({region: region})
   end
 
   def get_instances(name)
@@ -117,6 +118,7 @@ class AwsHelper
     tags.to_set ^ item_tags.to_set
   end
 
+<<<<<<< HEAD
   def get_autoscaling_groups(name)
     response = @autoscaling_client.describe_auto_scaling_groups(
       auto_scaling_group_names: [name]
@@ -144,6 +146,17 @@ class AwsHelper
       alarm_names: [name]
     )
     response.data.metric_alarms
+  end
+
+  def get_dns_zones(name)
+    @route53_client.list_hosted_zones.data.hosted_zones.select { |zone|
+      zone.name == name
+    }
+  end
+
+  def get_dns_records(name, zone, type)
+    records = @route53_client.list_resource_record_sets(hosted_zone_id: zone.id)
+    records.data.resource_record_sets.select { |r| r.type == type }
   end
 
 end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -118,7 +118,6 @@ class AwsHelper
     tags.to_set ^ item_tags.to_set
   end
 
-<<<<<<< HEAD
   def get_autoscaling_groups(name)
     response = @autoscaling_client.describe_auto_scaling_groups(
       auto_scaling_group_names: [name]

--- a/spec/unit/provider/route53_record/v2_spec.rb
+++ b/spec/unit/provider/route53_record/v2_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-provider_class = Puppet::Type.type(:route53_zone).provider(:v2)
+provider_class = Puppet::Type.type(:route53_a_record).provider(:v2)
 
 ENV['AWS_ACCESS_KEY_ID'] = 'redacted'
 ENV['AWS_SECRET_ACCESS_KEY'] = 'redacted'
@@ -9,8 +9,11 @@ ENV['AWS_REGION'] = 'sa-east-1'
 describe provider_class do
 
   context 'with the minimum params' do
-    let(:resource) { Puppet::Type.type(:route53_zone).new(
-      name: 'devopscentral.com.',
+    let(:resource) { Puppet::Type.type(:route53_a_record).new(
+      name: 'local.devopscentral.com.',
+      zone: 'devopscentral.com.',
+      ttl: 3000,
+      values: ['127.0.0.1']
     )}
 
     let(:provider) { resource.provider }
@@ -18,12 +21,12 @@ describe provider_class do
     let(:instance) { provider.class.instances.first }
 
     it 'should be an instance of the ProviderV2' do
-      expect(provider).to be_an_instance_of Puppet::Type::Route53_zone::ProviderV2
+      expect(provider).to be_an_instance_of Puppet::Type::Route53_a_record::ProviderV2
     end
 
     describe 'self.prefetch' do
       it 'exists' do
-        VCR.use_cassette('zone-setup') do
+        VCR.use_cassette('record-setup') do
           provider.class.instances
           provider.class.prefetch({})
         end
@@ -31,30 +34,30 @@ describe provider_class do
     end
 
     describe 'exists?' do
-      it 'should correctly report non-existent zones' do
-        VCR.use_cassette('no-zone-named') do
+      it 'should correctly report non-existent records' do
+        VCR.use_cassette('no-record-named') do
           expect(provider.exists?).to be_falsy
         end
       end
 
-      it 'should correctly find existing zones' do
-        VCR.use_cassette('zone-named') do
+      it 'should correctly find existing records' do
+        VCR.use_cassette('record-named') do
           expect(instance.exists?).to be_truthy
         end
       end
     end
 
     describe 'create' do
-      it 'should send a request to the EC2 API to create the zone' do
-        VCR.use_cassette('create-zone') do
+      it 'should send a request to the EC2 API to create the record' do
+        VCR.use_cassette('create-record') do
           expect(provider.create).to be_truthy
         end
       end
     end
 
     describe 'destroy' do
-      it 'should send a request to the EC2 API to destroy the zone' do
-        VCR.use_cassette('destroy-zone') do
+      it 'should send a request to the EC2 API to destroy the record' do
+        VCR.use_cassette('destroy-record') do
           expect(provider.destroy).to be_truthy
         end
       end

--- a/spec/unit/provider/route53_zone/v2_spec.rb
+++ b/spec/unit/provider/route53_zone/v2_spec.rb
@@ -1,0 +1,65 @@
+require 'spec_helper'
+
+provider_class = Puppet::Type.type(:route53_zone).provider(:v2)
+
+ENV['AWS_ACCESS_KEY_ID'] = 'redacted'
+ENV['AWS_SECRET_ACCESS_KEY'] = 'redacted'
+ENV['AWS_REGION'] = 'sa-east-1'
+
+describe provider_class do
+
+  context 'with the minimum params' do
+    let(:resource) { Puppet::Type.type(:route53_zone).new(
+      name: 'devopscentral.com.',
+    )}
+
+    let(:provider) { resource.provider }
+
+    let(:instance) { provider.class.instances.first }
+
+    it 'should be an instance of the ProviderV2' do
+      expect(provider).to be_an_instance_of Puppet::Type::Route53_zone::ProviderV2
+    end
+
+    describe 'self.prefetch' do
+      it 'exists' do
+        VCR.use_cassette('zone-setup') do
+          provider.class.instances
+          provider.class.prefetch({})
+        end
+      end
+    end
+
+    describe 'exists?' do
+      it 'should correctly report non-existent zones' do
+        VCR.use_cassette('no-zone-named') do
+          expect(provider.exists?).to be_falsy
+        end
+      end
+
+      it 'should correctly find existing zones' do
+        VCR.use_cassette('zone-named') do
+          expect(instance.exists?).to be_truthy
+        end
+      end
+    end
+
+    describe 'create' do
+      it 'should send a request to the EC2 API to create the zone' do
+        VCR.use_cassette('create-zone') do
+          expect(provider.create).to be_truthy
+        end
+      end
+    end
+
+    describe 'destroy' do
+      it 'should send a request to the EC2 API to destroy the zone' do
+        VCR.use_cassette('destroy-zone') do
+          expect(provider.destroy).to be_truthy
+        end
+      end
+    end
+
+  end
+
+end

--- a/spec/unit/provider/route53_zone/v2_spec.rb
+++ b/spec/unit/provider/route53_zone/v2_spec.rb
@@ -2,9 +2,9 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:route53_zone).provider(:v2)
 
-ENV['AWS_ACCESS_KEY_ID'] = 'redacted'
-ENV['AWS_SECRET_ACCESS_KEY'] = 'redacted'
-ENV['AWS_REGION'] = 'sa-east-1'
+#ENV['AWS_ACCESS_KEY_ID'] = 'redacted'
+#ENV['AWS_SECRET_ACCESS_KEY'] = 'redacted'
+#ENV['AWS_REGION'] = 'sa-east-1'
 
 describe provider_class do
 

--- a/spec/unit/type/route53_record_spec.rb
+++ b/spec/unit/type/route53_record_spec.rb
@@ -74,3 +74,28 @@ require 'spec_helper'
   end
 
 end
+
+describe Puppet::Type.type(:route53_txt_record) do
+
+  it 'should add additional quotes around values' do
+    record = Puppet::Type.type(:route53_txt_record).new({
+      name: 'example.com.',
+      ttl: 3000,
+      zone: 'example.com.',
+      values: 'value',
+    })
+    expect(record[:values]).to eq(["\"value\""])
+  end
+
+  it 'should not add additional quotes around values if already present' do
+    record = Puppet::Type.type(:route53_txt_record).new({
+      name: 'example.com.',
+      ttl: 3000,
+      zone: 'example.com.',
+      values: '"value"',
+    })
+    expect(record[:values]).to eq(["\"value\""])
+  end
+
+
+end

--- a/spec/unit/type/route53_record_spec.rb
+++ b/spec/unit/type/route53_record_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+[
+  :route53_a_record,
+  :route53_txt_record,
+  :route53_ns_record,
+].each do |type|
+
+  type_class = Puppet::Type.type(type)
+
+  describe type_class do
+
+    let :params do
+      [
+        :name,
+      ]
+    end
+
+    let :properties do
+      [
+        :ensure,
+        :ttl,
+        :values,
+        :zone,
+      ]
+    end
+
+    it 'should have expected properties' do
+      properties.each do |property|
+        expect(type_class.properties.map(&:name)).to be_include(property)
+      end
+    end
+
+    it 'should have expected parameters' do
+      params.each do |param|
+        expect(type_class.parameters).to be_include(param)
+      end
+    end
+  end
+
+end

--- a/spec/unit/type/route53_record_spec.rb
+++ b/spec/unit/type/route53_record_spec.rb
@@ -36,6 +36,35 @@ require 'spec_helper'
         expect(type_class.parameters).to be_include(param)
       end
     end
+
+    it 'should require a name' do
+      expect {
+        type_class.new({})
+      }.to raise_error(Puppet::Error, 'Title or name must be provided')
+    end
+
+    it 'should require a name with a trailing period' do
+      expect {
+        type_class.new({ name: 'invalid' })
+      }.to raise_error(Puppet::Error, /Record names must end with a \./)
+    end
+
+    it 'should require a zone with a trailing period' do
+      expect {
+        type_class.new({ name: 'valid.', zone: 'invalid' })
+      }.to raise_error(Puppet::Error, /Zone names must end with a \./)
+    end
+
+    context 'with a full set of properties' do
+      before :all do
+        @instance = type_class.new({ name: 'valid.', zone: 'valid.', ttl: "400" })
+      end
+
+      it 'should convert ttl values to an integer' do
+        expect(@instance[:ttl].kind_of?(Integer)).to be true
+      end
+    end
+
   end
 
 end

--- a/spec/unit/type/route53_record_spec.rb
+++ b/spec/unit/type/route53_record_spec.rb
@@ -55,6 +55,12 @@ require 'spec_helper'
       }.to raise_error(Puppet::Error, /Zone names must end with a \./)
     end
 
+    it 'should require ttl to be a number' do
+      expect {
+        type_class.new({ name: 'valid.', ttl: 'invalid' })
+      }.to raise_error(Puppet::Error, /TTL values must be integers/)
+    end
+
     context 'with a full set of properties' do
       before :all do
         @instance = type_class.new({ name: 'valid.', zone: 'valid.', ttl: "400" })

--- a/spec/unit/type/route53_zone_spec.rb
+++ b/spec/unit/type/route53_zone_spec.rb
@@ -27,4 +27,23 @@ describe type_class do
       expect(type_class.parameters).to be_include(param)
     end
   end
+
+  it 'should require a name' do
+    expect {
+      type_class.new({})
+    }.to raise_error(Puppet::Error, 'Title or name must be provided')
+  end
+
+  it 'should require a non-blank name' do
+    expect {
+      type_class.new({ name: '' })
+    }.to raise_error(Puppet::Error, /Empty values are not allowed/)
+  end
+
+  context 'with a valid name' do
+    it 'should create a valid instance' do
+      type_class.new({ name: 'name' })
+    end
+  end
+
 end

--- a/spec/unit/type/route53_zone_spec.rb
+++ b/spec/unit/type/route53_zone_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+type_class = Puppet::Type.type(:route53_zone)
+
+describe type_class do
+
+  let :params do
+    [
+      :name,
+    ]
+  end
+
+  let :properties do
+    [
+      :ensure,
+    ]
+  end
+
+  it 'should have expected properties' do
+    properties.each do |property|
+      expect(type_class.properties.map(&:name)).to be_include(property)
+    end
+  end
+
+  it 'should have expected parameters' do
+    params.each do |param|
+      expect(type_class.parameters).to be_include(param)
+    end
+  end
+end


### PR DESCRIPTION
Not ready for merging just yet, but just to get visibility onto this in the short term.

* This currently supports managing zones, and txt, a and ns records
* I'd in particular be interested in feedback on the approach to the record types