### PR TITLE
(fix) Order independent ingress insync detection

### DIFF
--- a/lib/puppet/type/ec2_securitygroup.rb
+++ b/lib/puppet/type/ec2_securitygroup.rb
@@ -20,8 +20,17 @@ Puppet::Type.newtype(:ec2_securitygroup) do
   newproperty(:ingress, :array_matching => :all) do
     desc 'rules for ingress traffic'
     def insync?(is)
-      should == stringify_values(is)
+      order_ingress(should) == stringify_values(is)
     end
+
+    def order_ingress(rules)
+      groups, ports = rules.partition { |rule| rule['security_group'] }
+      groups.sort_by! { |group| group['security_group'] }
+      ports.sort! { |a, b| [a['protocol'], a['port']] <=> [b['protocol'], b['port']] }
+
+      groups + ports
+    end
+
     def stringify_values(rules)
       rules.collect do |obj|
         obj.each { |k,v| obj[k] = v.to_s }

--- a/spec/acceptance/instance_spec.rb
+++ b/spec/acceptance/instance_spec.rb
@@ -103,7 +103,7 @@ describe "ec2_instance" do
     end
 
     def expect_failed_apply(config)
-      success = PuppetManifest.new(@template, config).apply
+      success = PuppetManifest.new(@template, config).apply[:exit_status].success?
       expect(success).to eq(false)
 
       expect(@ec2.get_instances(config[:name])).to be_empty


### PR DESCRIPTION
- Previously, it was possible to trivially generate spurious change
  notifications when the specified order of ingress rules inside a
  manifest did not match the order returned by AWS.  AWS always
  returns an ordered set of ip_permissions, first by protocol, then by
  port.  Since the conversion to group authorizations is lossy,
  segregate and individually sort those rules by group name.
- Verify with an additional acceptance test that orders ingress rules
  within a manifest differently than what AWS returns, which would have
  previously caused such change notifications.
- To support scanning Puppet apply output, it was necessary to change
  from system() to Open3.popen2e, and PuppetManifest.apply was updated
  to return a hash with the output lines and exit_status rather than
  simply returning a true / false success value.  Several callsites
  were updated accordingly.
