### PR TITLE
This moves a few calls around to allow us to enable the pending tests

### DIFF
--- a/spec/acceptance/instance_spec.rb
+++ b/spec/acceptance/instance_spec.rb
@@ -33,12 +33,12 @@ describe "ec2_instance" do
       }
 
       PuppetManifest.new(@template, @config).apply
+      instance_placeholder = get_instance(@config[:name])
+      @aws.ec2_client.wait_until(:instance_running, instance_ids:[instance_placeholder.instance_id])
       @instance = get_instance(@config[:name])
     end
 
     after(:all) do
-      @aws.ec2_client.wait_until(:instance_running, instance_ids:[@instance.instance_id])
-
       new_config = @config.update({:ensure => 'absent'})
       PuppetManifest.new(@template, new_config).apply
 
@@ -68,8 +68,6 @@ describe "ec2_instance" do
 
     it "and return public_dns_name, private_dns_name,
       public_ip_address, private_ip_address" do
-      pending('we return instance on pending, and not running, and
-        also need to provide better validation around the values')
       expect(@instance.public_dns_name).to match(/\.compute\.amazonaws\.com/)
       expect(@instance.private_dns_name).to match(/\.compute\.internal/)
       expect{ IPAddr.new(@instance.public_ip_address) }.not_to raise_error


### PR DESCRIPTION
This results in an additional call to the API, but we we're already
waiting for the running state in the after step so it's not much slower.