### PR TITLE
(CLOUD-232) Add VPC security group support

### DIFF
--- a/examples/vpc-example/init.pp
+++ b/examples/vpc-example/init.pp
@@ -33,3 +33,24 @@ ec2_vpc_routetable { 'sample-routes':
     },
   ],
 }
+
+ec2_securitygroup { 'sample-sg':
+  ensure      => present,
+  description => 'Sample VPC security group to allow ssh',
+  vpc_name    => 'sample-vpc',
+  region      => 'sa-east-1',
+  ingress     => [{
+    protocol => 'tcp',
+    port     => 22,
+    cidr     => '0.0.0.0/0',
+  }],
+}
+
+ec2_instance { 'sample-instance':
+  ensure          => present,
+  region          => 'sa-east-1',
+  image_id        => 'ami-e08efbd0',
+  instance_type   => 'm3.large',
+  security_groups => 'sample-sg',
+  subnet          => 'sample-subnet',
+}

--- a/lib/puppet/provider/ec2_instance/v2.rb
+++ b/lib/puppet/provider/ec2_instance/v2.rb
@@ -119,10 +119,6 @@ Puppet::Type.type(:ec2_instance).provide(:v2, :parent => PuppetX::Puppetlabs::Aw
       Puppet.warning "Ambiguous subnet name '#{resource[:subnet]}' resolves to subnets #{subnet_map} - using #{subnet.subnet_id}"
     end
 
-    if subnet.nil?
-      raise Puppet::Error,
-        "Security groups '#{groups.join(', ')}' not found in VPCs '#{vpc_groups.keys.join(', ')}'"
-    end
     subnet
   end
 
@@ -157,6 +153,10 @@ Puppet::Type.type(:ec2_instance).provide(:v2, :parent => PuppetX::Puppetlabs::Aw
       end
 
       subnet = determine_subnet(vpc_groups.keys)
+      if subnet.nil?
+        raise Puppet::Error,
+          "Security groups '#{groups.join(', ')}' not found in VPCs '#{vpc_groups.keys.join(', ')}'"
+      end
       config[:subnet_id] = subnet.subnet_id
       vpc_groups[subnet.vpc_id]
     end

--- a/lib/puppet/type/ec2_instance.rb
+++ b/lib/puppet/type/ec2_instance.rb
@@ -152,4 +152,8 @@ Puppet::Type.newtype(:ec2_instance) do
     groups.is_a?(Array) ? groups : [groups]
   end
 
+  autorequire(:ec2_vpc_subnet) do
+    self[:subnet]
+  end
+
 end

--- a/lib/puppet/type/ec2_securitygroup.rb
+++ b/lib/puppet/type/ec2_securitygroup.rb
@@ -49,6 +49,17 @@ Puppet::Type.newtype(:ec2_securitygroup) do
     end
   end
 
+  newproperty(:vpc_name) do
+    desc 'The name of the virtual private cloud (VPC) the security group belongs to, if applicable.'
+  end
+
+  newproperty(:id) do
+    desc 'The AWS ID of the security group'
+    validate do |value|
+      fail "id is read-only"
+    end
+  end
+
   def should_autorequire?(rule)
     !rule.nil? and rule.key? 'security_group' and rule['security_group'] != name
   end

--- a/lib/puppet/type/ec2_vpc.rb
+++ b/lib/puppet/type/ec2_vpc.rb
@@ -37,6 +37,13 @@ Puppet::Type.newtype(:ec2_vpc) do
     desc 'The tags to assign to the VPC.'
   end
 
+  newproperty(:id) do
+    desc 'The AWS ID of the VPC'
+    validate do |value|
+      fail "id is read-only"
+    end
+  end
+
   autorequire(:ec2_vpc_dhcp_options) do
     self[:dhcp_options]
   end


### PR DESCRIPTION
The security groups in VPCs must be managed by their IDs, so I added `id` to the ec2_securitygroup type and updated the provider to only deal with the IDs.

The `vpc_name` property for ec2_securitygroup was added to create a SG in a VPC. This may only be done on SG creation, so I created a setter method that raises an error if it is not insync after create.

The ec2_vpc type now returns its ID. The provider was already setting it in `instances`.

This PR also contains a required bugfix.