### PR TITLE
Add basic subnet support

### DIFF
--- a/fixtures/vcr_cassettes/create-instance.yml
+++ b/fixtures/vcr_cassettes/create-instance.yml
@@ -5,16 +5,24 @@
         uri: "https://ec2.sa-east-1.amazonaws.com/"
         body: 
           encoding: UTF-8
-          string: "AWSAccessKeyId=redacted&Action=RunInstances&ImageId=ami-67a60d7a&InstanceType=t1.micro&MaxCount=1&MinCount=1&Placement.AvailabilityZone=sa-east-1a&SecurityGroup.1=web-sg&Signature=redacted%2Bh6uwC4cA%3D&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-03T14%3A00%3A45Z&UserData=&Version=2014-06-15"
+          string: "Action=DescribeSecurityGroups&Filter.1.Name=group-name&Filter.1.Value.1=web-sg&Version=2014-09-01"
         headers: 
           Content-Type: 
             - "application/x-www-form-urlencoded; charset=utf-8"
           Accept-Encoding: 
             - ""
           User-Agent: 
-            - "aws-sdk-ruby2/2.0.1 ruby/2.1.1 x86_64-darwin13.0"
+            - "aws-sdk-ruby2/2.0.5 ruby/2.1.4 x86_64-darwin14.0"
+          X-Amz-Date: 
+            - "20141106T104912Z"
+          Host: 
+            - ec2.sa-east-1.amazonaws.com
+          X-Amz-Content-Sha256: 
+            - "6b4497d6ee1ed745d75df9ca73c1bda511e74d65487aa09a89cf131932ff2f24"
+          Authorization: 
+            - "AWS4-HMAC-SHA256 Credential=/20141106/sa-east-1/ec2/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature="
           Content-Length: 
-            - "350"
+            - "97"
           Accept: 
             - "*/*"
       response: 
@@ -29,86 +37,40 @@
           Vary: 
             - Accept-Encoding
           Date: 
-            - "Fri, 03 Oct 2014 14:00:46 GMT"
+            - "Thu, 06 Nov 2014 10:49:21 GMT"
           Server: 
             - AmazonEC2
         body: 
           encoding: UTF-8
           string: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <RunInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
-                <requestId>e840bed7-aa57-4305-934c-05ae99132d67</requestId>
-                <reservationId>r-d1ae1bc4</reservationId>
-                <ownerId>482693910459</ownerId>
-                <groupSet>
-                    <item>
-                        <groupId>sg-d5d0f4c8</groupId>
-                        <groupName>web-sg</groupName>
-                    </item>
-                </groupSet>
-                <instancesSet>
-                    <item>
-                        <instanceId>i-e68e0cf3</instanceId>
-                        <imageId>ami-67a60d7a</imageId>
-                        <instanceState>
-                            <code>0</code>
-                            <name>pending</name>
-                        </instanceState>
-                        <privateDnsName/>
-                        <dnsName/>
-                        <reason/>
-                        <amiLaunchIndex>0</amiLaunchIndex>
-                        <productCodes/>
-                        <instanceType>t1.micro</instanceType>
-                        <launchTime>2014-10-03T14:00:46.000Z</launchTime>
-                        <placement>
-                            <availabilityZone>sa-east-1a</availabilityZone>
-                            <groupName/>
-                            <tenancy>default</tenancy>
-                        </placement>
-                        <kernelId>aki-5553f448</kernelId>
-                        <monitoring>
-                            <state>disabled</state>
-                        </monitoring>
-                        <groupSet>
-                            <item>
-                                <groupId>sg-d5d0f4c8</groupId>
-                                <groupName>web-sg</groupName>
-                            </item>
-                        </groupSet>
-                        <stateReason>
-                            <code>pending</code>
-                            <message>pending</message>
-                        </stateReason>
-                        <architecture>x86_64</architecture>
-                        <rootDeviceType>ebs</rootDeviceType>
-                        <rootDeviceName>/dev/sda1</rootDeviceName>
-                        <blockDeviceMapping/>
-                        <virtualizationType>paravirtual</virtualizationType>
-                        <clientToken/>
-                        <hypervisor>xen</hypervisor>
-                        <networkInterfaceSet/>
-                        <ebsOptimized>false</ebsOptimized>
-                    </item>
-                </instancesSet>
-            </RunInstancesResponse>
+            <DescribeSecurityGroupsResponse xmlns="http://ec2.amazonaws.com/doc/2014-09-01/">
+            </DescribeSecurityGroupsResponse>
         http_version: 
