### PR TITLE
(CLOUD-233) Add the ability to associate elastic IP addresses with instances

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -21,3 +21,5 @@ infrastructure.
   Puppet DSL to manage a AWS VPC environment
 * [Using IAM permissions](iam-profile) - an example IAM profile for
   controlling the API permissions required by the module
+* [Elastic IP Addresses](elastic-ip-addresses/) - attach existing elastic
+  IP addresses to instances managed by Puppet

--- a/examples/elastic-ip-addresses/README.md
+++ b/examples/elastic-ip-addresses/README.md
@@ -1,0 +1,51 @@
+# Managing Elastic IP Address Associations
+
+[Elastic IP
+addresses](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/elastic-ip-addresses-eip.html)
+are static IPs assigned to your AWS account that can be
+associated with an EC2 instance. The AWS Puppet module allows for
+attaching these IP addresses to instances managed by Puppet.
+
+## What
+
+For this example we'll create two instances, and attach an Elastic IP
+to one of them. We'll then switch that IP address to the second
+instance.
+
+## How
+
+First you'll need to allocate at Elastic IP to your account. The Amazon
+documentation [explains how to do
+this](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/elastic-ip-addresses-eip.html#using-instance-addressing-eips-allocating).
+The easiest ways of doing that are from the AWS console, or from the
+command line tools like so:
+
+    aws ec2 allocate-address --region sa-east-1
+
+Once you have the IP address you need to modify the manifest in `init.pp`.
+This is because the IP address present in the file is already allocated to
+a different account, and IP addresses are unique.
+
+With the module installed as described in the README, from this directory run:
+
+    puppet apply init.pp
+
+This creates the instances and associates the IP address to the one
+called `web-1`. We can see that by running:
+
+    puppet resource ec2_elastic_ip
+
+Which should return something like:
+
+```puppet
+ec2_elastic_ip { '177.71.189.57':
+  ensure   => 'attached',
+  instance => 'web-1',
+  region   => 'sa-east-1',
+}
+```
+
+We can now use `puppet resource` to switch the IP to the `web-2` instance:
+
+    puppet resource ec2_elastic_ip 177.71.189.57 region=sa-east-1 region=sa-east-1 instance=web-2
+

--- a/examples/elastic-ip-addresses/init.pp
+++ b/examples/elastic-ip-addresses/init.pp
@@ -1,0 +1,12 @@
+ec2_elastic_ip { '177.71.189.57':
+  ensure   => 'attached',
+  region   => 'sa-east-1',
+  instance => 'web-1',
+}
+
+ec2_instance { ['web-1', 'web-2']:
+  ensure        => present,
+  region        => 'sa-east-1',
+  image_id      => 'ami-67a60d7a',
+  instance_type => 't1.micro',
+}

--- a/fixtures/vcr_cassettes/create-ip.yml
+++ b/fixtures/vcr_cassettes/create-ip.yml
@@ -1,0 +1,185 @@
+--- 
+  http_interactions: 
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "Action=DescribeInstances&Filter.1.Name=tag%3AName&Filter.1.Value.1=web-1&Version=2014-09-01"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.5 ruby/2.0.0 universal.x86_64-darwin14"
+          X-Amz-Date: 
+            - "20150225T121426Z"
+          Host: 
+            - ec2.sa-east-1.amazonaws.com
+          X-Amz-Content-Sha256: 
+            - "42b7590d6fcede8c09f9f599a1f522a8e8169bd2235e1a36288abc85ecbddd2c"
+          Authorization: 
+            - "AWS4-HMAC-SHA256 Credential=redacted/20150225/sa-east-1/ec2/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=155d1a70595ab9e1dba87156054282b44462187d0bdae691ee65b6d3427f8f94"
+          Content-Length: 
+            - "91"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Wed, 25 Feb 2015 12:14:28 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2014-09-01/">
+                <requestId>687f5a9e-3981-43d7-8e91-9abe3db4e643</requestId>
+                <reservationSet>
+                    <item>
+                        <reservationId>r-16e7ae03</reservationId>
+                        <ownerId>482693910459</ownerId>
+                        <groupSet>
+                            <item>
+                                <groupId>sg-9717aa88</groupId>
+                                <groupName>web-sg</groupName>
+                            </item>
+                        </groupSet>
+                        <instancesSet>
+                            <item>
+                                <instanceId>i-bea189ab</instanceId>
+                                <imageId>ami-67a60d7a</imageId>
+                                <instanceState>
+                                    <code>16</code>
+                                    <name>running</name>
+                                </instanceState>
+                                <privateDnsName>ip-10-252-13-184.sa-east-1.compute.internal</privateDnsName>
+                                <dnsName>ec2-54-232-33-160.sa-east-1.compute.amazonaws.com</dnsName>
+                                <reason/>
+                                <amiLaunchIndex>0</amiLaunchIndex>
+                                <productCodes/>
+                                <instanceType>t1.micro</instanceType>
+                                <launchTime>2015-02-25T08:15:47.000Z</launchTime>
+                                <placement>
+                                    <availabilityZone>sa-east-1a</availabilityZone>
+                                    <groupName/>
+                                    <tenancy>default</tenancy>
+                                </placement>
+                                <kernelId>aki-5553f448</kernelId>
+                                <monitoring>
+                                    <state>disabled</state>
+                                </monitoring>
+                                <privateIpAddress>10.252.13.184</privateIpAddress>
+                                <ipAddress>54.232.33.160</ipAddress>
+                                <groupSet>
+                                    <item>
+                                        <groupId>sg-9717aa88</groupId>
+                                        <groupName>web-sg</groupName>
+                                    </item>
+                                </groupSet>
+                                <architecture>x86_64</architecture>
+                                <rootDeviceType>ebs</rootDeviceType>
+                                <rootDeviceName>/dev/sda1</rootDeviceName>
+                                <blockDeviceMapping>
+                                    <item>
+                                        <deviceName>/dev/sda1</deviceName>
+                                        <ebs>
+                                            <volumeId>vol-6f2ae073</volumeId>
+                                            <status>attached</status>
+                                            <attachTime>2015-02-25T08:15:51.000Z</attachTime>
+                                            <deleteOnTermination>true</deleteOnTermination>
+                                        </ebs>
+                                    </item>
+                                </blockDeviceMapping>
+                                <virtualizationType>paravirtual</virtualizationType>
+                                <clientToken/>
+                                <tagSet>
+                                    <item>
+                                        <key>Name</key>
+                                        <value>web-1</value>
+                                    </item>
+                                    <item>
+                                        <key>project</key>
+                                        <value>cloud</value>
+                                    </item>
+                                    <item>
+                                        <key>created_by</key>
+                                        <value>garethr</value>
+                                    </item>
+                                    <item>
+                                        <key>department</key>
+                                        <value>engineering</value>
+                                    </item>
+                                </tagSet>
+                                <hypervisor>xen</hypervisor>
+                                <networkInterfaceSet/>
+                                <ebsOptimized>false</ebsOptimized>
+                            </item>
+                        </instancesSet>
+                    </item>
+                </reservationSet>
+            </DescribeInstancesResponse>
+        http_version: 
+      recorded_at: "Wed, 25 Feb 2015 12:14:28 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "Action=AssociateAddress&InstanceId=i-bea189ab&PublicIp=177.71.189.57&Version=2014-09-01"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.5 ruby/2.0.0 universal.x86_64-darwin14"
+          X-Amz-Date: 
+            - "20150225T121428Z"
+          Host: 
+            - ec2.sa-east-1.amazonaws.com
+          X-Amz-Content-Sha256: 
+            - "09e0ef7c48c9af8625c29f7e8d2ad0b882d2f1b7e66f7e2507102bd24d202ee0"
+          Authorization: 
+            - "AWS4-HMAC-SHA256 Credential=redacted/20150225/sa-east-1/ec2/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=0e798c5dd4d1d7364eaf6acb453e9d341708511640a45fed419b09590a9c91d0"
+          Content-Length: 
+            - "87"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Wed, 25 Feb 2015 12:14:29 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <AssociateAddressResponse xmlns="http://ec2.amazonaws.com/doc/2014-09-01/">
+                <requestId>a6d2bb10-6da4-448d-8d65-6580a60c8674</requestId>
+                <return>true</return>
+            </AssociateAddressResponse>
+        http_version: 
+      recorded_at: "Wed, 25 Feb 2015 12:14:30 GMT"
+  recorded_with: "VCR 2.9.3"

--- a/fixtures/vcr_cassettes/destroy-ip.yml
+++ b/fixtures/vcr_cassettes/destroy-ip.yml
@@ -1,0 +1,53 @@
+--- 
+  http_interactions: 
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "Action=DisassociateAddress&PublicIp=177.71.189.57&Version=2014-09-01"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.5 ruby/2.0.0 universal.x86_64-darwin14"
+          X-Amz-Date: 
+            - "20150225T115645Z"
+          Host: 
+            - ec2.sa-east-1.amazonaws.com
+          X-Amz-Content-Sha256: 
+            - "8afd8d4319909610206de338bebbff027221ab128e355718b35cb61f0e715ca6"
+          Authorization: 
+            - "AWS4-HMAC-SHA256 Credential=redacted/20150225/sa-east-1/ec2/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=8d08658c7033f33925f0ad4ae624eec85e73dbc364658573b2142f72160a2006"
+          Content-Length: 
+            - "68"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Wed, 25 Feb 2015 11:56:45 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DisassociateAddressResponse xmlns="http://ec2.amazonaws.com/doc/2014-09-01/">
+                <requestId>add50e46-cb6f-4df1-96fc-0d22fd894b66</requestId>
+                <return>true</return>
+            </DisassociateAddressResponse>
+        http_version: 
+      recorded_at: "Wed, 25 Feb 2015 11:56:46 GMT"
+  recorded_with: "VCR 2.9.3"

--- a/fixtures/vcr_cassettes/ip-named.yml
+++ b/fixtures/vcr_cassettes/ip-named.yml
@@ -1,0 +1,191 @@
+--- 
+  http_interactions: 
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "Action=DescribeAddresses&Version=2014-09-01"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.5 ruby/2.0.0 universal.x86_64-darwin14"
+          X-Amz-Date: 
+            - "20150225T114333Z"
+          Host: 
+            - ec2.sa-east-1.amazonaws.com
+          X-Amz-Content-Sha256: 
+            - e1d23257a708c8025b4450924ca6fe8230d4ea8969e4e512bdea548c58fb370e
+          Authorization: 
+            - "AWS4-HMAC-SHA256 Credential=redacted/20150225/sa-east-1/ec2/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=45ab47ffe9b819f9a406cdb9dd1f8c9bc96b0219f4e362cb0aa63c38b4756260"
+          Content-Length: 
+            - "43"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Wed, 25 Feb 2015 11:43:32 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeAddressesResponse xmlns="http://ec2.amazonaws.com/doc/2014-09-01/">
+                <requestId>1fdfb3c7-ee56-4a77-8656-d9c90f64a206</requestId>
+                <addressesSet>
+                    <item>
+                        <publicIp>177.71.189.57</publicIp>
+                        <domain>standard</domain>
+                        <instanceId>i-8ba1899e</instanceId>
+                    </item>
+                </addressesSet>
+            </DescribeAddressesResponse>
+        http_version: 
+      recorded_at: "Wed, 25 Feb 2015 11:43:34 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "Action=DescribeInstances&InstanceId.1=i-8ba1899e&Version=2014-09-01"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.5 ruby/2.0.0 universal.x86_64-darwin14"
+          X-Amz-Date: 
+            - "20150225T114334Z"
+          Host: 
+            - ec2.sa-east-1.amazonaws.com
+          X-Amz-Content-Sha256: 
+            - "6f57408378d3d73b08eff48724d53c1cecebdfd4c5b7ed8fe28cf424da5bbc6c"
+          Authorization: 
+            - "AWS4-HMAC-SHA256 Credential=redacted/20150225/sa-east-1/ec2/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=f236bad3ae4fd1789dd2acf2583a29af42af1c3cfb4ddd0b544693638fe69076"
+          Content-Length: 
+            - "67"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Wed, 25 Feb 2015 11:43:34 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2014-09-01/">
+                <requestId>51e92a40-c836-416d-a851-2d7ff531bae6</requestId>
+                <reservationSet>
+                    <item>
+                        <reservationId>r-e0e4adf5</reservationId>
+                        <ownerId>482693910459</ownerId>
+                        <groupSet>
+                            <item>
+                                <groupId>sg-9717aa88</groupId>
+                                <groupName>web-sg</groupName>
+                            </item>
+                        </groupSet>
+                        <instancesSet>
+                            <item>
+                                <instanceId>i-8ba1899e</instanceId>
+                                <imageId>ami-67a60d7a</imageId>
+                                <instanceState>
+                                    <code>16</code>
+                                    <name>running</name>
+                                </instanceState>
+                                <privateDnsName>ip-10-252-18-146.sa-east-1.compute.internal</privateDnsName>
+                                <dnsName>ec2-177-71-189-57.sa-east-1.compute.amazonaws.com</dnsName>
+                                <reason/>
+                                <amiLaunchIndex>0</amiLaunchIndex>
+                                <productCodes/>
+                                <instanceType>t1.micro</instanceType>
+                                <launchTime>2015-02-25T08:15:45.000Z</launchTime>
+                                <placement>
+                                    <availabilityZone>sa-east-1a</availabilityZone>
+                                    <groupName/>
+                                    <tenancy>default</tenancy>
+                                </placement>
+                                <kernelId>aki-5553f448</kernelId>
+                                <monitoring>
+                                    <state>disabled</state>
+                                </monitoring>
+                                <privateIpAddress>10.252.18.146</privateIpAddress>
+                                <ipAddress>177.71.189.57</ipAddress>
+                                <groupSet>
+                                    <item>
+                                        <groupId>sg-9717aa88</groupId>
+                                        <groupName>web-sg</groupName>
+                                    </item>
+                                </groupSet>
+                                <architecture>x86_64</architecture>
+                                <rootDeviceType>ebs</rootDeviceType>
+                                <rootDeviceName>/dev/sda1</rootDeviceName>
+                                <blockDeviceMapping>
+                                    <item>
+                                        <deviceName>/dev/sda1</deviceName>
+                                        <ebs>
+                                            <volumeId>vol-862ae09a</volumeId>
+                                            <status>attached</status>
+                                            <attachTime>2015-02-25T08:15:47.000Z</attachTime>
+                                            <deleteOnTermination>true</deleteOnTermination>
+                                        </ebs>
+                                    </item>
+                                </blockDeviceMapping>
+                                <virtualizationType>paravirtual</virtualizationType>
+                                <clientToken/>
+                                <tagSet>
+                                    <item>
+                                        <key>created_by</key>
+                                        <value>garethr</value>
+                                    </item>
+                                    <item>
+                                        <key>Name</key>
+                                        <value>web-2</value>
+                                    </item>
+                                    <item>
+                                        <key>project</key>
+                                        <value>cloud</value>
+                                    </item>
+                                    <item>
+                                        <key>department</key>
+                                        <value>engineering</value>
+                                    </item>
+                                </tagSet>
+                                <hypervisor>xen</hypervisor>
+                                <networkInterfaceSet/>
+                                <ebsOptimized>false</ebsOptimized>
+                            </item>
+                        </instancesSet>
+                    </item>
+                </reservationSet>
+            </DescribeInstancesResponse>
+        http_version: 
+      recorded_at: "Wed, 25 Feb 2015 11:43:35 GMT"
+  recorded_with: "VCR 2.9.3"

--- a/fixtures/vcr_cassettes/ip-setup.yml
+++ b/fixtures/vcr_cassettes/ip-setup.yml
@@ -1,0 +1,379 @@
+--- 
+  http_interactions: 
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "Action=DescribeAddresses&Version=2014-09-01"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.5 ruby/2.0.0 universal.x86_64-darwin14"
+          X-Amz-Date: 
+            - "20150225T114327Z"
+          Host: 
+            - ec2.sa-east-1.amazonaws.com
+          X-Amz-Content-Sha256: 
+            - e1d23257a708c8025b4450924ca6fe8230d4ea8969e4e512bdea548c58fb370e
+          Authorization: 
+            - "AWS4-HMAC-SHA256 Credential=redacted/20150225/sa-east-1/ec2/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=6239e355914af81bddd551e86174d8a2bd22ee40efa28f22e48c1e4baf201f84"
+          Content-Length: 
+            - "43"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Wed, 25 Feb 2015 11:43:28 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeAddressesResponse xmlns="http://ec2.amazonaws.com/doc/2014-09-01/">
+                <requestId>478a2375-1686-421b-b902-7888b55a484a</requestId>
+                <addressesSet>
+                    <item>
+                        <publicIp>177.71.189.57</publicIp>
+                        <domain>standard</domain>
+                        <instanceId>i-8ba1899e</instanceId>
+                    </item>
+                </addressesSet>
+            </DescribeAddressesResponse>
+        http_version: 
+      recorded_at: "Wed, 25 Feb 2015 11:43:29 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "Action=DescribeInstances&InstanceId.1=i-8ba1899e&Version=2014-09-01"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.5 ruby/2.0.0 universal.x86_64-darwin14"
+          X-Amz-Date: 
+            - "20150225T114329Z"
+          Host: 
+            - ec2.sa-east-1.amazonaws.com
+          X-Amz-Content-Sha256: 
+            - "6f57408378d3d73b08eff48724d53c1cecebdfd4c5b7ed8fe28cf424da5bbc6c"
+          Authorization: 
+            - "AWS4-HMAC-SHA256 Credential=redacted/20150225/sa-east-1/ec2/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=8bf49f101cdf09becfee6c28815b74149c8296230a5d9f71afc5b8760de83f3f"
+          Content-Length: 
+            - "67"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Wed, 25 Feb 2015 11:43:28 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2014-09-01/">
+                <requestId>18c879db-f805-4807-a963-125745cc409e</requestId>
+                <reservationSet>
+                    <item>
+                        <reservationId>r-e0e4adf5</reservationId>
+                        <ownerId>482693910459</ownerId>
+                        <groupSet>
+                            <item>
+                                <groupId>sg-9717aa88</groupId>
+                                <groupName>web-sg</groupName>
+                            </item>
+                        </groupSet>
+                        <instancesSet>
+                            <item>
+                                <instanceId>i-8ba1899e</instanceId>
+                                <imageId>ami-67a60d7a</imageId>
+                                <instanceState>
+                                    <code>16</code>
+                                    <name>running</name>
+                                </instanceState>
+                                <privateDnsName>ip-10-252-18-146.sa-east-1.compute.internal</privateDnsName>
+                                <dnsName>ec2-177-71-189-57.sa-east-1.compute.amazonaws.com</dnsName>
+                                <reason/>
+                                <amiLaunchIndex>0</amiLaunchIndex>
+                                <productCodes/>
+                                <instanceType>t1.micro</instanceType>
+                                <launchTime>2015-02-25T08:15:45.000Z</launchTime>
+                                <placement>
+                                    <availabilityZone>sa-east-1a</availabilityZone>
+                                    <groupName/>
+                                    <tenancy>default</tenancy>
+                                </placement>
+                                <kernelId>aki-5553f448</kernelId>
+                                <monitoring>
+                                    <state>disabled</state>
+                                </monitoring>
+                                <privateIpAddress>10.252.18.146</privateIpAddress>
+                                <ipAddress>177.71.189.57</ipAddress>
+                                <groupSet>
+                                    <item>
+                                        <groupId>sg-9717aa88</groupId>
+                                        <groupName>web-sg</groupName>
+                                    </item>
+                                </groupSet>
+                                <architecture>x86_64</architecture>
+                                <rootDeviceType>ebs</rootDeviceType>
+                                <rootDeviceName>/dev/sda1</rootDeviceName>
+                                <blockDeviceMapping>
+                                    <item>
+                                        <deviceName>/dev/sda1</deviceName>
+                                        <ebs>
+                                            <volumeId>vol-862ae09a</volumeId>
+                                            <status>attached</status>
+                                            <attachTime>2015-02-25T08:15:47.000Z</attachTime>
+                                            <deleteOnTermination>true</deleteOnTermination>
+                                        </ebs>
+                                    </item>
+                                </blockDeviceMapping>
+                                <virtualizationType>paravirtual</virtualizationType>
+                                <clientToken/>
+                                <tagSet>
+                                    <item>
+                                        <key>created_by</key>
+                                        <value>garethr</value>
+                                    </item>
+                                    <item>
+                                        <key>Name</key>
+                                        <value>web-2</value>
+                                    </item>
+                                    <item>
+                                        <key>project</key>
+                                        <value>cloud</value>
+                                    </item>
+                                    <item>
+                                        <key>department</key>
+                                        <value>engineering</value>
+                                    </item>
+                                </tagSet>
+                                <hypervisor>xen</hypervisor>
+                                <networkInterfaceSet/>
+                                <ebsOptimized>false</ebsOptimized>
+                            </item>
+                        </instancesSet>
+                    </item>
+                </reservationSet>
+            </DescribeInstancesResponse>
+        http_version: 
+      recorded_at: "Wed, 25 Feb 2015 11:43:30 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "Action=DescribeAddresses&Version=2014-09-01"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.5 ruby/2.0.0 universal.x86_64-darwin14"
+          X-Amz-Date: 
+            - "20150225T114330Z"
+          Host: 
+            - ec2.sa-east-1.amazonaws.com
+          X-Amz-Content-Sha256: 
+            - e1d23257a708c8025b4450924ca6fe8230d4ea8969e4e512bdea548c58fb370e
+          Authorization: 
+            - "AWS4-HMAC-SHA256 Credential=redacted/20150225/sa-east-1/ec2/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=789e8472365dae5e645caf5421541dbe3100b47f6b77c363c0b2ff6f15490bea"
+          Content-Length: 
+            - "43"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Wed, 25 Feb 2015 11:43:30 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeAddressesResponse xmlns="http://ec2.amazonaws.com/doc/2014-09-01/">
+                <requestId>5be84f34-677a-4597-96da-a0b9b19e72ae</requestId>
+                <addressesSet>
+                    <item>
+                        <publicIp>177.71.189.57</publicIp>
+                        <domain>standard</domain>
+                        <instanceId>i-8ba1899e</instanceId>
+                    </item>
+                </addressesSet>
+            </DescribeAddressesResponse>
+        http_version: 
+      recorded_at: "Wed, 25 Feb 2015 11:43:32 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "Action=DescribeInstances&InstanceId.1=i-8ba1899e&Version=2014-09-01"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.5 ruby/2.0.0 universal.x86_64-darwin14"
+          X-Amz-Date: 
+            - "20150225T114332Z"
+          Host: 
+            - ec2.sa-east-1.amazonaws.com
+          X-Amz-Content-Sha256: 
+            - "6f57408378d3d73b08eff48724d53c1cecebdfd4c5b7ed8fe28cf424da5bbc6c"
+          Authorization: 
+            - "AWS4-HMAC-SHA256 Credential=redacted/20150225/sa-east-1/ec2/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=826d859590e08119e1e5c67c2da8725b53b0145f510e79bcc1fd337ff95e1497"
+          Content-Length: 
+            - "67"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Wed, 25 Feb 2015 11:43:31 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2014-09-01/">
+                <requestId>d9f25954-88f7-4aae-92e7-6c02140737c2</requestId>
+                <reservationSet>
+                    <item>
+                        <reservationId>r-e0e4adf5</reservationId>
+                        <ownerId>482693910459</ownerId>
+                        <groupSet>
+                            <item>
+                                <groupId>sg-9717aa88</groupId>
+                                <groupName>web-sg</groupName>
+                            </item>
+                        </groupSet>
+                        <instancesSet>
+                            <item>
+                                <instanceId>i-8ba1899e</instanceId>
+                                <imageId>ami-67a60d7a</imageId>
+                                <instanceState>
+                                    <code>16</code>
+                                    <name>running</name>
+                                </instanceState>
+                                <privateDnsName>ip-10-252-18-146.sa-east-1.compute.internal</privateDnsName>
+                                <dnsName>ec2-177-71-189-57.sa-east-1.compute.amazonaws.com</dnsName>
+                                <reason/>
+                                <amiLaunchIndex>0</amiLaunchIndex>
+                                <productCodes/>
+                                <instanceType>t1.micro</instanceType>
+                                <launchTime>2015-02-25T08:15:45.000Z</launchTime>
+                                <placement>
+                                    <availabilityZone>sa-east-1a</availabilityZone>
+                                    <groupName/>
+                                    <tenancy>default</tenancy>
+                                </placement>
+                                <kernelId>aki-5553f448</kernelId>
+                                <monitoring>
+                                    <state>disabled</state>
+                                </monitoring>
+                                <privateIpAddress>10.252.18.146</privateIpAddress>
+                                <ipAddress>177.71.189.57</ipAddress>
+                                <groupSet>
+                                    <item>
+                                        <groupId>sg-9717aa88</groupId>
+                                        <groupName>web-sg</groupName>
+                                    </item>
+                                </groupSet>
+                                <architecture>x86_64</architecture>
+                                <rootDeviceType>ebs</rootDeviceType>
+                                <rootDeviceName>/dev/sda1</rootDeviceName>
+                                <blockDeviceMapping>
+                                    <item>
+                                        <deviceName>/dev/sda1</deviceName>
+                                        <ebs>
+                                            <volumeId>vol-862ae09a</volumeId>
+                                            <status>attached</status>
+                                            <attachTime>2015-02-25T08:15:47.000Z</attachTime>
+                                            <deleteOnTermination>true</deleteOnTermination>
+                                        </ebs>
+                                    </item>
+                                </blockDeviceMapping>
+                                <virtualizationType>paravirtual</virtualizationType>
+                                <clientToken/>
+                                <tagSet>
+                                    <item>
+                                        <key>created_by</key>
+                                        <value>garethr</value>
+                                    </item>
+                                    <item>
+                                        <key>Name</key>
+                                        <value>web-2</value>
+                                    </item>
+                                    <item>
+                                        <key>project</key>
+                                        <value>cloud</value>
+                                    </item>
+                                    <item>
+                                        <key>department</key>
+                                        <value>engineering</value>
+                                    </item>
+                                </tagSet>
+                                <hypervisor>xen</hypervisor>
+                                <networkInterfaceSet/>
+                                <ebsOptimized>false</ebsOptimized>
+                            </item>
+                        </instancesSet>
+                    </item>
+                </reservationSet>
+            </DescribeInstancesResponse>
+        http_version: 
+      recorded_at: "Wed, 25 Feb 2015 11:43:33 GMT"
+  recorded_with: "VCR 2.9.3"

--- a/lib/puppet/provider/ec2_elastic_ip/v2.rb
+++ b/lib/puppet/provider/ec2_elastic_ip/v2.rb
@@ -1,0 +1,97 @@
+require_relative '../../../puppet_x/puppetlabs/aws.rb'
+
+Puppet::Type.type(:ec2_elastic_ip).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) do
+  confine feature: :aws
+
+  mk_resource_methods
+
+  def self.instances
+    regions.collect do |region|
+      ec2 = ec2_client(region)
+      ec2.describe_addresses.addresses.collect do |address|
+        instance_name = nil
+        unless address.instance_id.nil? || address.instance_id.empty?
+          instances = ec2.describe_instances(instance_ids: [address.instance_id]).collect do |response|
+            response.data.reservations.collect do |reservation|
+              reservation.instances.collect do |instance|
+                instance
+              end
+            end.flatten
+          end.flatten
+          name_tag = instances.first.tags.detect { |tag| tag.key == 'Name' }
+          instance_name = name_tag ? name_tag.value : nil
+        end
+        new({
+          name: address.public_ip,
+          instance_id: address.instance_id,
+          instance: instance_name,
+          allocation_id: address.allocation_id,
+          association_id: address.association_id,
+          domain: address.domain,
+          ensure: instance_name ? :attached : :detached,
+          region: region,
+        })
+      end
+    end.flatten
+  end
+
+  def self.prefetch(resources)
+    instances.each do |prov|
+      if resource = resources[prov.name]
+        resource.provider = prov if resource[:region] == prov.region
+      end
+    end
+  end
+
+  def exists?
+    Puppet.info("Checking if Elastic IP #{name} is associated")
+    @property_hash[:ensure] == :attached
+  end
+
+  def create
+    Puppet.info("Creating association for #{name}")
+    ec2 = ec2_client(resource[:region])
+    response = ec2.describe_instances(filters: [
+      {name: 'tag:Name', values: [resource[:instance]]}
+    ])
+    instance_ids = response.reservations.map(&:instances).flatten.map(&:instance_id)
+
+    fail "No instance found named #{resource[:instance]}" if instance_ids.empty?
+    if instance_ids.count > 1
+      Puppet.warning "Multiple instances found named #{resource[:instance]}, using #{instance_ids.first}"
+    end
+
+    config = if @property_hash[:domain] == 'vpc'
+      {
+        instance_id: instance_ids.first,
+        allocation_id: @property_hash[:allocation_id],
+        allow_reassociation: true,
+      }
+    else
+      {
+        instance_id: instance_ids.first,
+        public_ip: name,
+      }
+    end
+
+    ec2_client(resource[:region]).associate_address(config)
+    @property_hash[:instance] = resource[:instance]
+    @property_hash[:ensure] = :attached
+  end
+
+  def flush
+    create unless @property_hash[:ensure] == :detached
+  end
+
+  def destroy
+    Puppet.info("Deleting association with #{name}")
+    config = if @property_hash[:domain] == 'vpc'
+      {association_id: @property_hash[:association_id]}
+    else
+      {public_ip: name}
+    end
+    ec2_client(resource[:region]).disassociate_address(config)
+    @property_hash[:instance] = nil
+    @property_hash[:ensure] = :detached
+  end
+end

