### PR TITLE
(maint) Config Gemfile for Jenkins / Ruby 1.9.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
 def location_for(place, fake_version = nil)
   if place =~ /^(git:[^#]*)#(.*)/
@@ -33,7 +33,7 @@ group :development do
 end
 
 group :acceptance do
-  gem 'mustache'
+  gem 'mustache', '0.99.8'
 end
 
 if File.exists? "#{__FILE__}.local"


### PR DESCRIPTION
 - Under Jenkins, the GEM_SOURCE environment variable is
   configured to support cached gems during a pipline execution
   to reduce network dependencies.  However, the current Gemfile
   will always go out to Rubygems to install gems, which
   is wasteful.
 - Mustache 1.0.0 release on 1/11/2015, added a Ruby 2.0
   dependency, which is not appropriate for the build server
   or older versions of PE.  Pin to mustache 0.99.8, from
   12/1/2014, which supports Ruby >= 1.9.3