### PR TITLE
Use a flag to run tests under beaker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ Gemfile.lock
 Gemfile.local
 
 /graphs
+
+.vagrant

--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,10 @@ group :test do
   gem "mustache"
 end
 
+group :integration do
+  gem 'beaker-rspec',  :require => false
+end
+
 group :development do
   gem 'travis'
   gem 'travis-lint'

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -1,0 +1,13 @@
+HOSTS:
+  ubuntu-server-1404-x64:
+    roles:
+      - master
+    platform: ubuntu-server-14.04-amd64
+    box: puppetlabs/ubuntu-14.04-64-nocm
+    box_url: https://vagrantcloud.com/puppetlabs/ubuntu-14.04-64-nocm
+    hypervisor: vagrant
+    ip: '10.255.33.135'
+
+CONFIG:
+  log_level: verbose
+  type: foss

--- a/spec/spec_helper_integration.rb
+++ b/spec/spec_helper_integration.rb
@@ -1,0 +1,27 @@
+require 'beaker-rspec'
+
+unless ENV['BEAKER_provision'] == 'no'
+  # Could be toggled between PE and Puppet
+  master_name = 'puppet'
+  on master, "echo '10.255.33.135   #{master_name}' >> /etc/hosts"
+  on master, "hostname #{master_name}"
+  install_package master, 'ruby'
+  on master, 'gem install aws-sdk-core'
+  install_package master, 'puppetmaster'
+  on master, 'puppet agent --enable'
+  home = ENV['HOME']
+  file = File.open("#{home}/.aws/credentials")
+  agent_home = on(master, 'printenv HOME').stdout.chomp
+  on(master, "mkdir #{agent_home}/.aws")
+  create_remote_file(master, "#{agent_home}/.aws/credentials", file.read)
+end
+
+RSpec.configure do |c|
+
+  c.before :suite do
+    # Install from local code, could be toggled between local and package
+    proj_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
+    puppet_module_install(:source => proj_root, :module_name => 'aws')
+  end
+
+end


### PR DESCRIPTION
Rather than have two parallel test suites, this proposal allows toggling
tests to be run using beaker with an ENV variable.

This is currently a working demonstration with a number of hard coded
bits, in particular:

* Uses Puppet rather than allowing for PE as well
* Uses a single node as the master and agent
* Uses Vagrant as the backend, rather than allowing for Vagrant and vmspooler

These are all easily changeable, but want to get feedback on the
approach first.

Note that this is based on #44, but takes a different approach. This has been tested using the existing unchanged load banacer spec using:

```
VAGRANT_DEFAULT_PROVIDER=virtualbox SPEC=spec/acceptance/loadbalancer_spec.rb BEAKER_provision=yes BEAKER_destroy=no USE_BEAKER=true be rake spec
```