### PR TITLE
(CLOUD-212) Create stopped instance

### DIFF
--- a/fixtures/vcr_cassettes/create-instance.yml
+++ b/fixtures/vcr_cassettes/create-instance.yml
@@ -5,16 +5,24 @@
         uri: "https://ec2.sa-east-1.amazonaws.com/"
         body: 
           encoding: UTF-8
-          string: "AWSAccessKeyId=redacted&Action=RunInstances&ImageId=ami-67a60d7a&InstanceType=t1.micro&MaxCount=1&MinCount=1&Placement.AvailabilityZone=sa-east-1a&SecurityGroup.1=web-sg&Signature=redacted%2Bh6uwC4cA%3D&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-03T14%3A00%3A45Z&UserData=&Version=2014-06-15"
+          string: "Action=RunInstances&ImageId=ami-67a60d7a&InstanceType=t1.micro&MaxCount=1&MinCount=1&Monitoring.Enabled=false&Placement.AvailabilityZone=sa-east-1a&SecurityGroup.1=web-sg&Version=2014-09-01"
         headers: 
           Content-Type: 
             - "application/x-www-form-urlencoded; charset=utf-8"
           Accept-Encoding: 
             - ""
           User-Agent: 
-            - "aws-sdk-ruby2/2.0.1 ruby/2.1.1 x86_64-darwin13.0"
+            - "aws-sdk-ruby2/2.0.5 ruby/2.1.4 x86_64-darwin14.0"
+          X-Amz-Date: 
+            - "20150129T100524Z"
+          Host: 
+            - ec2.sa-east-1.amazonaws.com
+          X-Amz-Content-Sha256: 
+            - e5e51e6a26bad5b8c837d6060199f581f90454a909970fb353585d13dc53b3af
+          Authorization: 
+            - "AWS4-HMAC-SHA256 Credential=redacted/20150129/sa-east-1/ec2/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=de49349a7b55b9dc35ae9614b6baa41d56d20fbe495ff87fdde824c568e94b98"
           Content-Length: 
-            - "350"
+            - "189"
           Accept: 
             - "*/*"
       response: 
@@ -29,26 +37,26 @@
           Vary: 
             - Accept-Encoding
           Date: 
-            - "Fri, 03 Oct 2014 14:00:46 GMT"
+            - "Thu, 29 Jan 2015 10:05:23 GMT"
           Server: 
             - AmazonEC2
         body: 
           encoding: UTF-8
           string: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <RunInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
-                <requestId>e840bed7-aa57-4305-934c-05ae99132d67</requestId>
-                <reservationId>r-d1ae1bc4</reservationId>
+            <RunInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2014-09-01/">
+                <requestId>4d437131-94b2-4a01-98c1-749a53aa71ac</requestId>
+                <reservationId>r-84651a91</reservationId>
                 <ownerId>482693910459</ownerId>
                 <groupSet>
                     <item>
-                        <groupId>sg-d5d0f4c8</groupId>
+                        <groupId>sg-4b50e354</groupId>
                         <groupName>web-sg</groupName>
                     </item>
                 </groupSet>
                 <instancesSet>
                     <item>
-                        <instanceId>i-e68e0cf3</instanceId>
+                        <instanceId>i-c2065bd7</instanceId>
                         <imageId>ami-67a60d7a</imageId>
                         <instanceState>
                             <code>0</code>
@@ -60,7 +68,7 @@
                         <amiLaunchIndex>0</amiLaunchIndex>
                         <productCodes/>
                         <instanceType>t1.micro</instanceType>
-                        <launchTime>2014-10-03T14:00:46.000Z</launchTime>
+                        <launchTime>2015-01-29T10:05:24.000Z</launchTime>
                         <placement>
                             <availabilityZone>sa-east-1a</availabilityZone>
                             <groupName/>
@@ -72,7 +80,7 @@
                         </monitoring>
                         <groupSet>
                             <item>
-                                <groupId>sg-d5d0f4c8</groupId>
+                                <groupId>sg-4b50e354</groupId>
                                 <groupName>web-sg</groupName>
                             </item>
                         </groupSet>
@@ -93,22 +101,30 @@
                 </instancesSet>
             </RunInstancesResponse>
         http_version: 
