### PR TITLE
Add an example of using the Puppet testing tools with AWS manifests

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -10,6 +10,8 @@ infrastructure.
 * [Infrastructure as YAML](yaml-infrastructure-definition/) - describe an
   entire infrastructure stack in YAML, and use `create_resources` and
   Hiera to build your infrastructure
-* [Auditing Resources](audit-security-groups/) - example os using
+* [Auditing Resources](audit-security-groups/) - example of using
   Puppet's noop feature to Audit AWS resource changes and work alongside
   other tools
+* [Unit Testing](unit-testing) - how to make use of the Puppet testing
+  tools like rspec-puppet to test your AWS code

--- a/examples/unit-testing/.bundle/config
+++ b/examples/unit-testing/.bundle/config
@@ -1,0 +1,2 @@
+---
+BUNDLE_JOBS: 8

--- a/examples/unit-testing/.gitignore
+++ b/examples/unit-testing/.gitignore
@@ -1,0 +1,1 @@
+modules

--- a/examples/unit-testing/.rspec
+++ b/examples/unit-testing/.rspec
@@ -1,0 +1,2 @@
+--format documentation
+--color

--- a/examples/unit-testing/Gemfile
+++ b/examples/unit-testing/Gemfile
@@ -1,0 +1,8 @@
+source "https://rubygems.org"
+
+gem 'puppet'
+gem 'rspec-puppet', :git => 'https://github.com/rodjek/rspec-puppet.git'
+gem 'r10k'
+gem 'rake'
+gem 'puppetlabs_spec_helper'
+gem 'aws-sdk-core'

--- a/examples/unit-testing/Puppetfile
+++ b/examples/unit-testing/Puppetfile
@@ -1,0 +1,3 @@
+forge 'https://forgeapi.puppetlabs.com'
+
+mod 'puppetlabs/aws'