-      recorded_at: "Fri, 03 Oct 2014 14:00:47 GMT"
+      recorded_at: "Thu, 06 Nov 2014 10:49:21 GMT"
     - request: 
         method: post
         uri: "https://ec2.sa-east-1.amazonaws.com/"
         body: 
           encoding: UTF-8
-          string: "AWSAccessKeyId=redacted&Action=CreateTags&ResourceId.1=i-e68e0cf3&Signature=redacted%3D&SignatureMethod=HmacSHA256&SignatureVersion=2&Tag.1.Key=Name&Tag.1.Value=web-15&Timestamp=2014-10-03T14%3A00%3A47Z&Version=2014-06-15"
+          string: "Action=RunInstances&ImageId=ami-67a60d7a&InstanceType=t1.micro&MaxCount=1&MinCount=1&Monitoring.Enabled=false&Placement.AvailabilityZone=sa-east-1a&SecurityGroupId.1=sg-710d216c&Version=2014-09-01"
         headers: 
           Content-Type: 
             - "application/x-www-form-urlencoded; charset=utf-8"
           Accept-Encoding: 
             - ""
           User-Agent: 
-            - "aws-sdk-ruby2/2.0.1 ruby/2.1.1 x86_64-darwin13.0"
+            - "aws-sdk-ruby2/2.0.5 ruby/2.1.4 x86_64-darwin14.0"
+          X-Amz-Date: 
+            - "20141106T104921Z"
+          Host: 
+            - ec2.sa-east-1.amazonaws.com
+          X-Amz-Content-Sha256: 
+            - "35e98bfb255d7897a5d3b50b2071e07819dcf936d5194be9379931f538ce1e41"
+          Authorization: 
+            - "AWS4-HMAC-SHA256 Credential=/20141106/sa-east-1/ec2/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature="
           Content-Length: 
-            - "268"
+            - "196"
           Accept: 
             - "*/*"
       response: 
@@ -123,17 +85,65 @@
           Vary: 
             - Accept-Encoding
           Date: 
-            - "Fri, 03 Oct 2014 14:00:47 GMT"
+            - "Thu, 06 Nov 2014 10:49:24 GMT"
           Server: 
             - AmazonEC2
         body: 
           encoding: UTF-8
           string: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <CreateTagsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
-                <requestId>a9d1c644-c734-4bb6-a126-0fab8dc3ab87</requestId>
+            <RunInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2014-09-01/">
+                            </RunInstancesResponse>
+        http_version: 
+      recorded_at: "Thu, 06 Nov 2014 10:49:24 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "Action=CreateTags&ResourceId.1=i-38bfdb2d&Tag.1.Key=Name&Tag.1.Value=web-15&Version=2014-09-01"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.5 ruby/2.1.4 x86_64-darwin14.0"
+          X-Amz-Date: 
+            - "20141106T104924Z"
+          Host: 
+            - ec2.sa-east-1.amazonaws.com
+          X-Amz-Content-Sha256: 
+            - c581dd10ba0d9aca729dd750e4229acc44f0ad04cabea01e41444ac3e662a8b9
+          Authorization: 
+            - "AWS4-HMAC-SHA256 Credential=/20141106/sa-east-1/ec2/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature="
+          Content-Length: 
+            - "94"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Thu, 06 Nov 2014 10:49:26 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <CreateTagsResponse xmlns="http://ec2.amazonaws.com/doc/2014-09-01/">
+                <requestId>9e20f00b-f39d-40f7-b6cb-9750a44e7f1e</requestId>
                 <return>true</return>
             </CreateTagsResponse>
         http_version: 
-      recorded_at: "Fri, 03 Oct 2014 14:00:48 GMT"
+      recorded_at: "Thu, 06 Nov 2014 10:49:25 GMT"
   recorded_with: "VCR 2.9.3"

--- a/lib/puppet/provider/ec2_instance/v2.rb
+++ b/lib/puppet/provider/ec2_instance/v2.rb
@@ -24,7 +24,7 @@ Puppet::Type.type(:ec2_instance).provide(:v2, :parent => PuppetX::Puppetlabs::Aw
   end
 
   read_only(:instance_id, :instance_type, :region, :user_data, :key_name,
-            :availability_zones, :security_groups, :monitoring)
+            :availability_zones, :security_groups, :monitoring, :subnet)
 
   def self.prefetch(resources)
     instances.each do |prov|