--- a/lib/puppet/type/ec2_elastic_ip.rb
+++ b/lib/puppet/type/ec2_elastic_ip.rb
@@ -1,0 +1,40 @@
+Puppet::Type.newtype(:ec2_elastic_ip) do
+  @doc = "Type representing an Elastic IP and it's association."
+
+  newproperty(:ensure) do
+    newvalue(:attached) do
+      provider.create
+    end
+
+    newvalue(:detached) do
+      provider.destroy
+    end
+    defaultto { :detached }
+  end
+
+  newparam(:name, namevar: true) do
+    desc 'The IP address of the Elastic IP.'
+    validate do |value|
+      fail 'The name of an Elastic IP address must be a valid IP.' unless value =~ Resolv::IPv4::Regex
+    end
+  end
+
+  newproperty(:region) do
+    desc 'The name of the region in which the Elastic IP is found.'
+    validate do |value|
+      fail 'You must provide a region for Elastic IPs.' if value.nil? || value.empty?
+    end
+  end
+
+  newproperty(:instance) do
+    desc 'The name of the instance associated with the Elastic IP.'
+    validate do |value|
+      fail 'You must provide an instance for the Elastic IP association' if value.nil? || value.empty?
+    end
+  end
+
+  autorequire(:ec2_instance) do
+    self[:instance]
+  end
+
+end

