### PR TITLE
Prevent clash between blacksmith and metadata-lint due to gem dependency

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
 require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppet/vendor/semantic/lib/semantic'
 
 begin
   require 'puppet_blacksmith/rake_tasks'


### PR DESCRIPTION
unit tests failing due to dependencies in puppetblacksmith