@@ -41,6 +41,13 @@ Puppet::Type.type(:ec2_instance).provide(:v2, :parent => PuppetX::Puppetlabs::Aw
     instance.tags.each do |tag|
       tags[tag.key] = tag.value unless tag.key == 'Name'
     end
+    subnet_name = nil
+    if instance.subnet_id
+      subnet_response = ec2_client(region).describe_subnets(subnet_ids: [instance.subnet_id])
+      subnet_name_tag = subnet_response.data.subnets.first.tags.detect { |tag| tag.key == 'Name' }
+    end
+    subnet_name = subnet_name_tag ? subnet_name_tag.value : nil
+
     config = {
       name: name_tag ? name_tag.value : nil,
       instance_type: instance.instance_type,
@@ -54,6 +61,7 @@ Puppet::Type.type(:ec2_instance).provide(:v2, :parent => PuppetX::Puppetlabs::Aw
       region: region,
       hypervisor: instance.hypervisor,
       virtualization_type: instance.virtualization_type,
+      subnet: subnet_name,
     }
     if instance.state.name == 'running'
       config[:public_dns_name] = instance.public_dns_name
@@ -82,16 +90,34 @@ Puppet::Type.type(:ec2_instance).provide(:v2, :parent => PuppetX::Puppetlabs::Aw
     groups = [groups] unless groups.is_a?(Array)
     groups = groups.reject(&:nil?)
 
+    # this replicates the default behaviour of the API but also allows
+    # us to query the group id which varies between VPC or standard usage
+    groups = ['default'] if groups.empty?
+
     if stopped?
       restart
     else
       data = resource[:user_data].nil? ? nil : Base64.encode64(resource[:user_data])
 
+      ec2 = ec2_client(resource[:region])
+
+      classic_groups = []
+      vpc_groups = Hash.new
+
+
+      ec2.describe_security_groups(filters: [
+        {name: 'group-name', values: groups},
+      ]).each do |response|
+        response.security_groups.each do |sg|
+          classic_groups.push(sg) if sg.vpc_id.nil?
+          (vpc_groups[sg.vpc_id] ||= []).push(sg) if sg.vpc_id
+        end
+      end
+
       config = {
         image_id: resource[:image_id],
         min_count: 1,
         max_count: 1,
-        security_groups: groups,
         instance_type: resource[:instance_type],
         user_data: data,
         placement: {
@@ -105,13 +131,57 @@ Puppet::Type.type(:ec2_instance).provide(:v2, :parent => PuppetX::Puppetlabs::Aw
       key = resource[:key_name] ? resource[:key_name] : false
       config['key_name'] = key if key
 
-      response = ec2_client(resource[:region]).run_instances(config)
+      # must specify a subnet to launch inside a VPC
+      if ! resource[:subnet]
+        matching_groups = classic_groups
+      else
+        # filter by VPC, since describe_subnets doesn't work on empty tag:Name
+        subnet_response = ec2.describe_subnets(filters: [
+          {name: "vpc-id", values: vpc_groups.keys}])
+
+        # then find the name in the VPC subnets that we have
+        subnets = subnet_response.data.subnets.select do |s|
+          if resource[:subnet].empty?
+            ! s.tags.any? { |t| t.key == 'Name' }
+          else
+            s.tags.any? { |t| t.key == 'Name' && t.value == resource[:subnet] }
+          end
+        end
+
+        # handle ambiguous name collisions by selecting first matching subnet / vpc
+        subnet = subnets.first
+        if subnets.length > 1
+          subnet_map = subnets.map { |s| "#{s.subnet_id} (vpc: #{s.vpc_id})" }.join(', ')
+          Puppet.warning "Ambiguous subnet name '#{resource[:subnet]}' resolves to subnets #{subnet_map} - using #{subnet.subnet_id}"
+        end
+
+        if subnet.nil?
+          raise Puppet::Error,
+            "Invalid security groups '#{groups.join(', ')}' not found in VPCs '#{vpc_groups.keys.join(', ')}'"
+        end
+
+        config[:subnet_id] = subnet.subnet_id
+        matching_groups = vpc_groups[subnet.vpc_id]
+      end
+
+      config[:security_group_ids] = matching_groups.map(&:group_id)
+
+      if (groups.uniq.length != matching_groups.map(&:group_name).uniq.length)
+        Puppet.warning <<-EOF
+Not all specified security groups found.
+Specified #{groups.length}: #{groups.join(', ')}
+Found #{matching_groups.length}:
+#{matching_groups.map { |g| 'Name : ' + g.group_name + ' - ' + g.group_id + "\n" }}
+        EOF
+      end
+
+      response = ec2.run_instances(config)
 
       @property_hash[:ensure] = :present
 
       tags = resource[:tags] ? resource[:tags].map { |k,v| {key: k, value: v} } : []
       tags << {key: 'Name', value: name}
-      ec2_client(resource[:region]).create_tags(
+      ec2.create_tags(
         resources: response.instances.map(&:instance_id),
         tags: tags
       )
@@ -148,12 +218,13 @@ Puppet::Type.type(:ec2_instance).provide(:v2, :parent => PuppetX::Puppetlabs::Aw
 
   def tags=(value)
     Puppet.info("Updating tags for #{name} in region #{region}")
-    ec2_client(resource[:region]).create_tags(
+    ec2 = ec2_client(resource[:region])
+    ec2.create_tags(
       resources: [instance_id],
       tags: value.collect { |k,v| { :key => k, :value => v } }
     ) unless value.empty?
     missing_tags = tags.keys - value.keys
-    ec2_client(resource[:region]).delete_tags(
+    ec2.delete_tags(
       resources: [instance_id],
       tags: missing_tags.collect { |k| { :key => k } }
     ) unless missing_tags.empty?

--- a/lib/puppet/type/ec2_instance.rb
+++ b/lib/puppet/type/ec2_instance.rb
@@ -121,6 +121,10 @@ Puppet::Type.newtype(:ec2_instance) do
     end
   end
 
+  newproperty(:subnet) do
+    desc 'the VPC subnet to attach the instance to'
+  end
+
   autorequire(:ec2_securitygroup) do
     groups = self[:security_groups]
     groups.is_a?(Array) ? groups : [groups]

--- a/spec/acceptance/instance_spec.rb
+++ b/spec/acceptance/instance_spec.rb
@@ -61,6 +61,11 @@ describe "ec2_instance" do
       expect(@instance.image_id).to eq(@config[:image_id])
     end
 
+    it "not associated with a VPC" do
+      expect(@instance.subnet_id).to be_nil
+      expect(@instance.vpc_id).to be_nil
+    end
+
     it "and return hypervisor, virtualization_type properties" do
       expect(@instance.hypervisor).to eq('xen')
       expect(@instance.virtualization_type).to eq('paravirtual')
@@ -68,7 +73,7 @@ describe "ec2_instance" do
 
     it "and return public_dns_name, private_dns_name,
       public_ip_address, private_ip_address" do
-      pending('we return instance on pending, and not running, and
+      skip('we return instance on pending, and not running, and
         also need to provide better validation around the values')
       expect(@instance.public_dns_name).to match(/\.compute\.amazonaws\.com/)
       expect(@instance.private_dns_name).to match(/\.compute\.internal/)
@@ -192,6 +197,45 @@ describe "ec2_instance" do
       @config[:ensure] = 'present'
       PuppetManifest.new(@template, @config).apply
       @aws.ec2_client.wait_until(:instance_running, instance_ids:[@instance.instance_id])
+    end
+  end
+
+  describe 'with a specified subnet should create a new instance' do
+
+    before(:each) do
+      @config = {
+        :name => "#{PuppetManifest.env_id}-#{SecureRandom.uuid}",
+        :instance_type => 't1.micro',
+        :region => 'sa-east-1',
+        :image_id => 'ami-41e85d5c',
+        :ensure => 'present',
+        :tags => {
+          :department => 'engineering',
+          :project    => 'cloud',
+          :created_by => 'aws-acceptance'
+        },
+        :optional => {
+          # This is currently a hardcoded, pre-existing subnet.
+          # Once the VPC support is merged this test should move to the VPC
+          # test suite and use a subnet created during the tests
+          :subnet => 'subnet-acceptance',
+        }
+      }
+
+      PuppetManifest.new(@template, @config).apply
+      @instance = get_instance(@config[:name])
+    end
+
+    after(:each) do
+      @config[:ensure] = 'absent'
+      PuppetManifest.new(@template, @config).apply
+
+      @aws.ec2_client.wait_until(:instance_terminated, instance_ids:[@instance.instance_id])
+    end
+
+    it "associated with a VPC" do
+      expect(@instance.subnet_id).not_to be_nil
+      expect(@instance.vpc_id).not_to be_nil
     end
   end
 

--- a/spec/unit/type/ec2_instance_spec.rb
+++ b/spec/unit/type/ec2_instance_spec.rb
@@ -20,6 +20,7 @@ describe type_class do
       :availability_zone,
       :monitoring,
       :key_name,
+      :subnet,
     ]
   end
 


### PR DESCRIPTION
While verifying the work in https://github.com/puppetlabs/puppetlabs-aws/pull/34 I extended the acceptance tests and fixed a bug when creating instances in subnets without specifying a security group. This PR replaces #34 (it contains the same commits, plus the tests and fix)