### PR TITLE
(maint) vpc_only_account? logic improvements

### DIFF
--- a/lib/puppet_x/puppetlabs/aws.rb
+++ b/lib/puppet_x/puppetlabs/aws.rb
@@ -43,7 +43,9 @@ module PuppetX
         response = ec2_client.describe_account_attributes(
           attribute_names: ['supported-platforms']
         )
-        response.data.account_attributes.first.attribute_values.size == 1
+
+        account_types = response.account_attributes.map(&:attribute_values).flatten.map(&:attribute_value)
+        account_types == ['VPC']
       end
 
       def self.elb_client(region = default_region)


### PR DESCRIPTION
 - Clean up code to provide a more self-descriptive mechanism
   for finding VPC only accounts.

   With clasic accounts, account_types is ["EC2", "VPC"] while
   a VPC only account has the values ["VPC"].  It's possible
   that there could be other / legacy account types that have
   a different list of supported-platforms, or that this
   changes in the future.