--- a/spec/acceptance/fixtures/eip.pp.tmpl
+++ b/spec/acceptance/fixtures/eip.pp.tmpl
@@ -1,0 +1,5 @@
+ec2_elastic_ip { '{{ip_address}}':
+  ensure   => {{ensure_eip}},
+  region   => '{{region}}',
+  instance => '{{name}}',
+}

--- a/spec/unit/provider/ec2_elastic_ip/v2_spec.rb
+++ b/spec/unit/provider/ec2_elastic_ip/v2_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+
+provider_class = Puppet::Type.type(:ec2_elastic_ip).provider(:v2)
+
+#ENV['AWS_ACCESS_KEY_ID'] = 'redacted'
+#ENV['AWS_SECRET_ACCESS_KEY'] = 'redacted'
+ENV['AWS_REGION'] = 'sa-east-1'
+
+describe provider_class do
+
+  context 'with the minimum params' do
+    let(:resource) { Puppet::Type.type(:ec2_elastic_ip).new(
+      name: '177.71.189.57',
+      region: 'sa-east-1',
+      instance: 'web-1',
+    )}
+
+    let(:provider) { resource.provider }
+
+    let(:instance) { provider.class.instances.first }
+
+    it 'should be an instance of the ProviderV2' do
+      expect(provider).to be_an_instance_of Puppet::Type::Ec2_elastic_ip::ProviderV2
+    end
+
+    describe 'self.prefetch' do
+      it 'exists' do
+        VCR.use_cassette('ip-setup') do
+          provider.class.instances
+          provider.class.prefetch({})
+        end
+      end
+    end
+
+    describe 'exists?' do
+      it 'should correctly report non-existent Elastic IP addresses' do
+        VCR.use_cassette('no-ip-named') do
+          expect(provider.exists?).to be_falsy
+        end
+      end
+
+      it 'should correctly find existing Elastic IP addresses' do
+        VCR.use_cassette('ip-named') do
+          expect(instance.exists?).to be_truthy
+        end
+      end
+    end
+
+    describe 'create' do
+      it 'should send a request to the EC2 API to create the association' do
+        VCR.use_cassette('create-ip') do
+          expect(provider.create).to be_truthy
+        end
+      end
+    end
+
+    describe 'destroy' do
+      it 'should send a request to the EC2 API to destroy the association' do
+        VCR.use_cassette('destroy-ip') do
+          expect(provider.destroy).to be_truthy
+        end
+      end
+    end
+
+  end
+
+end