-      recorded_at: "Fri, 03 Oct 2014 14:00:47 GMT"
+      recorded_at: "Thu, 29 Jan 2015 10:05:25 GMT"
     - request: 
         method: post
         uri: "https://ec2.sa-east-1.amazonaws.com/"
         body: 
           encoding: UTF-8
-          string: "AWSAccessKeyId=redacted&Action=CreateTags&ResourceId.1=i-e68e0cf3&Signature=redacted%3D&SignatureMethod=HmacSHA256&SignatureVersion=2&Tag.1.Key=Name&Tag.1.Value=web-15&Timestamp=2014-10-03T14%3A00%3A47Z&Version=2014-06-15"
+          string: "Action=DescribeInstances&InstanceId.1=i-c2065bd7&Version=2014-09-01"
         headers: 
           Content-Type: 
             - "application/x-www-form-urlencoded; charset=utf-8"
           Accept-Encoding: 
             - ""
           User-Agent: 
-            - "aws-sdk-ruby2/2.0.1 ruby/2.1.1 x86_64-darwin13.0"
+            - "aws-sdk-ruby2/2.0.5 ruby/2.1.4 x86_64-darwin14.0"
+          X-Amz-Date: 
+            - "20150129T100541Z"
+          Host: 
+            - ec2.sa-east-1.amazonaws.com
+          X-Amz-Content-Sha256: 
+            - "79d22502e4cfe2fb2a605d49b78bd9d76751221b988d9763c8d34facf73b6f00"
+          Authorization: 
+            - "AWS4-HMAC-SHA256 Credential=redacted/20150129/sa-east-1/ec2/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=c865fbb51f17ae6fc43ad3145cd2e8c50e008aaa0860e110ac01cde7cbbe8f3b"
           Content-Length: 
-            - "268"
+            - "67"
           Accept: 
             - "*/*"
       response: 
@@ -123,17 +139,131 @@
           Vary: 
             - Accept-Encoding
           Date: 
-            - "Fri, 03 Oct 2014 14:00:47 GMT"
+            - "Thu, 29 Jan 2015 10:05:41 GMT"
           Server: 
             - AmazonEC2
         body: 
           encoding: UTF-8
           string: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <CreateTagsResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
