### PR TITLE
Enable tests relevant to Classic accounts only

### DIFF
--- a/spec/acceptance/instance_spec.rb
+++ b/spec/acceptance/instance_spec.rb
@@ -62,10 +62,11 @@ describe "ec2_instance" do
       expect(@instance.image_id).to eq(@config[:image_id])
     end
 
-    it "not associated with a VPC" do
-      skip('VPC only accounts will fail here')
-      expect(@instance.subnet_id).to be_nil
-      expect(@instance.vpc_id).to be_nil
+    it "not associated with a VPC (EC2-Classic accounts only)" do
+      unless @aws.vpc_only?
+        expect(@instance.subnet_id).to be_nil
+        expect(@instance.vpc_id).to be_nil
+      end
     end
 
     it "and return hypervisor, virtualization_type properties" do

--- a/spec/acceptance/loadbalancer_spec.rb
+++ b/spec/acceptance/loadbalancer_spec.rb
@@ -71,22 +71,22 @@ describe "ec2_loadbalancer" do
       expect(@loadbalancer.availability_zones).to eq(@lb_config[:availability_zones])
     end
 
-    it "not part of a VPC" do
-      skip('VPC only accounts will fail here')
-      expect(@loadbalancer.vpc_id).to be_nil
-      expect(@loadbalancer.subnets).to be_empty
+    it "not part of a VPC (EC2-Classic accounts only)" do
+      unless @aws.vpc_only?
+        expect(@loadbalancer.vpc_id).to be_nil
+        expect(@loadbalancer.subnets).to be_empty
+      end
     end
 
     it "with one associated instance" do
       expect(@loadbalancer.instances.count).to eq(1)
     end
 
-    it "with no associated security groups" do
-      expect(@loadbalancer.security_groups).to be_empty
+    it "with no associated security groups (EC2-Classic accounts only)" do
+      expect(@loadbalancer.security_groups).to be_empty unless @aws.vpc_only?
     end
 
   end
-
 
   describe 'create a load balancer' do
 

--- a/spec/acceptance/securitygroup_spec.rb
+++ b/spec/acceptance/securitygroup_spec.rb
@@ -98,9 +98,8 @@ describe "ec2_securitygroup" do
       expect(@group.group_name).to eq(@config[:name])
     end
 
-    it "isn't attached to a VPC" do
-      skip('VPC only accounts will fail here')
-      expect(@group.vpc_id).to eq(nil)
+    it "isn't attached to a VPC (EC2-Classic accounts only)" do
+      expect(@group.vpc_id).to eq(nil) unless @aws.vpc_only?
     end
 
     it "with the specified tags" do

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -166,6 +166,13 @@ class AwsHelper
     response.data.load_balancer_descriptions
   end
 
+  def vpc_only?
+    response = @ec2_client.describe_account_attributes(
+      attribute_names: ['supported-platforms']
+    )
+    response.data.account_attributes.first.attribute_values.size == 1
+  end
+
   def tag_difference(item, tags)
     item_tags = {}
     item.tags.each { |s| item_tags[s.key.to_sym] = s.value if s.key != 'Name' }


### PR DESCRIPTION
We previously skipped these tests as they fail in the VPC-only
environment. This change adds a method to detect whether we are in a
VPC-only environment to the test helpers, and then only makes those test
assertions if Classic is available.