### PR TITLE
(CLOUD-179) Avoid throwing exceptions in prefetch

### DIFF
--- a/lib/puppet/provider/ec2_autoscalinggroup/v2.rb
+++ b/lib/puppet/provider/ec2_autoscalinggroup/v2.rb
@@ -31,7 +31,9 @@ Puppet::Type.type(:ec2_autoscalinggroup).provide(:v2, :parent => PuppetX::Puppet
   def self.group_to_hash(region, group)
     subnet_names = []
     unless group.vpc_zone_identifier.nil? || group.vpc_zone_identifier.empty?
-      response = ec2_client(region).describe_subnets(subnet_ids: group.vpc_zone_identifier.to_s.split(','))
+      response = ec2_client(region).describe_subnets(filters: [
+        {name: 'subnet-id', values: group.vpc_zone_identifier.to_s.split(',')}
+      ])
       subnet_names = response.data.subnets.collect do |subnet|
         subnet_name_tag = subnet.tags.detect { |tag| tag.key == 'Name' }
         subnet_name_tag ? subnet_name_tag.value : nil

--- a/lib/puppet/provider/ec2_instance/v2.rb
+++ b/lib/puppet/provider/ec2_instance/v2.rb
@@ -46,10 +46,11 @@ Puppet::Type.type(:ec2_instance).provide(:v2, :parent => PuppetX::Puppetlabs::Aw
     end
     subnet_name = nil
     if instance.subnet_id
-      subnet_response = ec2_client(region).describe_subnets(subnet_ids: [instance.subnet_id])
-      subnet_name_tag = subnet_response.data.subnets.first.tags.detect { |tag| tag.key == 'Name' }
+      subnet_response = ec2_client(region).describe_subnets(filters: [
+        {name: 'subnet-id', values: [instance.subnet_id]}
+      ])
+      subnet_name = subnet_response.data.subnets.empty? ? nil : name_from_tag(subnet_response.data.subnets.first)
     end
-    subnet_name = subnet_name_tag ? subnet_name_tag.value : nil
 
     devices = instance.block_device_mappings.collect do |mapping|
       {

--- a/lib/puppet/provider/ec2_vpc/v2.rb
+++ b/lib/puppet/provider/ec2_vpc/v2.rb
@@ -31,10 +31,10 @@ Puppet::Type.type(:ec2_vpc).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) do
 
   def self.vpc_to_hash(region, vpc)
     options_name = unless vpc.dhcp_options_id.nil? || vpc.dhcp_options_id.empty?
-      response = ec2_client(region).describe_dhcp_options(
-        dhcp_options_ids: [vpc.dhcp_options_id]
-      )
-      name_from_tag(response.dhcp_options.first)
+      response = ec2_client(region).describe_dhcp_options(filters: [
+        {name: 'dhcp-options-id', values: [vpc.dhcp_options_id]}
+      ])
+      response.data.dhcp_options.empty? ? nil : name_from_tag(response.data.dhcp_options.first)
     else
       nil
     end

--- a/lib/puppet/provider/ec2_vpc_internet_gateway/v2.rb
+++ b/lib/puppet/provider/ec2_vpc_internet_gateway/v2.rb
@@ -35,7 +35,9 @@ Puppet::Type.type(:ec2_vpc_internet_gateway).provide(:v2, :parent => PuppetX::Pu
     vpc_id = nil
     attachments = gateway.attachments.map(&:vpc_id)
     if assigned_name and ! attachments.empty?
-      vpc_response = ec2_client(region).describe_vpcs(vpc_ids: attachments)
+      vpc_response = ec2_client(region).describe_vpcs(filters: [
+        {name: 'vpc-id', values: attachments}
+      ])
       vpc = vpc_response.data.vpcs.first
       vpc_name_tag = vpc.tags.detect { |tag| tag.key == 'Name' }
       if vpc_name_tag
@@ -43,7 +45,6 @@ Puppet::Type.type(:ec2_vpc_internet_gateway).provide(:v2, :parent => PuppetX::Pu
         vpc_id = vpc.vpc_id
       end
     end
-
     {
       name: assigned_name,
       vpc: vpc_name,

--- a/lib/puppet/provider/ec2_vpc_subnet/v2.rb
+++ b/lib/puppet/provider/ec2_vpc_subnet/v2.rb
@@ -31,23 +31,25 @@ Puppet::Type.type(:ec2_vpc_subnet).provide(:v2, :parent => PuppetX::Puppetlabs::
 
   def self.subnet_to_hash(region, subnet)
     ec2 = ec2_client(region)
-    vpc_response = ec2.describe_vpcs(vpc_ids: [subnet.vpc_id])
-    vpc_name_tag = vpc_response.data.vpcs.first.tags.detect { |tag| tag.key == 'Name' }
+    vpc_response = ec2.describe_vpcs(filters: [
+      {name: 'vpc-id', values: [subnet.vpc_id]}
+    ])
+
+    vpc_name = vpc_response.data.vpcs.empty? ? nil : name_from_tag(vpc_response.data.vpcs.first)
 
     table_response = ec2.describe_route_tables(filters: [
       {name: 'association.subnet-id', values: [subnet.subnet_id]},
       {name: 'vpc-id', values: [subnet.vpc_id]},
     ])
-    tables = table_response.data.route_tables
-    table_name_tag = tables.empty? ? nil : tables.first.tags.detect { |tag| tag.key == 'Name' }
+    table_name = table_response.data.route_tables.empty? ? nil : name_from_tag(table_response.data.route_tables.first)
 
     {
       name: name_from_tag(subnet),
-      route_table: table_name_tag ? table_name_tag.value : nil,
+      route_table: table_name,
       id: subnet.subnet_id,
       cidr_block: subnet.cidr_block,
       availability_zone: subnet.availability_zone,
-      vpc: vpc_name_tag ? vpc_name_tag.value : nil,
+      vpc: vpc_name,
       ensure: :present,
       region: region,
       tags: tags_for(subnet),

--- a/lib/puppet/provider/ec2_vpc_vpn/v2.rb
+++ b/lib/puppet/provider/ec2_vpc_vpn/v2.rb
@@ -35,9 +35,9 @@ Puppet::Type.type(:ec2_vpc_vpn).provide(:v2, :parent => PuppetX::Puppetlabs::Aws
   def self.connection_to_hash(region, connection)
     ec2 = ec2_client(region)
 
-    customer_response = ec2.describe_customer_gateways(
-      customer_gateway_ids: [connection.customer_gateway_id]
-    )
+    customer_response = ec2.describe_customer_gateways(filters: [
+      {name: 'customer-gateway-id', values: [connection.customer_gateway_id]}
+    ])
 
     customer_gateways = customer_response.data.customer_gateways
     customer_gateway_name = unless customer_gateways.empty?
@@ -47,9 +47,9 @@ Puppet::Type.type(:ec2_vpc_vpn).provide(:v2, :parent => PuppetX::Puppetlabs::Aws
       nil
     end
 
-    vpn_response = ec2.describe_vpn_gateways(
-      vpn_gateway_ids: [connection.vpn_gateway_id]
-    )
+    vpn_response = ec2.describe_vpn_gateways(filters: [
+      {name: 'vpn-gateway-id', values: [connection.vpn_gateway_id]}
+    ])
 
     vpn_gateways = vpn_response.data.vpn_gateways
     vpn_gateway_name = unless vpn_gateways.empty?

--- a/lib/puppet/provider/ec2_vpc_vpn_gateway/v2.rb
+++ b/lib/puppet/provider/ec2_vpc_vpn_gateway/v2.rb
@@ -38,12 +38,10 @@ Puppet::Type.type(:ec2_vpc_vpn_gateway).provide(:v2, :parent => PuppetX::Puppetl
     attached = gateway.vpc_attachments.detect { |vpc| vpc.state == 'attached' }
     if attached
       vpc_id = attached.vpc_id
-      vpc_response = ec2_client(region).describe_vpcs(
-        vpc_ids: [vpc_id]
-      )
-      vpc = vpc_response.data.vpcs.first
-      vpc_name_tag = vpc.tags.detect { |tag| tag.key == 'Name' }
-      vpc_name = vpc_name_tag ? vpc_name_tag.value : nil
+      vpc_response = ec2_client(region).describe_vpcs(filters: [
+        {name: 'vpc-id', values: [vpc_id]}
+      ])
+      vpc_name = vpc_response.data.vpcs.empty? ? nil : name_from_tag(vpc_response.data.vpcs.first)
     else
       vpc_name = nil
       vpc_id = nil

--- a/lib/puppet/provider/elb_loadbalancer/v2.rb
+++ b/lib/puppet/provider/elb_loadbalancer/v2.rb
@@ -32,7 +32,9 @@ Puppet::Type.type(:elb_loadbalancer).provide(:v2, :parent => PuppetX::Puppetlabs
     instance_ids = load_balancer.instances.map(&:instance_id)
     instance_names = []
     unless instance_ids.empty?
-      instances = ec2_client(region).describe_instances(instance_ids: instance_ids).collect do |response|
+      instances = ec2_client(region).describe_instances(filters: [
+        {name: 'instance-id', values: instance_ids}
+      ]).collect do |response|
         response.data.reservations.collect do |reservation|
           reservation.instances.collect do |instance|
             instance


### PR DESCRIPTION
I have a guess this accounts for at least some orphaned resources left
after test runs. The story goes like this:

* Get a list of a resources (say instances)
* For each of those instances, we trigger further requests to get
  the names from the ids (say for related security groups)
* This was previously done using the *_ids param to describe_*
* This formulation will throw an exception if a resource with that id
  exist
* If prefetch fails, the Puppet run continues (this is fixed in 4.0)
* But the entire prefetch for that resource fails
* Resources won't correctly deal with exists?
* We could create extra resources or not delete others

This happens infrequently in the small, because it generally relies on
something else to be operating on the resources during the operation -
ie. between the initial describe_* call, another call deletes an
unrelated resource. But in the large that happens enough, especially
with the test suite.

This change swaps out the *_ids param for a filter on the *-id property.
This does exactly the same thing, but doesn't throw an exception. So now
we can simply deal with an empty array as needed.