-                <requestId>a9d1c644-c734-4bb6-a126-0fab8dc3ab87</requestId>
+            <DescribeInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2014-09-01/">
+                <requestId>f20d7b31-d24e-43f5-9e12-ae4c387915aa</requestId>
+                <reservationSet>
+                    <item>
+                        <reservationId>r-84651a91</reservationId>
+                        <ownerId>482693910459</ownerId>
+                        <groupSet>
+                            <item>
+                                <groupId>sg-4b50e354</groupId>
+                                <groupName>web-sg</groupName>
+                            </item>
+                        </groupSet>
+                        <instancesSet>
+                            <item>
+                                <instanceId>i-c2065bd7</instanceId>
+                                <imageId>ami-67a60d7a</imageId>
+                                <instanceState>
+                                    <code>16</code>
+                                    <name>running</name>
+                                </instanceState>
+                                <privateDnsName>ip-10-252-9-105.sa-east-1.compute.internal</privateDnsName>
+                                <dnsName>ec2-54-94-69-247.sa-east-1.compute.amazonaws.com</dnsName>
+                                <reason/>
+                                <amiLaunchIndex>0</amiLaunchIndex>
+                                <productCodes/>
+                                <instanceType>t1.micro</instanceType>
+                                <launchTime>2015-01-29T10:05:24.000Z</launchTime>
+                                <placement>
+                                    <availabilityZone>sa-east-1a</availabilityZone>
+                                    <groupName/>
+                                    <tenancy>default</tenancy>
+                                </placement>
+                                <kernelId>aki-5553f448</kernelId>
+                                <monitoring>
+                                    <state>disabled</state>
+                                </monitoring>
+                                <privateIpAddress>10.252.9.105</privateIpAddress>
+                                <ipAddress>54.94.69.247</ipAddress>
+                                <groupSet>
+                                    <item>
+                                        <groupId>sg-4b50e354</groupId>
+                                        <groupName>web-sg</groupName>
+                                    </item>
+                                </groupSet>
+                                <architecture>x86_64</architecture>
+                                <rootDeviceType>ebs</rootDeviceType>
+                                <rootDeviceName>/dev/sda1</rootDeviceName>
+                                <blockDeviceMapping>
+                                    <item>
+                                        <deviceName>/dev/sda1</deviceName>
+                                        <ebs>
+                                            <volumeId>vol-2246833e</volumeId>
+                                            <status>attached</status>
+                                            <attachTime>2015-01-29T10:05:26.000Z</attachTime>
+                                            <deleteOnTermination>true</deleteOnTermination>
+                                        </ebs>
+                                    </item>
+                                </blockDeviceMapping>
+                                <virtualizationType>paravirtual</virtualizationType>
+                                <clientToken/>
+                                <hypervisor>xen</hypervisor>
+                                <networkInterfaceSet/>
+                                <ebsOptimized>false</ebsOptimized>
+                            </item>
+                        </instancesSet>
+                    </item>
+                </reservationSet>
+            </DescribeInstancesResponse>
+        http_version: 
+      recorded_at: "Thu, 29 Jan 2015 10:05:42 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "Action=CreateTags&ResourceId.1=i-c2065bd7&Tag.1.Key=Name&Tag.1.Value=web-15&Version=2014-09-01"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.5 ruby/2.1.4 x86_64-darwin14.0"
+          X-Amz-Date: 
+            - "20150129T100543Z"
+          Host: 
+            - ec2.sa-east-1.amazonaws.com
+          X-Amz-Content-Sha256: 
+            - e13ad3e9a1c18100c1691ed8873f484725efd544bc8dd395faacb9f3916ee8ba
+          Authorization: 
+            - "AWS4-HMAC-SHA256 Credential=redacted/20150129/sa-east-1/ec2/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=4aa9f5044f88d1d60b993cccc2a30d848a58d2e8e32d18280f3e18b50b11ae12"
+          Content-Length: 
+            - "94"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Thu, 29 Jan 2015 10:05:42 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <CreateTagsResponse xmlns="http://ec2.amazonaws.com/doc/2014-09-01/">
+                <requestId>9ff199c9-2172-4f2c-9bb9-2ef3ae3a5062</requestId>
                 <return>true</return>
             </CreateTagsResponse>
         http_version: 
-      recorded_at: "Fri, 03 Oct 2014 14:00:48 GMT"
+      recorded_at: "Thu, 29 Jan 2015 10:05:44 GMT"
   recorded_with: "VCR 2.9.3"

--- a/fixtures/vcr_cassettes/stop-instance.yml
+++ b/fixtures/vcr_cassettes/stop-instance.yml
@@ -5,16 +5,24 @@
         uri: "https://ec2.sa-east-1.amazonaws.com/"
         body: 
           encoding: UTF-8
-          string: "AWSAccessKeyId=&Action=DescribeInstances&Filter.1.Name=tag%3AName&Filter.1.Value.1=web-15&Filter.2.Name=instance-state-name&Filter.2.Value.1=pending&Filter.2.Value.2=running&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-23T13%3A44%3A16Z&Version=2014-06-15"
+          string: "Action=RunInstances&ImageId=ami-67a60d7a&InstanceType=t1.micro&MaxCount=1&MinCount=1&Monitoring.Enabled=false&Placement.AvailabilityZone=sa-east-1a&SecurityGroup.1=web-sg&Version=2014-09-01"
         headers: 
           Content-Type: 
             - "application/x-www-form-urlencoded; charset=utf-8"
           Accept-Encoding: 
             - ""
           User-Agent: 
-            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+            - "aws-sdk-ruby2/2.0.5 ruby/2.1.4 x86_64-darwin14.0"
+          X-Amz-Date: 
+            - "20150129T100544Z"
+          Host: 
+            - ec2.sa-east-1.amazonaws.com
+          X-Amz-Content-Sha256: 
+            - e5e51e6a26bad5b8c837d6060199f581f90454a909970fb353585d13dc53b3af
+          Authorization: 
+            - "AWS4-HMAC-SHA256 Credential=redacted/20150129/sa-east-1/ec2/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=6ee771e71c31ef6a8662d59bd81d0f4767c1e1981f9997aab0191f52e22a3dcc"
           Content-Length: 
-            - "354"
+            - "189"
           Accept: 
             - "*/*"
       response: 
@@ -29,32 +37,94 @@
           Vary: 
             - Accept-Encoding
           Date: 