--- a/spec/unit/type/ec2_elastic_ip_spec.rb
+++ b/spec/unit/type/ec2_elastic_ip_spec.rb
@@ -1,0 +1,83 @@
+require 'spec_helper'
+
+type_class = Puppet::Type.type(:ec2_elastic_ip)
+
+describe type_class do
+
+  let :params do
+    [
+      :name,
+    ]
+  end
+
+  let :properties do
+    [
+      :ensure,
+      :instance,
+      :region,
+    ]
+  end
+
+  it 'should have expected properties' do
+    properties.each do |property|
+      expect(type_class.properties.map(&:name)).to be_include(property)
+    end
+  end
+
+  it 'should have expected parameters' do
+    params.each do |param|
+      expect(type_class.parameters).to be_include(param)
+    end
+  end
+
+  it 'should require a name' do
+    expect {
+      type_class.new({})
+    }.to raise_error(Puppet::Error, 'Title or name must be provided')
+  end
+
+  it 'should require a valid ip address for the name' do
+    expect {
+      type_class.new({ name: 'invalid' })
+    }.to raise_error(Puppet::Error, /The name of an Elastic IP address must be a valid IP/)
+  end
+
+  it 'should require a region to be specified' do
+    expect {
+      type_class.new({ name: '10.0.0.1', region: '' })
+    }.to raise_error(Puppet::Error, /You must provide a region for Elastic IPs/)
+  end
+
+  it 'should require an instance to be specified' do
+    expect {
+      type_class.new({ name: '10.0.0.1', region: 'us-east-1', instance: '' })
+    }.to raise_error(Puppet::Error, /You must provide an instance for the Elastic IP association/)
+  end
+
+  it 'should not work with :present' do
+    expect {
+      type_class.new({ name: '10.0.0.1', :ensure => :present })
+    }.to raise_error(Puppet::Error, /Invalid value :present. Valid values are attached, detached./)
+  end
+
+  it 'should not work with :absent' do
+    expect {
+      type_class.new({ name: '10.0.0.1', :ensure => :absent })
+    }.to raise_error(Puppet::Error, /Invalid value :absent. Valid values are attached, detached./)
+  end
+
+  it 'should support :attached as a value to :ensure' do
+    type_class.new(:name => '10.0.0.1', :ensure => :attached)
+  end
+
+  it 'should support :detached as a value to :ensure' do
+    type_class.new(:name => '10.0.0.1', :ensure => :detached)
+  end
+
+  context 'with valid properties' do
+    it 'should create a valid elastic ip ' do
+      type_class.new({ name: '10.0.0.1', region: 'us-east-1', instance: 'web-1' })
+    end
+  end
+
+end


### PR DESCRIPTION
This doesn't provide the ability to allocate IP addresses, just
associate them.

Allocation is difficult within Puppet, as you can't know the IP address
ahead of time, and the Elastic IP resource doesn't support any form of
metadata or tags.