### PR TITLE
(CLOUD-70) Handle much more complex security groups

### DIFF
--- a/examples/vpc-example/init.pp
+++ b/examples/vpc-example/init.pp
@@ -11,7 +11,11 @@ ec2_securitygroup { 'sample-sg':
   description => 'Security group for VPC',
   ingress     => [{
     security_group => 'sample-sg',
-  }],
+  },{
+    protocol => 'tcp',
+    port     => 22,
+    cidr     => '0.0.0.0/0'
+  }]
 }
 
 ec2_vpc_subnet { 'sample-subnet':

--- a/lib/puppet/provider/ec2_securitygroup/v2.rb
+++ b/lib/puppet/provider/ec2_securitygroup/v2.rb
@@ -1,4 +1,5 @@
-require_relative '../../../puppet_x/puppetlabs/aws.rb'
+require_relative '../../../puppet_x/puppetlabs/aws'
+require_relative '../../../puppet_x/puppetlabs/aws_ingress_rules_parser'
 
 Puppet::Type.type(:ec2_securitygroup).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) do
   confine feature: :aws
@@ -28,29 +29,41 @@ Puppet::Type.type(:ec2_securitygroup).provide(:v2, :parent => PuppetX::Puppetlab
     end
   end
 
-  def self.format_ingress_rules(client, group)
-    group[:ip_permissions].collect do |rule|
-      if rule.user_id_group_pairs.empty?
-        {
-          'protocol' => rule.ip_protocol,
-          'port' => rule.to_port.to_i,
-          'cidr' => rule.ip_ranges.first.cidr_ip
-        }
-      else
-        rule.user_id_group_pairs.collect do |security_group|
-          name = security_group.group_name
-          if name.nil?
-            group_response = client.describe_security_groups(
-              group_ids: [security_group.group_id]
-            )
-            name = group_response.data.security_groups.first.group_name
-          end
-          {
-            'security_group' => name
-          }
-        end
+  def self.prepare_ingress_rule_for_puppet(client, rule, group = nil, cidr = nil)
+    config = {
+      'protocol' => rule.ip_protocol,
+      'from_port' => rule.from_port.to_i,
+      'to_port' => rule.to_port.to_i,
+    }
+    if group
+      name = group.group_name
+      if name.nil?
+        group_response = client.describe_security_groups(filters: [
+          {name: 'group-id', values: [group.group_id]}
+        ])
+        groups = group_response.data.security_groups
+        name = groups.empty? ? nil : groups.first.group_name
       end
-    end.flatten.uniq
+      config['security_group'] = name
+    end
+    config['cidr'] = cidr.cidr_ip if cidr
+    config
+  end
+
+  def self.format_ingress_rules(client, group)
+    rules = []
+    group[:ip_permissions].each do |rule|
+      addition = []
+      rule.user_id_group_pairs.each do |security_group|
+        addition << prepare_ingress_rule_for_puppet(client, rule, security_group)
+      end
+      rule.ip_ranges.each do |cidr|
+        addition << prepare_ingress_rule_for_puppet(client, rule, nil, cidr)
+      end
+      addition << prepare_ingress_rule_for_puppet(client, rule) if addition.empty?
+      rules << addition
+    end
+    rules.flatten.uniq.compact
   end
 
   def self.security_group_to_hash(region, group)
@@ -71,9 +84,8 @@ Puppet::Type.type(:ec2_securitygroup).provide(:v2, :parent => PuppetX::Puppetlab
     end
     {
       id: group.group_id,
-      name: group[:group_name],
-      id: group[:group_id],
-      description: group[:description],
+      name: group.group_name,
+      description: group.description,
       ensure: :present,
       ingress: format_ingress_rules(ec2, group),
       vpc: vpc_name,
@@ -120,17 +132,26 @@ Puppet::Type.type(:ec2_securitygroup).provide(:v2, :parent => PuppetX::Puppetlab
     @property_hash[:ensure] = :present
   end
 
-  def authorize_ingress(new_rules, existing_rules=[])
+  def prepare_ingress_for_api(rule)
     ec2 = ec2_client(resource[:region])
-    new_rules = [new_rules] unless new_rules.is_a?(Array)
+    from_port ||= rule['from_port'] || rule['port'] || 1
+    to_port ||= rule['to_port'] || rule['port'] || 65535
+    rule_hash = {
+      group_id: @property_hash[:id],
+      ip_permissions: []
+    }
 
-    to_create = new_rules - existing_rules
-    to_delete = existing_rules - new_rules
+    protocols = rule.key?('protocol') ? Array(rule['protocol']) : ['tcp', 'udp', 'icmp']
 
-
-    to_create.reject(&:nil?).each do |rule|
+    protocols.each do |protocol|
+      permission = {
+        ip_protocol: protocol,
+      }
+      permission[:to_port] = protocol == 'icmp' ? -1 : to_port.to_i
+      permission[:from_port] = protocol == 'icmp' ? -1 : from_port.to_i
       if rule.key? 'security_group'
         source_group_name = rule['security_group']
+
         filters = [ {name: 'group-name', values: [source_group_name]} ]
         if vpc_only_account?
           response = ec2.describe_security_groups(group_ids: [@property_hash[:id]])
@@ -143,57 +164,33 @@ Puppet::Type.type(:ec2_securitygroup).provide(:v2, :parent => PuppetX::Puppetlab
         source_group_id = group_response.data.security_groups.first.group_id
         Puppet.warning "#{match_count} groups found called #{source_group_name}, using #{source_group_id}" if match_count > 1
 
-        permissions = ['tcp', 'udp', 'icmp'].collect do |protocol|
-          {
-            ip_protocol: protocol,
-            to_port: protocol == 'icmp' ? -1 : 65535,
-            from_port: protocol == 'icmp' ? -1 : 1,
-            user_id_group_pairs: [{
-              group_id: source_group_id
-            }]
-          }
-        end
-
-        ec2.authorize_security_group_ingress(
-          group_id: @property_hash[:id],
-          ip_permissions: permissions
-        )
-      else
-        ec2.authorize_security_group_ingress(
-          group_id: @property_hash[:id],
-          ip_permissions: [{
-            ip_protocol: rule['protocol'],
-            to_port: rule['port'].to_i,
-            from_port: rule['port'].to_i,
-            ip_ranges: [{
-              cidr_ip: rule['cidr']
-            }]
-          }]
-        )
+        permission[:user_id_group_pairs] = [{
+          group_id: source_group_id
+        }]
+      elsif rule.key? 'cidr'
+        permission[:ip_ranges] = [{cidr_ip: rule['cidr']}]
       end
+      rule_hash[:ip_permissions] << permission
     end
+
+    rule_hash
+  end
+
+  def authorize_ingress(new_rules, existing_rules=[])
+    ec2 = ec2_client(resource[:region])
+    new_rules = [new_rules] unless new_rules.is_a?(Array)
+
+    parser = PuppetX::Puppetlabs::AwsIngressRulesParser.new(new_rules)
+    to_create = parser.rules_to_create(existing_rules)
+    to_delete = parser.rules_to_delete(existing_rules)
 
     to_delete.reject(&:nil?).each do |rule|
-      if rule.key? 'security_group'
-         ec2.revoke_security_group_ingress(
-          group_id: @property_hash[:id],
-          source_security_group_name: rule['security_group']
-        )
-      else
-        ec2.revoke_security_group_ingress(
-          group_id: @property_hash[:id],
-          ip_permissions: [{
-            ip_protocol: rule['protocol'],
-            to_port: rule['port'].to_i,
-            from_port: rule['port'].to_i,
-            ip_ranges: [{
-              cidr_ip: rule['cidr']
-            }]
-          }]
-        )
-      end
+      ec2.revoke_security_group_ingress(prepare_ingress_for_api(rule))
     end
 
+    to_create.each do |rule|
+      ec2.authorize_security_group_ingress(prepare_ingress_for_api(rule))
+    end
   end
 
   def ingress=(value)

--- a/lib/puppet_x/puppetlabs/aws_ingress_rules_parser.rb
+++ b/lib/puppet_x/puppetlabs/aws_ingress_rules_parser.rb
@@ -1,0 +1,63 @@
+module PuppetX
+  module Puppetlabs
+    class AwsIngressRulesParser
+
+
+        def initialize(rules)
+          @rules = []
+          @rules << rules.reject(&:nil?).collect do |rule|
+            # expand port to to_port and from_port
+            new_rule = Marshal.load(Marshal.dump(rule))
+            if rule.key? 'port'
+              value = rule['port']
+              new_rule.delete 'port'
+              new_rule['from_port'] = value.to_i
+              new_rule['to_port'] = value.to_i
+            end
+            # add default ports if missing
+            unless new_rule.key? 'to_port'
+              if rule['protocol'] == 'icpm'
+                new_rule['from_port']= -1
+                new_rule['to_port']= -1
+              else
+                new_rule['from_port']= 1
+                new_rule['to_port']= 65535
+              end
+            end
+            # expand when protocol not specified
+            unless rule['protocol']
+              ['tcp', 'udp'].each do |proto|
+                copy = Marshal.load(Marshal.dump(new_rule))
+                copy['protocol'] = proto
+                @rules << copy
+              end
+              new_rule['protocol'] = 'icmp'
+              if new_rule.key? 'to_port'
+                new_rule['to_port'] = -1
+                new_rule['from_port'] = -1
+              end
+            end
+            new_rule
+          end
+          @rules = @rules.flatten
+
+        end
+
+        def rules_to_create(rules)
+          stringify_values(@rules) - stringify_values(rules)
+        end
+
+        def rules_to_delete(rules)
+          stringify_values(rules) - stringify_values(@rules)
+        end
+
+        private
+        def stringify_values(rules)
+          rules.collect do |obj|
+            obj.each { |k,v| obj[k] = v.to_s }
+          end
+        end
+
+    end
+  end
+end

--- a/spec/acceptance/securitygroup_spec.rb
+++ b/spec/acceptance/securitygroup_spec.rb
@@ -15,13 +15,16 @@ describe "ec2_securitygroup" do
     groups.first
   end
 
-  def get_group_permission(ip_permissions, group_name, protocol)
+  def get_group_permission(ip_permissions, group_name, protocol, from_port, to_port)
     group = get_group(group_name)
     ip_permissions.detect do |perm|
       pairs = perm[:user_id_group_pairs]
       # group name is nil in VPC only
       pairs.any? do |pair|
-        pair.group_id == group.group_id && perm[:ip_protocol] == protocol
+        pair.group_id == group.group_id &&
+        perm[:ip_protocol] == protocol
+        perm[:from_port] == from_port
+        perm[:to_port] == to_port
       end
     end
   end
@@ -31,20 +34,25 @@ describe "ec2_securitygroup" do
   def check_ingress_rule(rule, ip_permissions)
     if (rule.has_key? :security_group)
       group_name = rule[:security_group]
-      # a match occurs when AWS has a TCP / UDP / ICMP perm setup for group
-      tcp_perm = get_group_permission(ip_permissions, group_name, 'tcp')
-      udp_perm = get_group_permission(ip_permissions, group_name, 'udp')
-      icmp_perm = get_group_permission(ip_permissions, group_name, 'icmp')
-      match = !tcp_perm.nil? && !udp_perm.nil? && !icmp_perm.nil?
+      protocols = rule[:protocol] || ['tcp', 'udp', 'icmp']
+      match = Array(protocols).all? do |protocol|
+        from_port = rule[:port] || rule[:from_port] || (protocol == 'icmp' ? -1 : 1)
+        to_port = rule[:port] || rule[:to_port] || (protocol == 'icmp' ? -1 : 65535)
+        get_group_permission(ip_permissions, group_name, protocol, from_port, to_port)
+      end
       msg = "Could not find ingress rule for #{group_name}"
     else
+      protocol = rule[:protocol] || 'tcp'
+      from_port = rule[:port] || rule[:from_port] || (protocol == 'icmp' ? -1 : 1)
+      to_port = rule[:port] || rule[:to_port] || (protocol == 'icmp' ? -1 : 65535)
       match = ip_permissions.any? do |perm|
-        rule[:protocol] == perm[:ip_protocol] &&
-        rule[:port] == perm[:from_port] &&
-        rule[:port] == perm[:to_port] &&
+        protocol == perm[:ip_protocol] &&
+        from_port == perm[:from_port] &&
+        to_port == perm[:to_port] &&
         perm[:ip_ranges].any? { |ip| ip[:cidr_ip] == rule[:cidr] }
       end
-      msg = "Could not find ingress rule for #{rule[:protocol]} port #{rule[:port]} and CIDR #{rule[:cidr]}"
+
+      msg = "Could not find ingress rule for #{protocol} from port #{from_port} to #{to_port} with CIDR #{rule[:cidr]}"
     end
     [match, msg]
   end
@@ -362,8 +370,11 @@ describe "ec2_securitygroup" do
       it 'ingress rules are correct' do
         @config[:ingress].each do |i|
           i.each do |key, value|
-            regex = /('#{key}')(\s*)(=>)(\s*)('#{value}')/
-            expect(@response.stdout).to match(regex)
+            keys = key == :port ? ['from_port', 'to_port'] : [key]
+            keys.each do |new_key|
+              regex = /('#{new_key}')(\s*)(=>)(\s*)('#{value}')/
+              expect(@response.stdout).to match(regex)
+            end
           end
         end
       end
@@ -374,6 +385,93 @@ describe "ec2_securitygroup" do
       @config[:ensure] = 'absent'
       PuppetManifest.new(@template, @config).apply
       expect { get_group(@config[:name]) }.to raise_error(Aws::EC2::Errors::InvalidGroupNotFound)
+    end
+
+  end
+
+  describe 'should create a new security group' do
+
+    before(:all) do
+      @name = "#{PuppetManifest.env_id}-#{SecureRandom.uuid}"
+      @config = {
+        :name => @name,
+        :ensure => 'present',
+        :description => 'aws acceptance securitygroup',
+        :region => @default_region,
+        :ingress => [
+          {
+            :protocol  => 'tcp',
+            :from_port => 22,
+            :to_port => 1000,
+            :cidr      => '0.0.0.0/0'
+          }
+        ],
+      }
+
+      PuppetManifest.new(@template, @config).apply
+      @group = get_group(@config[:name])
+    end
+
+    after(:all) do
+      new_config = @config.update({:ensure => 'absent'})
+      PuppetManifest.new(@template, new_config).apply
+
+      expect { get_group(@config[:name]) }.to raise_error(::Aws::EC2::Errors::InvalidGroupNotFound)
+    end
+
+    it "with the specified ingress rules" do
+      @config[:ingress].all? { |rule| has_ingress_rule(rule, @group.ip_permissions)}
+    end
+
+    rules_to_test = [
+      [{
+        :protocol  => 'udp',
+        :from_port => 80,
+        :to_port   => 100,
+        :cidr      => '0.0.0.0/0'
+      }],
+      [{
+        :port => 22,
+        :cidr => '0.0.0.0/0'
+      }],
+      [{
+        :protocol => 'tcp',
+        :port     => 22,
+        :cidr     => '0.0.0.0/0'
+      },{
+        :protocol  => 'udp',
+        :from_port => 80,
+        :to_port   => 100,
+        :cidr      => '0.0.0.0/0'
+      }],
+      [{
+        :protocol => 'tcp',
+        :security_group => '<<name>>',
+      }],
+      [{
+        :protocol => 'udp',
+        :from_port => 100,
+        :to_port   => 120,
+        :security_group => '<<name>>',
+      }]
+    ]
+
+    rules_to_test.each_with_index do |rules, i|
+      it "should be able to modify the ingress rules protocol and ports: #{i+1}" do
+        new_rules = []
+        rules.each do |rule|
+          rule[:security_group] = @name if rule.keys.include?(:security_group)
+          new_rules << rule
+        end
+        new_config = @config.dup.update({:ingress => new_rules})
+        exit_status = PuppetManifest.new(@template, new_config).apply[:exit_status]
+        expect(exit_status.exitstatus).to eq(2)
+
+        @group = get_group(@config[:name])
+
+        new_rules.all? { |rule| has_ingress_rule(rule, @group.ip_permissions)}
+        @config[:ingress].all? { |rule| doesnt_have_ingress_rule(rule, @group.ip_permissions)}
+      end
     end
 
   end

--- a/spec/unit/ingress_rules_spec.rb
+++ b/spec/unit/ingress_rules_spec.rb
@@ -1,0 +1,144 @@
+require 'spec_helper'
+require 'puppet_x/puppetlabs/aws_ingress_rules_parser'
+
+describe PuppetX::Puppetlabs::AwsIngressRulesParser do
+  context 'starting with a blank rule set' do
+    let(:parser) { PuppetX::Puppetlabs::AwsIngressRulesParser.new([]) }
+
+    describe '#rules_to_create' do
+      it 'should be empty if passed a blank rule set' do
+        expect(parser.rules_to_create([])).to be_empty
+      end
+    end
+
+    describe '#to_delete' do
+      it 'should be empty if passed a blank rule set' do
+        expect(parser.rules_to_delete([])).to be_empty
+      end
+    end
+  end
+
+  context 'starting with a single port' do
+    let(:rules) { [{ 'port' => 80 }] }
+    let(:parser) { PuppetX::Puppetlabs::AwsIngressRulesParser.new(rules) }
+
+    context 'compared a blank rule set' do
+
+      describe '#rules_to_create' do
+        it 'should expand the protocols, and use to_ and from_ keys' do
+          expect(parser.rules_to_create([])).to eq([
+            {"from_port"=>"80", "to_port"=>"80", "protocol"=>"tcp"},
+            {"from_port"=>"80", "to_port"=>"80", "protocol"=>"udp"},
+            {"from_port"=>"-1", "to_port"=>"-1", "protocol"=>"icmp"}
+          ])
+        end
+      end
+
+      describe '#to_delete' do
+        it 'should be empty' do
+          expect(parser.rules_to_delete([])).to be_empty
+        end
+      end
+
+    end
+  end
+
+  context 'starting with a single security group' do
+    let(:rules) { [{ 'security_group' => 'sample-group' }] }
+    let(:parser) { PuppetX::Puppetlabs::AwsIngressRulesParser.new(rules) }
+
+    context 'compared to a blank rule set' do
+
+      describe '#rules_to_create' do
+        it 'should expand the protocols, and use to_ and from_ keys' do
+          expect(parser.rules_to_create([])).to eq([
+            {"security_group"=>"sample-group", "from_port"=>"1", "to_port"=>"65535", "protocol"=>"tcp"},
+            {"security_group"=>"sample-group", "from_port"=>"1", "to_port"=>"65535", "protocol"=>"udp"},
+            {"security_group"=>"sample-group", "from_port"=>"-1", "to_port"=>"-1", "protocol"=>"icmp"}
+          ])
+        end
+      end
+
+      describe '#to_delete' do
+        it 'should be empty' do
+          expect(parser.rules_to_delete([])).to be_empty
+        end
+      end
+
+    end
+  end
+
+  context 'starting with a single cidr group' do
+    let(:rules) { [{ 'cidr' => '0.0.0.0/0' }] }
+    let(:parser) { PuppetX::Puppetlabs::AwsIngressRulesParser.new(rules) }
+
+    context 'compared to a blank rule set' do
+
+      describe '#rules_to_create' do
+        it 'should expand the protocols, and use to_ and from_ keys' do
+          expect(parser.rules_to_create([])).to eq([
+            {"cidr"=>"0.0.0.0/0", "from_port"=>"1", "to_port"=>"65535", "protocol"=>"tcp"},
+            {"cidr"=>"0.0.0.0/0", "from_port"=>"1", "to_port"=>"65535", "protocol"=>"udp"},
+            {"cidr"=>"0.0.0.0/0", "from_port"=>"-1", "to_port"=>"-1", "protocol"=>"icmp"}
+          ])
+        end
+      end
+
+      describe '#to_delete' do
+        it 'should be empty' do
+          expect(parser.rules_to_delete([])).to be_empty
+        end
+      end
+
+    end
+  end
+
+  context 'starting with a rule with a protocol' do
+    let(:rules) { [{ 'security_group' => 'sample-group', 'protocol' => 'tcp' }] }
+    let(:parser) { PuppetX::Puppetlabs::AwsIngressRulesParser.new(rules) }
+
+    context 'compared to a blank rule set' do
+
+      describe '#rules_to_create' do
+        it 'should not expand the protocols, but should use to_ and from_ keys' do
+          expect(parser.rules_to_create([])).to eq([
+            {"security_group"=>"sample-group", "from_port"=>"1", "to_port"=>"65535", "protocol"=>"tcp"},
+          ])
+        end
+      end
+
+      describe '#to_delete' do
+        it 'should be empty' do
+          expect(parser.rules_to_delete([])).to be_empty
+        end
+      end
+
+    end
+  end
+
+  context 'starting with a rule with port' do
+    let(:rules) { [{ 'security_group' => 'sample-group', 'port' => 80 }] }
+    let(:parser) { PuppetX::Puppetlabs::AwsIngressRulesParser.new(rules) }
+
+    context 'compared to a blank rule set' do
+
+      describe '#rules_to_create' do
+        it 'should not expand the protocols, but should use to_ and from_ keys' do
+          expect(parser.rules_to_create([])).to eq([
+            {"security_group"=>"sample-group", "from_port"=>"80", "to_port"=>"80", "protocol"=>"tcp"},
+            {"security_group"=>"sample-group", "from_port"=>"80", "to_port"=>"80", "protocol"=>"udp"},
+            {"security_group"=>"sample-group", "from_port"=>"-1", "to_port"=>"-1", "protocol"=>"icmp"},
+          ])
+        end
+      end
+
+      describe '#to_delete' do
+        it 'should be empty' do
+          expect(parser.rules_to_delete([])).to be_empty
+        end
+      end
+
+    end
+  end
+
+end


### PR DESCRIPTION
Previously we had support for quite simple security group types. This
issue gives an idea of a more realistic target:
https://github.com/puppetlabs/puppetlabs-aws/issues/42

This work in progress code aims to handle that issue, as well as
multiple variations. I have local test cases that need turning into acceptance
tests, and some more of the rules code can be pulled into the new class.

The class itself also wants a bit of tidying up and independent tests.
But at the moment this works for me locally against a non-trivial
security group config so woot.