-            - "Thu, 23 Oct 2014 13:44:17 GMT"
+            - "Thu, 29 Jan 2015 10:05:43 GMT"
           Server: 
             - AmazonEC2
         body: 
           encoding: UTF-8
           string: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <DescribeInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
-            </DescribeInstancesResponse>
+            <RunInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2014-09-01/">
+                <requestId>ea114da7-6af4-4107-916c-5cef52897ae3</requestId>
+                <reservationId>r-ed6619f8</reservationId>
+                <ownerId>482693910459</ownerId>
+                <groupSet>
+                    <item>
+                        <groupId>sg-4b50e354</groupId>
+                        <groupName>web-sg</groupName>
+                    </item>
+                </groupSet>
+                <instancesSet>
+                    <item>
+                        <instanceId>i-44075a51</instanceId>
+                        <imageId>ami-67a60d7a</imageId>
+                        <instanceState>
+                            <code>0</code>
+                            <name>pending</name>
+                        </instanceState>
+                        <privateDnsName/>
+                        <dnsName/>
+                        <reason/>
+                        <amiLaunchIndex>0</amiLaunchIndex>
+                        <productCodes/>
+                        <instanceType>t1.micro</instanceType>
+                        <launchTime>2015-01-29T10:05:43.000Z</launchTime>
+                        <placement>
+                            <availabilityZone>sa-east-1a</availabilityZone>
+                            <groupName/>
+                            <tenancy>default</tenancy>
+                        </placement>
+                        <kernelId>aki-5553f448</kernelId>
+                        <monitoring>
+                            <state>disabled</state>
+                        </monitoring>
+                        <groupSet>
+                            <item>
+                                <groupId>sg-4b50e354</groupId>
+                                <groupName>web-sg</groupName>
+                            </item>
+                        </groupSet>
+                        <stateReason>
+                            <code>pending</code>
+                            <message>pending</message>
+                        </stateReason>
+                        <architecture>x86_64</architecture>
+                        <rootDeviceType>ebs</rootDeviceType>
+                        <rootDeviceName>/dev/sda1</rootDeviceName>
+                        <blockDeviceMapping/>
+                        <virtualizationType>paravirtual</virtualizationType>
+                        <clientToken/>
+                        <hypervisor>xen</hypervisor>
+                        <networkInterfaceSet/>
+                        <ebsOptimized>false</ebsOptimized>
+                    </item>
+                </instancesSet>
+            </RunInstancesResponse>
         http_version: 
-      recorded_at: "Thu, 23 Oct 2014 13:44:18 GMT"
+      recorded_at: "Thu, 29 Jan 2015 10:05:45 GMT"
     - request: 
         method: post
         uri: "https://ec2.sa-east-1.amazonaws.com/"
         body: 
           encoding: UTF-8
-          string: "AWSAccessKeyId=&Action=StopInstances&InstanceId.1=i-c67ae9d3&Signature=&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-23T13%3A44%3A18Z&Version=2014-06-15"
+          string: "Action=DescribeInstances&InstanceId.1=i-44075a51&Version=2014-09-01"
         headers: 
           Content-Type: 
             - "application/x-www-form-urlencoded; charset=utf-8"
           Accept-Encoding: 
             - ""
           User-Agent: 
-            - "aws-sdk-ruby2/2.0.2 ruby/2.1.1 x86_64-darwin13.0"
+            - "aws-sdk-ruby2/2.0.5 ruby/2.1.4 x86_64-darwin14.0"
+          X-Amz-Date: 
+            - "20150129T100617Z"
+          Host: 
+            - ec2.sa-east-1.amazonaws.com
+          X-Amz-Content-Sha256: 
+            - dbcbf98fd8d46bee60cd2306cc07a4fbe80ecf21b333e327c46abe25ab8fe64e
+          Authorization: 
+            - "AWS4-HMAC-SHA256 Credential=redacted/20150129/sa-east-1/ec2/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=75ad249326e6bd6a4f8d41479aacb72d2c5287102b99fb697aedf910ae6e8992"
           Content-Length: 
-            - "239"
+            - "67"
           Accept: 
             - "*/*"
       response: 
@@ -69,15 +139,193 @@
           Vary: 
             - Accept-Encoding
           Date: 
