### PR TITLE
Route53 modify paramaters

### DIFF
--- a/spec/acceptance/fixtures/route53_with_ns_create.pp.tmpl
+++ b/spec/acceptance/fixtures/route53_with_ns_create.pp.tmpl
@@ -1,0 +1,24 @@
+route53_zone { '{{name}}':
+  ensure => present,
+}
+
+route53_a_record { '{{a_record_name}}':
+  ensure => present,
+  zone   => '{{name}}',
+  ttl    => {{a_ttl}},
+  values => [{{#a_values}}'{{.}}',{{/a_values}}],
+}
+
+route53_txt_record { '{{txt_record_name}}':
+  ensure => present,
+  zone   => '{{name}}',
+  ttl    => {{txt_ttl}},
+  values => [{{#txt_values}}'{{.}}',{{/txt_values}}],
+}
+
+route53_ns_record { '{{ns_record_name}}':
+  ensure  => present,
+  zone    => '{{name}}',
+  ttl     => {{ns_ttl}},
+  values  => [{{#ns_values}}'{{.}}',{{/ns_values}}],
+}

--- a/spec/acceptance/fixtures/route53_with_ns_delete.pp.tmpl
+++ b/spec/acceptance/fixtures/route53_with_ns_delete.pp.tmpl
@@ -1,0 +1,21 @@
+route53_a_record { '{{a_record_name}}':
+  ensure => absent,
+  zone   => '{{name}}',
+  before => Route53_zone['{{name}}'],
+}
+
+route53_txt_record { '{{txt_record_name}}':
+  ensure => absent,
+  zone   => '{{name}}',
+  before => Route53_zone['{{name}}'],
+}
+
+route53_ns_record { '{{ns_record_name}}':
+  ensure  => absent,
+  zone    => '{{name}}',
+  before => Route53_zone['{{name}}'],
+}
+
+route53_zone { '{{name}}':
+  ensure => absent,
+}

--- a/spec/acceptance/route53_spec.rb
+++ b/spec/acceptance/route53_spec.rb
@@ -151,4 +151,81 @@ describe "route53_zone" do
     end
   end
 
+  describe 'create new zone' do
+
+    before(:all) do
+      @template = 'route53_with_ns_create.pp.tmpl'
+      @name = "#{SecureRandom.uuid}.com."
+      @config = {
+        :name             => @name,
+        :a_record_name    => "local.#{@name}",
+        :a_ttl            => 3000,
+        :a_values         => ['127.0.0.1', '127.0.0.2', '127.0.0.3'],
+        :txt_record_name  => "local.#{@name}",
+        :txt_ttl          => 4000,
+        :txt_values       => ['This is a test', 'Test all the things!', 'Very wow much test'],
+        :ns_record_name   => "local.#{@name}",
+        :ns_ttl           => 6000,
+        :ns_values         => ['ns1.example.com','ns2.example.com','ns3.example.com'],
+      }
+      PuppetManifest.new(@template, @config).apply
+      @zone = find_zone(@name)
+    end
+
+    after(:all) do
+      template = 'route53_with_ns_delete.pp.tmpl'
+      PuppetManifest.new(template, @config).apply
+      expect(@aws.get_dns_zones(@name)).to be_empty
+    end
+
+    context 'mutate the properties' do
+
+      context 'ns record' do
+
+        it 'ttl' do
+          config = @config.clone
+          config[:ns_ttl] = 4000
+          r = PuppetManifest.new(@template, config).apply
+          expect(r[:output].any?{|x| x.include? 'Error'}).to eq(false)
+          record = find_record(config[:ns_record_name], @zone, 'NS')
+          expect(record.ttl).to eq(config[:ns_ttl])
+        end
+
+        it 'value' do
+          config = @config.clone
+          config[:ns_values] = ['ns1.example.com', 'ns5.example.com', 'ns3.example.com']
+          r = PuppetManifest.new(@template, config).apply
+          expect(r[:output].any?{|x| x.include? 'Error'}).to eq(false)
+          record = find_record(config[:ns_record_name], @zone, 'NS')
+          expect(record.resource_records.map(&:values).flatten).to eq(config[:ns_values])
+        end
+
+      end
+
+      context 'txt record' do
+
+        it 'ttl' do
+          config = @config.clone
+          config[:txt_ttl] = 7000
+          r = PuppetManifest.new(@template, config).apply
+          expect(r[:output].any?{|x| x.include? 'Error'}).to eq(false)
+          record = find_record(config[:txt_record_name], @zone, 'TXT')
+          expect(record.ttl).to eq(config[:txt_ttl])
+        end
+
+        it 'value' do
+          config = @config.clone
+          config[:txt_values] = ['This is a test', 'Test all the other things!', 'Very wow much test']
+          r = PuppetManifest.new(@template, config).apply
+          expect(r[:output].any?{|x| x.include? 'Error'}).to eq(false)
+          record = find_record(config[:txt_record_name], @zone, 'TXT')
+          expect(record.resource_records.map{|x| x.value.delete('/"')}).to eq(config[:txt_values])
+        end
+
+      end
+
+    end
+
+  end
+
 end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -155,7 +155,7 @@ class AwsHelper
 
   def get_dns_records(name, zone, type)
     records = @route53_client.list_resource_record_sets(hosted_zone_id: zone.id)
-    records.data.resource_record_sets.select { |r| r.type == type }
+    records.data.resource_record_sets.select { |r| r.type == type && r.name == name}
   end
 
 end


### PR DESCRIPTION
Replaces https://github.com/puppetlabs/puppetlabs-aws/pull/81.

This PR contains slightly modified versions of the commits in the above, specifically removing a pry statement and fixing one of the tests.