### PR TITLE
(CLOUD-203) Support tagging for security groups

### DIFF
--- a/lib/puppet/type/ec2_securitygroup.rb
+++ b/lib/puppet/type/ec2_securitygroup.rb
@@ -1,3 +1,5 @@
+require_relative '../../puppet_x/puppetlabs/property/tag.rb'
+
 Puppet::Type.newtype(:ec2_securitygroup) do
   @doc = 'type representing an EC2 security group'
 
@@ -38,7 +40,7 @@ Puppet::Type.newtype(:ec2_securitygroup) do
     end
   end
 
-  newparam(:tags, :array_matching => :all) do
+  newproperty(:tags, :parent => PuppetX::Property::AwsTag) do
     desc 'the tags for the security group'
   end
 

--- a/spec/acceptance/securitygroup_spec.rb
+++ b/spec/acceptance/securitygroup_spec.rb
@@ -265,15 +265,14 @@ describe "ec2_securitygroup" do
     end
 
     it 'that can have tags changed' do
-      pending 'changing tags not yet supported for security groups'
       expect(@aws.tag_difference(@group, @config[:tags])).to be_empty
 
       tags = {:created_by => 'aws-tests', :foo => 'bar'}
       @config[:tags].update(tags)
 
       PuppetManifest.new(@template, @config).apply
-      @group = get_group(@config[:name])
-      expect(@aws.tag_difference(@group, @config[:tags])).to be_empty
+      group = get_group(@config[:name])
+      expect(@aws.tag_difference(group, @config[:tags])).to be_empty
     end
   end
 
@@ -353,7 +352,6 @@ describe "ec2_securitygroup" do
       end
 
       it 'tags are correct' do
-        pending('This test is blocked by CLOUD-203')
         @config[:tags].each do |tag, value|
           regex = /('#{tag.to_s}')(\s*)(=>)(\s*)('#{value}')/
           expect(@response.stdout).to match(regex)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,3 +15,17 @@ if ENV['PARSER'] == 'future'
     c.parser = 'future'
   end
 end
+
+RSpec::Matchers.define :order_tags_on_output do |expected|
+  match do |actual|
+    tags = {'b' => 1, 'a' => 2}
+    reverse = {'a' => 2, 'b' => 1}
+    srv = actual.new(:name => 'sample', :tags => tags )
+    expect(srv.property(:tags).insync?(tags)).to be true
+    expect(srv.property(:tags).insync?(reverse)).to be true
+    expect(srv.property(:tags).should_to_s(tags).to_s).to eq(reverse.to_s)
+  end
+  failure_message_for_should do |actual|
+    "expected that #{actual} would order tags"
+  end
+end

--- a/spec/unit/type/ec2_instance_spec.rb
+++ b/spec/unit/type/ec2_instance_spec.rb
@@ -37,19 +37,14 @@ describe type_class do
   end
 
   it 'should support :stopped as a value to :ensure' do
-    Puppet::Type.type(:ec2_instance).new(:name => 'sample', :ensure => :stopped)
+    type_class.new(:name => 'sample', :ensure => :stopped)
   end
 
   it 'should support :running as a value to :ensure' do
-    Puppet::Type.type(:ec2_instance).new(:name => 'sample', :ensure => :running)
+    type_class.new(:name => 'sample', :ensure => :running)
   end
 
   it 'should order tags on output' do
-    tags = {'b' => 1, 'a' => 2}
-    reverse = {'a' => 2, 'b' => 1}
-    srv = Puppet::Type.type(:ec2_instance).new(:name => 'sample', :tags => tags )
-    expect(srv.property(:tags).insync?(tags)).to be true
-    expect(srv.property(:tags).insync?(reverse)).to be true
-    expect(srv.property(:tags).should_to_s(tags).to_s).to eq(reverse.to_s)
+    expect(type_class).to order_tags_on_output
   end
 end

--- a/spec/unit/type/ec2_securitygroup_spec.rb
+++ b/spec/unit/type/ec2_securitygroup_spec.rb
@@ -7,7 +7,6 @@ describe type_class do
   let :params do
     [
       :name,
-      :tags,
     ]
   end
 
@@ -17,6 +16,7 @@ describe type_class do
       :description,
       :region,
       :ingress,
+      :tags,
     ]
   end
 
@@ -31,4 +31,14 @@ describe type_class do
       expect(type_class.parameters).to be_include(param)
     end
   end
+
+  it 'should order tags on output' do
+    tags = {'b' => 1, 'a' => 2}
+    reverse = {'a' => 2, 'b' => 1}
+    srv = type_class.new(:name => 'sample', :tags => tags )
+    expect(srv.property(:tags).insync?(tags)).to be true
+    expect(srv.property(:tags).insync?(reverse)).to be true
+    expect(srv.property(:tags).should_to_s(tags).to_s).to eq(reverse.to_s)
+  end
+
 end

--- a/spec/unit/type/ec2_securitygroup_spec.rb
+++ b/spec/unit/type/ec2_securitygroup_spec.rb
@@ -33,12 +33,7 @@ describe type_class do
   end
 
   it 'should order tags on output' do
-    tags = {'b' => 1, 'a' => 2}
-    reverse = {'a' => 2, 'b' => 1}
-    srv = type_class.new(:name => 'sample', :tags => tags )
-    expect(srv.property(:tags).insync?(tags)).to be true
-    expect(srv.property(:tags).insync?(reverse)).to be true
-    expect(srv.property(:tags).should_to_s(tags).to_s).to eq(reverse.to_s)
+    expect(type_class).to order_tags_on_output
   end
 
 end

--- a/spec/unit/type/ec2_vpc_spec.rb
+++ b/spec/unit/type/ec2_vpc_spec.rb
@@ -61,12 +61,7 @@ describe type_class do
   end
 
   it 'should order tags on output' do
-    tags = {'b' => 1, 'a' => 2}
-    reverse = {'a' => 2, 'b' => 1}
-    srv = type_class.new(:name => 'sample', :tags => tags )
-    expect(srv.property(:tags).insync?(tags)).to be true
-    expect(srv.property(:tags).insync?(reverse)).to be true
-    expect(srv.property(:tags).should_to_s(tags).to_s).to eq(reverse.to_s)
+    expect(type_class).to order_tags_on_output
   end
 
 end


### PR DESCRIPTION
This adds the ability to view tags using puppet resource and to
chnage tags after the security group has been created.

This should be rebased and merged after the VPC PR as it relies on the
tagging helpers containers in that work. Note this means a few specs will fail
until that happens.