-            - "Thu, 23 Oct 2014 13:44:18 GMT"
+            - "Thu, 29 Jan 2015 10:06:16 GMT"
           Server: 
             - AmazonEC2
         body: 
           encoding: UTF-8
           string: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <StopInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
+            <DescribeInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2014-09-01/">
+                <requestId>ed56c955-4d89-4e48-885e-b0718d28968d</requestId>
+                <reservationSet>
+                    <item>
+                        <reservationId>r-ed6619f8</reservationId>
+                        <ownerId>482693910459</ownerId>
+                        <groupSet>
+                            <item>
+                                <groupId>sg-4b50e354</groupId>
+                                <groupName>web-sg</groupName>
+                            </item>
+                        </groupSet>
+                        <instancesSet>
+                            <item>
+                                <instanceId>i-44075a51</instanceId>
+                                <imageId>ami-67a60d7a</imageId>
+                                <instanceState>
+                                    <code>16</code>
+                                    <name>running</name>
+                                </instanceState>
+                                <privateDnsName>ip-10-252-25-166.sa-east-1.compute.internal</privateDnsName>
+                                <dnsName>ec2-54-232-74-148.sa-east-1.compute.amazonaws.com</dnsName>
+                                <reason/>
+                                <amiLaunchIndex>0</amiLaunchIndex>
+                                <productCodes/>
+                                <instanceType>t1.micro</instanceType>
+                                <launchTime>2015-01-29T10:05:43.000Z</launchTime>
+                                <placement>
+                                    <availabilityZone>sa-east-1a</availabilityZone>
+                                    <groupName/>
+                                    <tenancy>default</tenancy>
+                                </placement>
+                                <kernelId>aki-5553f448</kernelId>
+                                <monitoring>
+                                    <state>disabled</state>
+                                </monitoring>
+                                <privateIpAddress>10.252.25.166</privateIpAddress>
+                                <ipAddress>54.232.74.148</ipAddress>
+                                <groupSet>
+                                    <item>
+                                        <groupId>sg-4b50e354</groupId>
+                                        <groupName>web-sg</groupName>
+                                    </item>
+                                </groupSet>
+                                <architecture>x86_64</architecture>
+                                <rootDeviceType>ebs</rootDeviceType>
+                                <rootDeviceName>/dev/sda1</rootDeviceName>
+                                <blockDeviceMapping>
+                                    <item>
+                                        <deviceName>/dev/sda1</deviceName>
+                                        <ebs>
+                                            <volumeId>vol-2346833f</volumeId>
+                                            <status>attached</status>
+                                            <attachTime>2015-01-29T10:05:46.000Z</attachTime>
+                                            <deleteOnTermination>true</deleteOnTermination>
+                                        </ebs>
+                                    </item>
+                                </blockDeviceMapping>
+                                <virtualizationType>paravirtual</virtualizationType>
+                                <clientToken/>
+                                <hypervisor>xen</hypervisor>
+                                <networkInterfaceSet/>
+                                <ebsOptimized>false</ebsOptimized>
+                            </item>
+                        </instancesSet>
+                    </item>
+                </reservationSet>
+            </DescribeInstancesResponse>
+        http_version: 
+      recorded_at: "Thu, 29 Jan 2015 10:06:18 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "Action=CreateTags&ResourceId.1=i-44075a51&Tag.1.Key=Name&Tag.1.Value=web-15&Version=2014-09-01"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.5 ruby/2.1.4 x86_64-darwin14.0"
+          X-Amz-Date: 
+            - "20150129T100618Z"
+          Host: 
+            - ec2.sa-east-1.amazonaws.com
+          X-Amz-Content-Sha256: 
+            - "399ae9555f555b7c853b7d1d269e902e11eb20b51329d9344505435761acf41b"
+          Authorization: 
+            - "AWS4-HMAC-SHA256 Credential=redacted/20150129/sa-east-1/ec2/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=f3b9dd0fe477579180b70feef0d4f93d5e2cd23745f68379a5ac764ba09a6202"
+          Content-Length: 
+            - "94"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Thu, 29 Jan 2015 10:06:18 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <CreateTagsResponse xmlns="http://ec2.amazonaws.com/doc/2014-09-01/">
+                <requestId>0c15b5ff-713b-43ea-8ce2-2df2918fbd6c</requestId>
+                <return>true</return>
+            </CreateTagsResponse>
+        http_version: 
+      recorded_at: "Thu, 29 Jan 2015 10:06:19 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "Action=StopInstances&InstanceId.1=i-44075a51&Version=2014-09-01"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.5 ruby/2.1.4 x86_64-darwin14.0"
+          X-Amz-Date: 
+            - "20150129T100619Z"
+          Host: 
+            - ec2.sa-east-1.amazonaws.com
+          X-Amz-Content-Sha256: 
+            - "38d93303a9d1e21e7fb9a77747f4bd0dc90382707900a91af998ec0a48cb228a"
+          Authorization: 
+            - "AWS4-HMAC-SHA256 Credential=redacted/20150129/sa-east-1/ec2/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=771b8e09598b11c8e1bc215a5281e29aee61cea14446dbc5d21a8c6f5768e35c"
+          Content-Length: 
+            - "63"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Thu, 29 Jan 2015 10:06:18 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <StopInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2014-09-01/">
+                <requestId>d4dfa07b-6ea6-4f0f-a55a-af7e632b9326</requestId>
+                <instancesSet>
+                    <item>
+                        <instanceId>i-44075a51</instanceId>
+                        <currentState>
+                            <code>64</code>
+                            <name>stopping</name>
+                        </currentState>
+                        <previousState>
+                            <code>16</code>
+                            <name>running</name>
+                        </previousState>
+                    </item>
+                </instancesSet>
             </StopInstancesResponse>
         http_version: 