--- a/examples/unit-testing/README.md
+++ b/examples/unit-testing/README.md
@@ -1,0 +1,69 @@
+# Unit Testing AWS Infrastucture
+
+This example demonstrates using the standard Puppet testing tools to
+test code using the AWS module.
+
+## What
+
+Note that in this example we're not actually creating any
+infrastructure, we're just writing unit tests for our manifests using
+[rspec-puppet](http://rspec-puppet.com/). We'll also check the code
+against the puppet style guide using
+[puppet-lint](http://puppet-lint.com/) and for any syntax errors using
+[puppet-syntax](https://github.com/gds-operations/puppet-syntax).
+
+
+## How
+
+First you'll need to install the testing dependencies using
+[bundler](http://bundler.io/). We'll then use
+[R10k](https://github.com/adrienthebo/r10k) to make the AWS module
+available to the manifests under test.
+
+    bundle install
+    bundle exec r10k puppetfile install
+
+With that all set up you should be able to run all of the tests:
+
+    bundle exec rake test
+
+This should output something like the following:
+
+```
+---> syntax:manifests
+---> syntax:templates
+---> syntax:hiera:yaml
+/Users/garethr/.rvm/rubies/ruby-2.1.4/bin/ruby -S rspec
+spec/hosts/arbiter_spec.rb
+
+arbiter
+  should compile into a catalogue without dependency cycles
+  should contain exactly 2 Ec2_instance resources
+  should contain Ec2_instance[web1] with region => "sa-east-1" and
+instance_type => "t1.micro"
+  should contain Ec2_instance[web2] with region => "sa-east-1" and
+instance_type => "t1.micro"
+
+Finished in 0.23166 seconds
+4 examples, 0 failures
+```
+
+Note that if you prefer you can run the lint, syntax and spec tests
+separately with individual commands:
+
+    bundle exec rake lint
+    bundle exec rake syntax
+    bundle exec rake spec
+
+See the [manifest under test](manifests/site.pp) and the
+[accompanying Hiera data](spec/fixtures/hiera/test.yaml) for what we're
+testing, and then take a look at the [tests
+themselves](spec/hosts/arbiter_spec.rb).
+
+
+## Discussion
+
+One of the advantages of using Puppet to describe your infrastructure is
+that you can take advantage of the existing tools, including testing
+tools and support for syntax highlighting in editors like Vim or more advnaced functionality in IDEs like [Geppetto](https://docs.puppetlabs.com/geppetto/4.0/) and [Visual
+Studio](https://visualstudiogallery.msdn.microsoft.com/a517bc05-258e-4010-be95-71bef6a10d3a).

--- a/examples/unit-testing/Rakefile
+++ b/examples/unit-testing/Rakefile
@@ -1,0 +1,34 @@
+require 'rake'
+require 'rspec/core/rake_task'
+
+require 'puppet-lint/tasks/puppet-lint'
+require 'puppet-syntax/tasks/puppet-syntax'
+
+exclude_paths = [
+  "pkg/**/*",
+  "vendor/**/*",
+  "spec/**/*",
+  "modules/**/*",
+]
+
+PuppetSyntax.exclude_paths = exclude_paths
+
+RSpec::Core::RakeTask.new(:spec) do |t|
+  t.pattern = 'spec/*/*_spec.rb'
+end
+
+Rake::Task[:lint].clear
+PuppetLint::RakeTask.new :lint do |config|
+  config.ignore_paths = exclude_paths
+  config.disable_checks = [ '80chars', 'autoloader_layout', 'class_inherits_from_params_class' ]
+  config.fail_on_warnings = true
+  config.with_context = true
+  config.log_format = "%{path}:%{linenumber}:%{check}:%{KIND}:%{message}"
+end
+
+desc "Run lint and spec tests"
+task :test => [
+  :lint,
+  :syntax,
+  :spec,
+]

--- a/examples/unit-testing/manifests/site.pp
+++ b/examples/unit-testing/manifests/site.pp
@@ -1,0 +1,9 @@
+node 'arbiter' {
+  Ec2_instance {
+    image_id => hiera('default_image_id'),
+    instance_type   => hiera('default_instance_type'),
+    region  => hiera('default_region'),
+  }
+  $instances = hiera_hash('instances', {})
+  create_resources(ec2_instance, $instances)
+}

--- a/examples/unit-testing/spec/fixtures/hiera/hiera.yaml
+++ b/examples/unit-testing/spec/fixtures/hiera/hiera.yaml
@@ -1,0 +1,7 @@
+---
+:backends:
+  - yaml
+:hierarchy:
+  - test
+:yaml:
+  :datadir: 'spec/fixtures/hiera'

--- a/examples/unit-testing/spec/fixtures/hiera/test.yaml
+++ b/examples/unit-testing/spec/fixtures/hiera/test.yaml
@@ -1,0 +1,7 @@
+---
+default_image_id: ami-67a60d7a
+default_instance_type: t1.micro
+default_region: sa-east-1
+instances:
+  web1: {}
+  web2: {}

--- a/examples/unit-testing/spec/hosts/arbiter_spec.rb
+++ b/examples/unit-testing/spec/hosts/arbiter_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+
+describe 'arbiter' do
+  it { should compile.with_all_deps }
+  it { should have_ec2_instance_resource_count(2) }
+
+  2.times do |i|
+    it { should contain_ec2_instance("web#{i+1}").with_region('sa-east-1').with_instance_type('t1.micro') }
+  end
+end

--- a/examples/unit-testing/spec/spec_helper.rb
+++ b/examples/unit-testing/spec/spec_helper.rb
@@ -1,0 +1,9 @@
+require 'rspec-puppet'
+
+root_path = File.expand_path(File.join(__FILE__, '..', '..'))
+
+RSpec.configure do |c|
+  c.module_path = File.join(root_path, 'modules')
+  c.manifest_dir = File.join(root_path, 'manifests')
+  c.hiera_config = 'spec/fixtures/hiera/hiera.yaml'
+end


### PR DESCRIPTION
I think one of the compelling reasons for using Puppet for describing infrastructure is the existing tooling already available. This simple demo shows how to using rspec-puppet to write unit tests against AWS manifests - this would make a great CD pipeline for changes to AWS.