### PR TITLE
(CLOUD-142, CLOUD-202) Better handling of stopping instances

### DIFF
--- a/lib/puppet/type/ec2_instance.rb
+++ b/lib/puppet/type/ec2_instance.rb
@@ -1,11 +1,28 @@
 Puppet::Type.newtype(:ec2_instance) do
   @doc = 'type representing an EC2 instance'
 
-  ensurable do
-    defaultvalues
-    aliasvalue(:running, :present)
+  newproperty(:ensure) do
+    newvalue(:present) do
+      provider.create unless provider.running?
+    end
+    newvalue(:absent) do
+      provider.destroy if provider.exists?
+    end
+    newvalue(:running) do
+      provider.create unless provider.running?
+    end
     newvalue(:stopped) do
-      provider.stop
+      provider.stop unless provider.stopped?
+    end
+    def change_to_s(current, desired)
+      current = :running if current == :present
+      desired = :running if desired == :present
+      current == desired ? current : "changed #{current} to #{desired}"
+    end
+    def insync?(is)
+      is = :present if is == :running
+      is = :stopped if is == :stopping
+      is.to_s == should.to_s
     end
   end
 

--- a/spec/unit/type/ec2_instance_spec.rb
+++ b/spec/unit/type/ec2_instance_spec.rb
@@ -34,4 +34,12 @@ describe type_class do
       expect(type_class.parameters).to be_include(param)
     end
   end
+
+  it 'should support :stopped as a value to :ensure' do
+    Puppet::Type.type(:ec2_instance).new(:name => 'sample', :ensure => :stopped)
+  end
+
+  it 'should support :running as a value to :ensure' do
+    Puppet::Type.type(:ec2_instance).new(:name => 'sample', :ensure => :running)
+  end
 end


### PR DESCRIPTION
This started out as just making the log messages nicer, so you now get:

* changed running to stopped
* changed stopped to running

I also improved other notice messages or their placement around stopped,
and better handled using running as an alias of present. Ensure for
puppet resources will also now correctly report the status rather than
just present or absent.

Also a minor fix for a typo affecting the output of information in puppet resource.