-      recorded_at: "Thu, 23 Oct 2014 13:44:19 GMT"
+      recorded_at: "Thu, 29 Jan 2015 10:06:20 GMT"
   recorded_with: "VCR 2.9.3"

--- a/spec/acceptance/instance_spec.rb
+++ b/spec/acceptance/instance_spec.rb
@@ -195,4 +195,42 @@ describe "ec2_instance" do
     end
   end
 
+  describe 'create a new instance' do
+
+    let(:config) do
+      {
+        :name => "#{PuppetManifest.env_id}-#{SecureRandom.uuid}",
+        :instance_type => 't1.micro',
+        :region => 'sa-east-1',
+        :image_id => 'ami-41e85d5c',
+        :ensure => 'present',
+        :tags => {
+          :department => 'engineering',
+          :project    => 'cloud',
+          :created_by => 'aws-acceptance'
+        }
+      }
+    end
+
+    after(:each) do
+      config[:ensure] = 'absent'
+      PuppetManifest.new(@template, config).apply
+    end
+
+    it 'launched as stopped' do
+      config[:ensure] = 'stopped'
+      r = PuppetManifest.new(@template, config).apply
+      expect(r[:output].any?{ |o| o.include?('Error:')}).to eq(false)
+      instance = get_instance(config[:name])
+      @aws.ec2_client.wait_until(:instance_stopped, instance_ids:[instance.instance_id])
+    end
+
+    it 'launched as running' do
+      config[:ensure] = 'running'
+      r = PuppetManifest.new(@template, config).apply
+      expect(r[:output].any?{ |o| o.include?('Error:')}).to eq(false)
+      instance = get_instance(config[:name])
+      @aws.ec2_client.wait_until(:instance_running, instance_ids:[instance.instance_id])
+    end
+  end
 end

--- a/spec/acceptance/instance_spec.rb
+++ b/spec/acceptance/instance_spec.rb
@@ -68,8 +68,6 @@ describe "ec2_instance" do
 
     it "and return public_dns_name, private_dns_name,
       public_ip_address, private_ip_address" do
-      pending('we return instance on pending, and not running, and
-        also need to provide better validation around the values')
       expect(@instance.public_dns_name).to match(/\.compute\.amazonaws\.com/)
       expect(@instance.private_dns_name).to match(/\.compute\.internal/)
       expect{ IPAddr.new(@instance.public_ip_address) }.not_to raise_error


### PR DESCRIPTION
This resolves CLOUD-212, specifically that describing a stopped instance would fail if that instance didn't already exist.

As noted in one of the commits, this introduces the wait_until running for instances in create. It's needed for this functionality (you can't stop an instance until it's running) and we've been talking about adding it anyway to resolve some of the race conditions in failing to tag new instances.