### PR TITLE
(CLOUD-204, CLOUD-161) Work around failures to tag new instances

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ def location_for(place, fake_version = nil)
 end
 
 gem 'aws-sdk-core', '2.0.5'
+gem 'retries'
 
 group :test do
   gem 'rake'

--- a/README.md
+++ b/README.md
@@ -32,16 +32,20 @@ Puppet.
 
     gem install aws-sdk-core
 
-If you're running Puppet Enterprise you need to install the gem using
+We also use the retries library so install that with:
+
+    gem install retries
+
+If you're running Puppet Enterprise you need to install the gems using
 the following, so it can be used by the Puppet Enterprise Ruby.
 
-    /opt/puppet/bin/gem install aws-sdk-core
+    /opt/puppet/bin/gem install aws-sdk-core retries
 
 And if you're running [Puppet
 Server](https://github.com/puppetlabs/puppet-server) you need to
  make the gem available to JRuby with:
 
-    /opt/puppet/bin/puppetserver gem install aws-sdk-core
+    /opt/puppet/bin/puppetserver gem install aws-sdk-core retries
 
 Once the gem is installed you will need to restart the puppet-server:
 

--- a/lib/puppet/provider/ec2_instance/v2.rb
+++ b/lib/puppet/provider/ec2_instance/v2.rb
@@ -1,8 +1,10 @@
 require_relative '../../../puppet_x/puppetlabs/aws.rb'
-require "base64"
+require 'base64'
+require 'retries'
 
 Puppet::Type.type(:ec2_instance).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) do
   confine feature: :aws
+  confine feature: :retries
 
   mk_resource_methods
 
@@ -116,14 +118,15 @@ Puppet::Type.type(:ec2_instance).provide(:v2, :parent => PuppetX::Puppetlabs::Aw
       response = ec2.run_instances(config)
 
       instance_ids = response.instances.map(&:instance_id)
-      ec2.wait_until(:instance_running, instance_ids: instance_ids)
 
-      tags = resource[:tags] ? resource[:tags].map { |k,v| {key: k, value: v} } : []
-      tags << {key: 'Name', value: name}
-      ec2.create_tags(
-        resources: instance_ids,
-        tags: tags
-      )
+      with_retries(:max_tries => 5) do
+        tags = resource[:tags] ? resource[:tags].map { |k,v| {key: k, value: v} } : []
+        tags << {key: 'Name', value: name}
+        ec2.create_tags(
+          resources: instance_ids,
+          tags: tags
+        )
+      end
 
       @property_hash[:instance_id] = instance_ids.first
       @property_hash[:ensure] = :present
@@ -140,7 +143,10 @@ Puppet::Type.type(:ec2_instance).provide(:v2, :parent => PuppetX::Puppetlabs::Aw
   def stop
     create unless exists?
     Puppet.info("Stopping instance #{name} in region #{resource[:region]}")
-    ec2_client(resource[:region]).stop_instances(
+    ec2 = ec2_client(resource[:region])
+    # Can't stop an instance that hasn't started yet
+    ec2.wait_until(:instance_running, instance_ids: [@property_hash[:instance_id]])
+    ec2.stop_instances(
       instance_ids: [@property_hash[:instance_id]]
     )
     @property_hash[:ensure] = :stopped


### PR DESCRIPTION
Due to either network failures (over the internet) and/or eventual
consistency issues in AWS, it's possible to start an instance and then
fail to tag it. The API doesn't expose a tranactional endpoint for this.

Unfortunately, names of instances are just tags. So in the case tagging
fails we can't retrieve information via name later.

We have tried simply waiting for the instance to be running (which
minimises the eventual consistency issues) but have still seen the odd
failure. This patch replaces that wait (a good thing, instance creation
is now quicker from Puppet's point of view) with retries of the tagging
calls in case of failure.