### PR TITLE
(CLOUD-211) Allow load balancers to be created in VPC environments

### DIFF
--- a/lib/puppet/provider/elb_loadbalancer/v2.rb
+++ b/lib/puppet/provider/elb_loadbalancer/v2.rb
@@ -18,7 +18,7 @@ Puppet::Type.type(:elb_loadbalancer).provide(:v2, :parent => PuppetX::Puppetlabs
     end.flatten
   end
 
-  read_only(:region, :scheme, :availability_zones, :listeners)
+  read_only(:region, :scheme, :availability_zones, :listeners, :tags)
 
   def self.prefetch(resources)
     instances.each do |prov|
@@ -59,7 +59,7 @@ Puppet::Type.type(:elb_loadbalancer).provide(:v2, :parent => PuppetX::Puppetlabs
     tags = {}
     unless tag_response.tag_descriptions.nil? || tag_response.tag_descriptions.empty?
       tag_response.tag_descriptions.first.tags.each do |tag|
-        tags[tag.key.to_sym] = tag.value unless tag.key == 'Name'
+        tags[tag.key] = tag.value unless tag.key == 'Name'
       end
     end
     subnet_names = []

--- a/lib/puppet/type/elb_loadbalancer.rb
+++ b/lib/puppet/type/elb_loadbalancer.rb
@@ -19,14 +19,6 @@ Puppet::Type.newtype(:elb_loadbalancer) do
     end
   end
 
-  newproperty(:availability_zones, :array_matching => :all) do
-    desc 'The availability zones in which to launch the load balancer.'
-  end
-
-  newproperty(:instances, :array_matching => :all) do
-    desc 'The instances to associate with the load balancer.'
-  end
-
   newproperty(:listeners, :array_matching => :all) do
     desc 'The ports and protocols the load balancer listens to.'
     def insync?(is)
@@ -52,9 +44,59 @@ Puppet::Type.newtype(:elb_loadbalancer) do
     desc 'The tags for the load balancer.'
   end
 
+  newproperty(:subnets, :array_matching => :all) do
+    defaultto []
+    desc 'The region in which to launch the load balancer.'
+    def insync?(is)
+      is.to_set == should.to_set
+    end
+  end
+
+  newproperty(:security_groups, :array_matching => :all) do
+    defaultto []
+    desc 'The security groups to associate the load balancer (VPC only).'
+    def insync?(is)
+      is.to_set == should.to_set
+    end
+  end
+
+  newproperty(:availability_zones, :array_matching => :all) do
+    desc 'The availability zones in which to launch the load balancer.'
+    defaultto []
+  end
+
+  newproperty(:instances, :array_matching => :all) do
+    desc 'The instances to associate with the load balancer.'
+  end
+
+  newproperty(:scheme) do
+    desc 'Whether the load balancer is internal or public facing.'
+    defaultto :'internet-facing'
+    newvalues(:'internet-facing', :internal)
+    def insync?(is)
+      is.to_s == should.to_s
+    end
+  end
+
+  validate do
+    subnets = self[:subnets]
+    zones = self[:availability_zones]
+    fail "You can specify either subnets or availability_zones for the ELB #{self[:name]}" if !zones.empty? && !subnets.empty?
+  end
+
   autorequire(:ec2_instance) do
     instances = self[:instances]
     instances.is_a?(Array) ? instances : [instances]
+  end
+
+  autorequire(:ec2_securitygroup) do
+    groups = self[:security_groups]
+    groups.is_a?(Array) ? groups : [groups]
+  end
+
+  autorequire(:ec2_vpc_subnet) do
+    subnets = self[:subnets]
+    subnets.is_a?(Array) ? subnets : [subnets]
   end
 
 end

--- a/lib/puppet/type/elb_loadbalancer.rb
+++ b/lib/puppet/type/elb_loadbalancer.rb
@@ -53,7 +53,6 @@ Puppet::Type.newtype(:elb_loadbalancer) do
   end
 
   newproperty(:security_groups, :array_matching => :all) do
-    defaultto []
     desc 'The security groups to associate the load balancer (VPC only).'
     def insync?(is)
       is.to_set == should.to_set

--- a/spec/acceptance/fixtures/vpc.pp.tmpl
+++ b/spec/acceptance/fixtures/vpc.pp.tmpl
@@ -134,3 +134,20 @@ ec2_instance { '{{name}}-instance':
   {{/tags}}
   },
 }
+
+elb_loadbalancer { '{{lb_name}}':
+  ensure    => {{ensure}},
+  region    => '{{region}}',
+  subnets   => '{{name}}-subnet',
+  scheme    => '{{lb_scheme}}',
+  instances => '{{name}}-instance',
+  listeners => [{
+    protocol => 'tcp',
+    port => 80,
+  }],
+  tags      => {
+  {{#tags}}
+    {{k}} => '{{v}}',
+  {{/tags}}
+  },
+}

--- a/spec/acceptance/fixtures/vpc.pp.tmpl
+++ b/spec/acceptance/fixtures/vpc.pp.tmpl
@@ -142,8 +142,10 @@ elb_loadbalancer { '{{lb_name}}':
   scheme    => '{{lb_scheme}}',
   instances => '{{name}}-instance',
   listeners => [{
-    protocol => 'tcp',
-    port => 80,
+    protocol           => 'tcp',
+    load_balancer_port => 80,
+    instance_protocol  => 'tcp',
+    instance_port      => 80,
   }],
   tags      => {
   {{#tags}}

--- a/spec/acceptance/fixtures/vpc_delete.pp.tmpl
+++ b/spec/acceptance/fixtures/vpc_delete.pp.tmpl
@@ -3,6 +3,11 @@ ec2_instance { '{{name}}-instance':
   region => 'sa-east-1',
 } ~>
 
+elb_loadbalancer { '{{lb_name}}':
+  ensure => {{ensure}},
+  region => 'sa-east-1',
+} ~>
+
 ec2_vpc_internet_gateway { '{{name}}-igw':
   ensure => {{ensure}},
   region => 'sa-east-1',
@@ -47,3 +52,5 @@ ec2_vpc_dhcp_options { '{{name}}-options':
   ensure => {{ensure}},
   region => 'sa-east-1',
 }
+
+

--- a/spec/acceptance/loadbalancer_spec.rb
+++ b/spec/acceptance/loadbalancer_spec.rb
@@ -87,6 +87,10 @@ describe "ec2_loadbalancer" do
       end
     end
 
+    it "with the default scheme" do
+      expect(@loadbalancer.scheme).to eq('internet-facing')
+    end
+
     it "with one associated instance" do
       expect(@loadbalancer.instances.count).to eq(1)
     end

--- a/spec/unit/type/elb_loadbalancer_spec.rb
+++ b/spec/unit/type/elb_loadbalancer_spec.rb
@@ -33,6 +33,9 @@ describe type_class do
       :instances,
       :listeners,
       :tags,
+      :security_groups,
+      :subnets,
+      :scheme,
     ]
   end
 
@@ -61,12 +64,7 @@ describe type_class do
   end
 
   it 'should order tags on output' do
-    tags = {'b' => 1, 'a' => 2}
-    reverse = {'a' => 2, 'b' => 1}
-    elb = type_class.new(:name => 'sample', :tags => tags )
-    expect(elb.property(:tags).insync?(tags)).to be true
-    expect(elb.property(:tags).insync?(reverse)).to be true
-    expect(elb.property(:tags).should_to_s(tags).to_s).to eq(reverse.to_s)
+    expect(type_class).to order_tags_on_output
   end
 
   it "should require a non-empty valid listener" do
@@ -104,6 +102,54 @@ describe type_class do
       'instance_protocol' => 'TCP',
       'instance_port' => '80',
     }])).to be true
+  end
+
+  it 'should default security groups to a blank array' do
+    elb = type_class.new({:name => 'sample'})
+    expect(elb[:security_groups]).to eq([])
+  end
+
+  it 'should default subnets to a blank array' do
+    elb = type_class.new({:name => 'sample'})
+    expect(elb[:subnets]).to eq([])
+  end
+
+  it 'should default availability zones to a blank array' do
+    elb = type_class.new({:name => 'sample'})
+    expect(elb[:availability_zones]).to eq([])
+  end
+
+  it 'should default scheme to public' do
+    elb = type_class.new({:name => 'sample'})
+    expect(elb[:scheme]).to eq(:'internet-facing')
+  end
+
+  it 'should not allow invalid values for scheme' do
+    expect {
+      type_class.new({:name => 'sample', :scheme => 'invalid'})
+    }.to raise_error(Puppet::Error)
+  end
+
+  it 'should allow valid values for scheme' do
+    elb = type_class.new({:name => 'sample', :scheme => 'internal'})
+    expect(elb[:scheme]).to eq(:internal)
+  end
+
+  ['subnets', 'security_groups'].each do |property|
+    it "should ignore the order of #{property} for matching" do
+      values = ['a', 'b']
+      config = {:name => 'sample'}
+      config[property.to_sym] = values
+      elb = type_class.new(config)
+      expect(elb.property(property.to_sym).insync?(values)).to be true
+      expect(elb.property(property.to_sym).insync?(values.reverse)).to be true
+    end
+  end
+
+  it "should disallow passing both a subnet and an availability zone" do
+    expect {
+      type_class.new({:name => 'sample', :subnets => ['subnet'], :availability_zones => ['zones']})
+    }.to raise_error(Puppet::Error)
   end
 
 end

--- a/spec/unit/type/elb_loadbalancer_spec.rb
+++ b/spec/unit/type/elb_loadbalancer_spec.rb
@@ -104,11 +104,6 @@ describe type_class do
     }])).to be true
   end
 
-  it 'should default security groups to a blank array' do
-    elb = type_class.new({:name => 'sample'})
-    expect(elb[:security_groups]).to eq([])
-  end
-
   it 'should default subnets to a blank array' do
     elb = type_class.new({:name => 'sample'})
     expect(elb[:subnets]).to eq([])


### PR DESCRIPTION
This allows for:

* attaching a ELB to a list of subnets
* associating an ELB with security groups (a VPC only feature)
* specifying whether the ELB is internal only or has a public address

This also updates the descriptions on the ELB type to match the format elsewhere, Leading caps and a full stop at the end.