### PR TITLE
(CLOUD-143) Improve formatting of instance tags when output in logs

### DIFF
--- a/lib/puppet/type/ec2_instance.rb
+++ b/lib/puppet/type/ec2_instance.rb
@@ -1,3 +1,5 @@
+require_relative '../../puppet_x/puppetlabs/property/tag.rb'
+
 Puppet::Type.newtype(:ec2_instance) do
   @doc = 'type representing an EC2 instance'
 
@@ -37,7 +39,7 @@ Puppet::Type.newtype(:ec2_instance) do
     desc 'the security groups to associate the instance'
   end
 
-  newproperty(:tags) do
+  newproperty(:tags, :parent => PuppetX::Property::AwsTag) do
     desc 'the tags for the instance'
   end
 

--- a/lib/puppet_x/puppetlabs/property/tag.rb
+++ b/lib/puppet_x/puppetlabs/property/tag.rb
@@ -1,0 +1,14 @@
+module PuppetX
+  module Property
+    class AwsTag < Puppet::Property
+
+      def format_tags(value)
+        Hash[value.sort]
+      end
+
+      [:should_to_s, :is_to_s].each { |method|
+        alias_method method, :format_tags
+      }
+    end
+  end
+end

--- a/spec/unit/type/ec2_instance_spec.rb
+++ b/spec/unit/type/ec2_instance_spec.rb
@@ -42,4 +42,13 @@ describe type_class do
   it 'should support :running as a value to :ensure' do
     Puppet::Type.type(:ec2_instance).new(:name => 'sample', :ensure => :running)
   end
+
+  it 'should order tags on output' do
+    tags = {'b' => 1, 'a' => 2}
+    reverse = {'a' => 2, 'b' => 1}
+    srv = Puppet::Type.type(:ec2_instance).new(:name => 'sample', :tags => tags )
+    expect(srv.property(:tags).insync?(tags)).to be true
+    expect(srv.property(:tags).insync?(reverse)).to be true
+    expect(srv.property(:tags).should_to_s(tags).to_s).to eq(reverse.to_s)
+  end
 end


### PR DESCRIPTION
Previously tags would be output in the order they were entered or
returned from the AWS API, which might be different. The string
representations could also use single quotes or double quotes. All of
which made parsing changes by eye difficult. This change normalises both
sides of the is and should to be the same, as well as ordering by key
name.