### PR TITLE
(CLOUD-42) Performance improvements

### DIFF
--- a/fixtures/vcr_cassettes/group-named-test.yml
+++ b/fixtures/vcr_cassettes/group-named-test.yml
@@ -5,6 +5,57 @@
         uri: "https://ec2.sa-east-1.amazonaws.com/"
         body: 
           encoding: UTF-8
+          string: "Action=DescribeVpcs&Version=2014-09-01"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.5 ruby/2.0.0 universal.x86_64-darwin14"
+          X-Amz-Date: 
+            - "20150511T081254Z"
+          Host: 
+            - ec2.sa-east-1.amazonaws.com
+          X-Amz-Content-Sha256: 
+            - a5f2916dc835304d35fa21090cbec3b88c7389b76b81e560905ce762a499b8c1
+          Authorization: 
+            - "AWS4-HMAC-SHA256 Credential=redacted/20150511/sa-east-1/ec2/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=f368f89f9e6248ff6d50b018bb01e6ab48793aeff7a22649b0cdf520a5a4dc63"
+          Content-Length: 
+            - "38"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Mon, 11 May 2015 08:12:53 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-09-01/">
+                <requestId>f1c9fde4-0fdf-4f9a-8ca1-341d0cc733f9</requestId>
+                <vpcSet>
+                </vpcSet>
+            </DescribeVpcsResponse>
+        http_version: 
+      recorded_at: "Mon, 11 May 2015 08:12:55 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
           string: "Action=DescribeSecurityGroups&Version=2014-09-01"
         headers: 
           Content-Type: 
@@ -14,13 +65,13 @@
           User-Agent: 
             - "aws-sdk-ruby2/2.0.5 ruby/2.0.0 universal.x86_64-darwin14"
           X-Amz-Date: 
-            - "20150224T181019Z"
+            - "20150511T081255Z"
           Host: 
             - ec2.sa-east-1.amazonaws.com
           X-Amz-Content-Sha256: 
             - "5d21a760e19d65e1362145b2d52df2569bac924f2eaee44aefe25f75ead4e7e2"
           Authorization: 
-            - "AWS4-HMAC-SHA256 Credential=redacted/20150224/sa-east-1/ec2/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=50a9cac09e0f99a59786eb7060cf5b60cd4d9e5d522d7ef36bfb81b5fbb88393"
+            - "AWS4-HMAC-SHA256 Credential=redacted/20150511/sa-east-1/ec2/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=070674801bc51a13f598ff5f67b95a56bed15ae8799a3f2215d086cb95b9a5e9"
           Content-Length: 
             - "48"
           Accept: 
@@ -37,7 +88,7 @@
           Vary: 
             - Accept-Encoding
           Date: 
-            - "Tue, 24 Feb 2015 18:10:19 GMT"
+            - "Mon, 11 May 2015 08:12:55 GMT"
           Server: 
             - AmazonEC2
         body: 
@@ -45,428 +96,18 @@
           string: |-
             <?xml version="1.0" encoding="UTF-8"?>
             <DescribeSecurityGroupsResponse xmlns="http://ec2.amazonaws.com/doc/2014-09-01/">
-                <requestId>35486255-fd7c-41ab-b5e1-375b26429c6b</requestId>
+                <requestId>a71b19a6-71b3-44a1-b0f2-40db5a9706f1</requestId>
                 <securityGroupInfo>
                     <item>
-                        <ownerId>482693910459</ownerId>
-                        <groupId>sg-9917aa86</groupId>
-                        <groupName>lb-sg</groupName>
-                        <groupDescription>Security group for load balancer</groupDescription>
-                        <ipPermissions>
-                            <item>
-                                <ipProtocol>tcp</ipProtocol>
-                                <fromPort>80</fromPort>
-                                <toPort>80</toPort>
-                                <groups/>
-                                <ipRanges>
-                                    <item>
-                                        <cidrIp>0.0.0.0/0</cidrIp>
-                                    </item>
-                                </ipRanges>
-                            </item>
-                        </ipPermissions>
+                        <ownerId>x</ownerId>
+                        <groupId>sg-x</groupId>
+                        <groupName></groupName>
+                        <groupDescription>group for testing autoscaling group</groupDescription>
+                        <ipPermissions/>
                         <ipPermissionsEgress/>
                     </item>
                 </securityGroupInfo>
             </DescribeSecurityGroupsResponse>
         http_version: 
-      recorded_at: "Tue, 24 Feb 2015 18:10:21 GMT"
-    - request: 
-        method: post
-        uri: "https://ec2.sa-east-1.amazonaws.com/"
-        body: 
-          encoding: UTF-8
-          string: "Action=DescribeVpcs&Version=2014-09-01&VpcId.1=vpc-bd9a16d8"
-        headers: 
-          Content-Type: 
-            - "application/x-www-form-urlencoded; charset=utf-8"
-          Accept-Encoding: 
-            - ""
-          User-Agent: 
-            - "aws-sdk-ruby2/2.0.5 ruby/2.0.0 universal.x86_64-darwin14"
-          X-Amz-Date: 
-            - "20150224T181021Z"
-          Host: 
-            - ec2.sa-east-1.amazonaws.com
-          X-Amz-Content-Sha256: 
-            - "6be63b442b739fff8026512888983019d34f6a43b7daad573209dc8a5f3d018d"
-          Authorization: 
-            - "AWS4-HMAC-SHA256 Credential=redacted/20150224/sa-east-1/ec2/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=099c7975a1180bf653e6a72afdd0b011e46191e24a83bd53af1a0d3e2e06c97a"
-          Content-Length: 
-            - "59"
-          Accept: 
-            - "*/*"
-      response: 
-        status: 
-          code: 200
-          message: OK
-        headers: 
-          Content-Type: 
-            - "text/xml;charset=UTF-8"
-          Transfer-Encoding: 
-            - chunked
-          Vary: 
-            - Accept-Encoding
-          Date: 
-            - "Tue, 24 Feb 2015 18:10:22 GMT"
-          Server: 
-            - AmazonEC2
-        body: 
-          encoding: UTF-8
-          string: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-09-01/">
-                <requestId>1d291ab0-e063-44b8-8426-82ee0b414498</requestId>
-                <vpcSet>
-                </vpcSet>
-            </DescribeVpcsResponse>
-        http_version: 
-      recorded_at: "Tue, 24 Feb 2015 18:10:22 GMT"
-    - request: 
-        method: post
-        uri: "https://ec2.sa-east-1.amazonaws.com/"
-        body: 
-          encoding: UTF-8
-          string: "Action=DescribeSecurityGroups&GroupId.1=sg-06a27263&Version=2014-09-01"
-        headers: 
-          Content-Type: 
-            - "application/x-www-form-urlencoded; charset=utf-8"
-          Accept-Encoding: 
-            - ""
-          User-Agent: 
-            - "aws-sdk-ruby2/2.0.5 ruby/2.0.0 universal.x86_64-darwin14"
-          X-Amz-Date: 
-            - "20150224T181022Z"
-          Host: 
-            - ec2.sa-east-1.amazonaws.com
-          X-Amz-Content-Sha256: 
-            - c1c0f505cc429502bf01376e90d82644d96c7e615cceb3d57cd12b734f508855
-          Authorization: 
-            - "AWS4-HMAC-SHA256 Credential=redacted/20150224/sa-east-1/ec2/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=b338c62bfd4aed6729351e3172d4b9eada8069c2f77b754234802111b8a0a661"
-          Content-Length: 
-            - "70"
-          Accept: 
-            - "*/*"
-      response: 
-        status: 
-          code: 200
-          message: OK
-        headers: 
-          Content-Type: 
-            - "text/xml;charset=UTF-8"
-          Transfer-Encoding: 
-            - chunked
-          Vary: 
-            - Accept-Encoding
-          Date: 
-            - "Tue, 24 Feb 2015 18:10:23 GMT"
-          Server: 
-            - AmazonEC2
-        body: 
-          encoding: UTF-8
-          string: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <DescribeSecurityGroupsResponse xmlns="http://ec2.amazonaws.com/doc/2014-09-01/">
-                <requestId>60b93653-fdcf-427e-9122-3f69105f7164</requestId>
-                <securityGroupInfo>
-                </securityGroupInfo>
-            </DescribeSecurityGroupsResponse>
-        http_version: 
-      recorded_at: "Tue, 24 Feb 2015 18:10:23 GMT"
-    - request: 
-        method: post
-        uri: "https://ec2.sa-east-1.amazonaws.com/"
-        body: 
-          encoding: UTF-8
-          string: "Action=DescribeVpcs&Version=2014-09-01&VpcId.1=vpc-35c25750"
-        headers: 
-          Content-Type: 
-            - "application/x-www-form-urlencoded; charset=utf-8"
-          Accept-Encoding: 
-            - ""
-          User-Agent: 
-            - "aws-sdk-ruby2/2.0.5 ruby/2.0.0 universal.x86_64-darwin14"
-          X-Amz-Date: 
-            - "20150224T181023Z"
-          Host: 
-            - ec2.sa-east-1.amazonaws.com
-          X-Amz-Content-Sha256: 
-            - "728ca83d7c54feaeb7681e8b63230f80abe011185116c65d91ff763d8bec748e"
-          Authorization: 
-            - "AWS4-HMAC-SHA256 Credential=redacted/20150224/sa-east-1/ec2/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=319dc59185d47df3457a50d1dc59fe1b5634bece759e1bc5522a739ab302558d"
-          Content-Length: 
-            - "59"
-          Accept: 
-            - "*/*"
-      response: 
-        status: 
-          code: 200
-          message: OK
-        headers: 
-          Content-Type: 
-            - "text/xml;charset=UTF-8"
-          Transfer-Encoding: 
-            - chunked
-          Vary: 
-            - Accept-Encoding
-          Date: 
-            - "Tue, 24 Feb 2015 18:10:24 GMT"
-          Server: 
-            - AmazonEC2
-        body: 
-          encoding: UTF-8
-          string: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-09-01/">
-                <requestId>703368fc-10d3-4f61-8134-aeeb841960b6</requestId>
-            </DescribeVpcsResponse>
-        http_version: 
-      recorded_at: "Tue, 24 Feb 2015 18:10:24 GMT"
-    - request: 
-        method: post
-        uri: "https://ec2.sa-east-1.amazonaws.com/"
-        body: 
-          encoding: UTF-8
-          string: "Action=DescribeSecurityGroups&GroupId.1=sg-03904a66&Version=2014-09-01"
-        headers: 
-          Content-Type: 
-            - "application/x-www-form-urlencoded; charset=utf-8"
-          Accept-Encoding: 
-            - ""
-          User-Agent: 
-            - "aws-sdk-ruby2/2.0.5 ruby/2.0.0 universal.x86_64-darwin14"
-          X-Amz-Date: 
-            - "20150224T181024Z"
-          Host: 
-            - ec2.sa-east-1.amazonaws.com
-          X-Amz-Content-Sha256: 
-            - "2b8897b8eb97470085add5732874ed823cd6d7e2613f638f0bafdc54c5f6ec49"
-          Authorization: 
-            - "AWS4-HMAC-SHA256 Credential=redacted/20150224/sa-east-1/ec2/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=71cfb1611346139c57add06afdaf384613410ccedd1341568d274391bfe99428"
-          Content-Length: 
-            - "70"
-          Accept: 
-            - "*/*"
-      response: 
-        status: 
-          code: 200
-          message: OK
-        headers: 
-          Content-Type: 
-            - "text/xml;charset=UTF-8"
-          Transfer-Encoding: 
-            - chunked
-          Vary: 
-            - Accept-Encoding
-          Date: 
-            - "Tue, 24 Feb 2015 18:10:25 GMT"
-          Server: 
-            - AmazonEC2
-        body: 
-          encoding: UTF-8
-          string: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <DescribeSecurityGroupsResponse xmlns="http://ec2.amazonaws.com/doc/2014-09-01/">
-                <requestId>6d78c5c7-575a-4aff-bb1c-18ab72ef88b1</requestId>
-            </DescribeSecurityGroupsResponse>
-        http_version: 
-      recorded_at: "Tue, 24 Feb 2015 18:10:26 GMT"
-    - request: 
-        method: post
-        uri: "https://ec2.sa-east-1.amazonaws.com/"
-        body: 
-          encoding: UTF-8
-          string: "Action=DescribeVpcs&Version=2014-09-01&VpcId.1=vpc-35c25750"
-        headers: 
-          Content-Type: 
-            - "application/x-www-form-urlencoded; charset=utf-8"
-          Accept-Encoding: 
-            - ""
-          User-Agent: 
-            - "aws-sdk-ruby2/2.0.5 ruby/2.0.0 universal.x86_64-darwin14"
-          X-Amz-Date: 
-            - "20150224T181026Z"
-          Host: 
-            - ec2.sa-east-1.amazonaws.com
-          X-Amz-Content-Sha256: 
-            - "728ca83d7c54feaeb7681e8b63230f80abe011185116c65d91ff763d8bec748e"
-          Authorization: 
-            - "AWS4-HMAC-SHA256 Credential=redacted/20150224/sa-east-1/ec2/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=724b13ceb3d5730609e0e05a6fc9292c725ec1d5fed41e9164c8fca140a043d8"
-          Content-Length: 
-            - "59"
-          Accept: 
-            - "*/*"
-      response: 
-        status: 
-          code: 200
-          message: OK
-        headers: 
-          Content-Type: 
-            - "text/xml;charset=UTF-8"
-          Transfer-Encoding: 
-            - chunked
-          Vary: 
-            - Accept-Encoding
-          Date: 
-            - "Tue, 24 Feb 2015 18:10:26 GMT"
-          Server: 
-            - AmazonEC2
-        body: 
-          encoding: UTF-8
-          string: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <DescribeVpcsResponse xmlns="http://ec2.amazonaws.com/doc/2014-09-01/">
-                <requestId>e80b1f01-4f00-4ef4-b2d1-330a5e6ba6ae</requestId>
-            </DescribeVpcsResponse>
-        http_version: 
-      recorded_at: "Tue, 24 Feb 2015 18:10:27 GMT"
-    - request: 
-        method: post
-        uri: "https://ec2.sa-east-1.amazonaws.com/"
-        body: 
-          encoding: UTF-8
-          string: "Action=DescribeSecurityGroups&GroupId.1=sg-3d954f58&Version=2014-09-01"
-        headers: 
-          Content-Type: 
-            - "application/x-www-form-urlencoded; charset=utf-8"
-          Accept-Encoding: 
-            - ""
-          User-Agent: 
-            - "aws-sdk-ruby2/2.0.5 ruby/2.0.0 universal.x86_64-darwin14"
-          X-Amz-Date: 
-            - "20150224T181027Z"
-          Host: 
-            - ec2.sa-east-1.amazonaws.com
-          X-Amz-Content-Sha256: 
-            - b15501a6ac86d302df4485109afc2045837bed0813c75441d1605c7177d58cb5
-          Authorization: 
-            - "AWS4-HMAC-SHA256 Credential=redacted/20150224/sa-east-1/ec2/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=d79cca88e73af8c7ac6a5839e42d2e26c4628e05052c6dfbd4d08c53f5bd47cc"
-          Content-Length: 
-            - "70"
-          Accept: 
-            - "*/*"
-      response: 
-        status: 
-          code: 200
-          message: OK
-        headers: 
-          Content-Type: 
-            - "text/xml;charset=UTF-8"
-          Transfer-Encoding: 
-            - chunked
-          Vary: 
-            - Accept-Encoding
-          Date: 
-            - "Tue, 24 Feb 2015 18:10:28 GMT"
-          Server: 
-            - AmazonEC2
-        body: 
-          encoding: UTF-8
-          string: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <DescribeSecurityGroupsResponse xmlns="http://ec2.amazonaws.com/doc/2014-09-01/">
-                <requestId>44218c83-d8f0-4edc-9d13-2e013dcf27ea</requestId>
-            </DescribeSecurityGroupsResponse>
-        http_version: 
-      recorded_at: "Tue, 24 Feb 2015 18:10:28 GMT"
-    - request: 
-        method: post
-        uri: "https://ec2.sa-east-1.amazonaws.com/"
-        body: 
-          encoding: UTF-8
-          string: "Action=DescribeSecurityGroups&GroupId.1=sg-3d954f58&Version=2014-09-01"
-        headers: 
-          Content-Type: 
-            - "application/x-www-form-urlencoded; charset=utf-8"
-          Accept-Encoding: 
-            - ""
-          User-Agent: 
-            - "aws-sdk-ruby2/2.0.5 ruby/2.0.0 universal.x86_64-darwin14"
-          X-Amz-Date: 
-            - "20150224T181028Z"
-          Host: 
-            - ec2.sa-east-1.amazonaws.com
-          X-Amz-Content-Sha256: 
-            - b15501a6ac86d302df4485109afc2045837bed0813c75441d1605c7177d58cb5
-          Authorization: 
-            - "AWS4-HMAC-SHA256 Credential=redacted/20150224/sa-east-1/ec2/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=074c953f9373d5291cab799a5b06830633e8ce8fda953d93acc5e8265c14dac6"
-          Content-Length: 
-            - "70"
-          Accept: 
-            - "*/*"
-      response: 
-        status: 
-          code: 200
-          message: OK
-        headers: 
-          Content-Type: 
-            - "text/xml;charset=UTF-8"
-          Transfer-Encoding: 
-            - chunked
-          Vary: 
-            - Accept-Encoding
-          Date: 
-            - "Tue, 24 Feb 2015 18:10:29 GMT"
-          Server: 
-            - AmazonEC2
-        body: 
-          encoding: UTF-8
-          string: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <DescribeSecurityGroupsResponse xmlns="http://ec2.amazonaws.com/doc/2014-09-01/">
-                <requestId>3dc105b0-37f3-4fb8-8fcc-e39a9d5a147d</requestId>
-                <securityGroupInfo>
-                </securityGroupInfo>
-            </DescribeSecurityGroupsResponse>
-        http_version: 
-      recorded_at: "Tue, 24 Feb 2015 18:10:29 GMT"
-    - request: 
-        method: post
-        uri: "https://ec2.sa-east-1.amazonaws.com/"
-        body: 
-          encoding: UTF-8
-          string: "Action=DescribeSecurityGroups&GroupId.1=sg-3d954f58&Version=2014-09-01"
-        headers: 
-          Content-Type: 
-            - "application/x-www-form-urlencoded; charset=utf-8"
-          Accept-Encoding: 
-            - ""
-          User-Agent: 
-            - "aws-sdk-ruby2/2.0.5 ruby/2.0.0 universal.x86_64-darwin14"
-          X-Amz-Date: 
-            - "20150224T181029Z"
-          Host: 
-            - ec2.sa-east-1.amazonaws.com
-          X-Amz-Content-Sha256: 
-            - b15501a6ac86d302df4485109afc2045837bed0813c75441d1605c7177d58cb5
-          Authorization: 
-            - "AWS4-HMAC-SHA256 Credential=redacted/20150224/sa-east-1/ec2/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=74967d1d2577db868742c155cfc171f933f2d71cadb61062fb0532c7e2169c05"
-          Content-Length: 
-            - "70"
-          Accept: 
-            - "*/*"
-      response: 
-        status: 
-          code: 200
-          message: OK
-        headers: 
-          Content-Type: 
-            - "text/xml;charset=UTF-8"
-          Transfer-Encoding: 
-            - chunked
-          Vary: 
-            - Accept-Encoding
-          Date: 
-            - "Tue, 24 Feb 2015 18:10:30 GMT"
-          Server: 
-            - AmazonEC2
-        body: 
-          encoding: UTF-8
-          string: |-
-            <?xml version="1.0" encoding="UTF-8"?>
-            <DescribeSecurityGroupsResponse xmlns="http://ec2.amazonaws.com/doc/2014-09-01/">
-                <requestId>8b3d1e87-112f-4d79-9241-3c8b548e1f08</requestId>
-            </DescribeSecurityGroupsResponse>
-        http_version: 
-      recorded_at: "Tue, 24 Feb 2015 18:10:30 GMT"
+      recorded_at: "Mon, 11 May 2015 08:12:57 GMT"
   recorded_with: "VCR 2.9.3"

--- a/fixtures/vcr_cassettes/instance-setup.yml
+++ b/fixtures/vcr_cassettes/instance-setup.yml
@@ -5,16 +5,24 @@
         uri: "https://ec2.sa-east-1.amazonaws.com/"
         body: 
           encoding: UTF-8
-          string: "AWSAccessKeyId=redacted&Action=DescribeInstances&Filter.1.Name=instance-state-name&Filter.1.Value.1=pending&Filter.1.Value.2=running&Signature=redacted&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-03T13%3A42%3A54Z&Version=2014-06-15"
+          string: "Action=DescribeSubnets&Version=2014-09-01"
         headers: 
           Content-Type: 
             - "application/x-www-form-urlencoded; charset=utf-8"
           Accept-Encoding: 
             - ""
           User-Agent: 
-            - "aws-sdk-ruby2/2.0.1 ruby/2.1.1 x86_64-darwin13.0"
+            - "aws-sdk-ruby2/2.0.5 ruby/2.1.4 x86_64-darwin14.0"
+          X-Amz-Date: 
+            - "20150507T104713Z"
+          Host: 
+            - ec2.sa-east-1.amazonaws.com
+          X-Amz-Content-Sha256: 
+            - "3a82620a58eb8a58f422b0762600796f48166b8ce93cb23e176e8d65d498f8c8"
+          Authorization: 
+            - "AWS4-HMAC-SHA256 Credential=AKIAJKFCLZAZQRFMXDAA/20150507/sa-east-1/ec2/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=7cae871d925abb2199b7183de9e03b0317e0ba0255f078c267ad5a2c47cd64cb"
           Content-Length: 
-            - "309"
+            - "41"
           Accept: 
             - "*/*"
       response: 
@@ -29,359 +37,43 @@
           Vary: 
             - Accept-Encoding
           Date: 
-            - "Fri, 03 Oct 2014 13:42:55 GMT"
+            - "Thu, 07 May 2015 10:47:14 GMT"
           Server: 
             - AmazonEC2
         body: 
           encoding: UTF-8
           string: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <DescribeInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
-                <requestId>316d2fda-3c1e-4971-85b3-a0036f066470</requestId>
-                <reservationSet>
-                    <item>
-                        <reservationId>r-1a11ba0f</reservationId>
-                        <ownerId>482693910459</ownerId>
-                        <groupSet>
-                            <item>
-                                <groupId>sg-d5d0f4c8</groupId>
-                                <groupName>web-sg</groupName>
-                            </item>
-                        </groupSet>
-                        <instancesSet>
-                            <item>
-                                <instanceId>i-3171f124</instanceId>
-                                <imageId>ami-41e85d5c</imageId>
-                                <instanceState>
-                                    <code>16</code>
-                                    <name>running</name>
-                                </instanceState>
-                                <privateDnsName>ip-10-252-47-184.sa-east-1.compute.internal</privateDnsName>
-                                <dnsName>ec2-54-207-242-205.sa-east-1.compute.amazonaws.com</dnsName>
-                                <reason/>
-                                <amiLaunchIndex>0</amiLaunchIndex>
-                                <productCodes/>
-                                <instanceType>t1.micro</instanceType>
-                                <launchTime>2014-10-01T12:06:55.000Z</launchTime>
-                                <placement>
-                                    <availabilityZone>sa-east-1a</availabilityZone>
-                                    <groupName/>
-                                    <tenancy>default</tenancy>
-                                </placement>
-                                <kernelId>aki-5553f448</kernelId>
-                                <monitoring>
-                                    <state>disabled</state>
-                                </monitoring>
-                                <privateIpAddress>10.252.47.184</privateIpAddress>
-                                <ipAddress>54.207.242.205</ipAddress>
-                                <groupSet>
-                                    <item>
-                                        <groupId>sg-d5d0f4c8</groupId>
-                                        <groupName>web-sg</groupName>
-                                    </item>
-                                </groupSet>
-                                <architecture>x86_64</architecture>
-                                <rootDeviceType>ebs</rootDeviceType>
-                                <rootDeviceName>/dev/sda1</rootDeviceName>
-                                <blockDeviceMapping>
-                                    <item>
-                                        <deviceName>/dev/sda1</deviceName>
-                                        <ebs>
-                                            <volumeId>vol-cf2d86c2</volumeId>
-                                            <status>attached</status>
-                                            <attachTime>2014-10-01T12:06:57.000Z</attachTime>
-                                            <deleteOnTermination>true</deleteOnTermination>
-                                        </ebs>
-                                    </item>
-                                </blockDeviceMapping>
-                                <virtualizationType>paravirtual</virtualizationType>
-                                <clientToken/>
-                                <tagSet>
-                                    <item>
-                                        <key>project</key>
-                                        <value>cloud</value>
-                                    </item>
-                                    <item>
-                                        <key>Name</key>
-                                        <value>web-2</value>
-                                    </item>
-                                    <item>
-                                        <key>department</key>
-                                        <value>engineering</value>
-                                    </item>
-                                    <item>
-                                        <key>created_by</key>
-                                        <value>garethr</value>
-                                    </item>
-                                </tagSet>
-                                <hypervisor>xen</hypervisor>
-                                <networkInterfaceSet/>
-                                <ebsOptimized>false</ebsOptimized>
-                            </item>
-                        </instancesSet>
-                    </item>
-                    <item>
-                        <reservationId>r-af10bbba</reservationId>
-                        <ownerId>482693910459</ownerId>
-                        <groupSet>
-                            <item>
-                                <groupId>sg-d1d0f4cc</groupId>
-                                <groupName>db-sg</groupName>
-                            </item>
-                        </groupSet>
-                        <instancesSet>
-                            <item>
-                                <instanceId>i-d572f2c0</instanceId>
-                                <imageId>ami-41e85d5c</imageId>
-                                <instanceState>
-                                    <code>16</code>
-                                    <name>running</name>
-                                </instanceState>
-                                <privateDnsName>ip-10-252-22-200.sa-east-1.compute.internal</privateDnsName>
-                                <dnsName>ec2-177-71-132-75.sa-east-1.compute.amazonaws.com</dnsName>
-                                <reason/>
-                                <amiLaunchIndex>0</amiLaunchIndex>
-                                <productCodes/>
-                                <instanceType>t1.micro</instanceType>
-                                <launchTime>2014-10-01T12:07:02.000Z</launchTime>
-                                <placement>
-                                    <availabilityZone>sa-east-1a</availabilityZone>
-                                    <groupName/>
-                                    <tenancy>default</tenancy>
-                                </placement>
-                                <kernelId>aki-5553f448</kernelId>
-                                <monitoring>
-                                    <state>disabled</state>
-                                </monitoring>
-                                <privateIpAddress>10.252.22.200</privateIpAddress>
-                                <ipAddress>177.71.132.75</ipAddress>
-                                <groupSet>
-                                    <item>
-                                        <groupId>sg-d1d0f4cc</groupId>
-                                        <groupName>db-sg</groupName>
-                                    </item>
-                                </groupSet>
-                                <architecture>x86_64</architecture>
-                                <rootDeviceType>ebs</rootDeviceType>
-                                <rootDeviceName>/dev/sda1</rootDeviceName>
-                                <blockDeviceMapping>
-                                    <item>
-                                        <deviceName>/dev/sda1</deviceName>
-                                        <ebs>
-                                            <volumeId>vol-ce2d86c3</volumeId>
-                                            <status>attached</status>
-                                            <attachTime>2014-10-01T12:07:06.000Z</attachTime>
-                                            <deleteOnTermination>true</deleteOnTermination>
-                                        </ebs>
-                                    </item>
-                                </blockDeviceMapping>
-                                <virtualizationType>paravirtual</virtualizationType>
-                                <clientToken/>
-                                <tagSet>
-                                    <item>
-                                        <key>department</key>
-                                        <value>engineering</value>
-                                    </item>
-                                    <item>
-                                        <key>Name</key>
-                                        <value>db-1</value>
-                                    </item>
-                                    <item>
-                                        <key>created_by</key>
-                                        <value>garethr</value>
-                                    </item>
-                                    <item>
-                                        <key>project</key>
-                                        <value>cloud</value>
-                                    </item>
-                                </tagSet>
-                                <hypervisor>xen</hypervisor>
-                                <networkInterfaceSet/>
-                                <ebsOptimized>false</ebsOptimized>
-                            </item>
-                        </instancesSet>
-                    </item>
-                    <item>
-                        <reservationId>r-8f11ba9a</reservationId>
-                        <ownerId>482693910459</ownerId>
-                        <groupSet>
-                            <item>
-                                <groupId>sg-d5d0f4c8</groupId>
-                                <groupName>web-sg</groupName>
-                            </item>
-                        </groupSet>
-                        <instancesSet>
-                            <item>
-                                <instanceId>i-1774f402</instanceId>
-                                <imageId>ami-41e85d5c</imageId>
-                                <instanceState>
-                                    <code>16</code>
-                                    <name>running</name>
-                                </instanceState>
-                                <privateDnsName>ip-10-252-14-59.sa-east-1.compute.internal</privateDnsName>
-                                <dnsName>ec2-54-207-152-222.sa-east-1.compute.amazonaws.com</dnsName>
-                                <reason/>
-                                <amiLaunchIndex>0</amiLaunchIndex>
-                                <productCodes/>
-                                <instanceType>t1.micro</instanceType>
-                                <launchTime>2014-10-01T12:06:56.000Z</launchTime>
-                                <placement>
-                                    <availabilityZone>sa-east-1a</availabilityZone>
-                                    <groupName/>
-                                    <tenancy>default</tenancy>
-                                </placement>
-                                <kernelId>aki-5553f448</kernelId>
-                                <monitoring>
-                                    <state>disabled</state>
-                                </monitoring>
-                                <privateIpAddress>10.252.14.59</privateIpAddress>
-                                <ipAddress>54.207.152.222</ipAddress>
-                                <groupSet>
-                                    <item>
-                                        <groupId>sg-d5d0f4c8</groupId>
-                                        <groupName>web-sg</groupName>
-                                    </item>
-                                </groupSet>
-                                <architecture>x86_64</architecture>
-                                <rootDeviceType>ebs</rootDeviceType>
-                                <rootDeviceName>/dev/sda1</rootDeviceName>
-                                <blockDeviceMapping>
-                                    <item>
-                                        <deviceName>/dev/sda1</deviceName>
-                                        <ebs>
-                                            <volumeId>vol-d32d86de</volumeId>
-                                            <status>attached</status>
-                                            <attachTime>2014-10-01T12:07:01.000Z</attachTime>
-                                            <deleteOnTermination>true</deleteOnTermination>
-                                        </ebs>
-                                    </item>
-                                </blockDeviceMapping>
-                                <virtualizationType>paravirtual</virtualizationType>
-                                <clientToken/>
-                                <tagSet>
-                                    <item>
-                                        <key>project</key>
-                                        <value>cloud</value>
-                                    </item>
-                                    <item>
-                                        <key>department</key>
-                                        <value>engineering</value>
-                                    </item>
-                                    <item>
-                                        <key>created_by</key>
-                                        <value>garethr</value>
-                                    </item>
-                                    <item>
-                                        <key>Name</key>
-                                        <value>web-1</value>
-                                    </item>
-                                </tagSet>
-                                <hypervisor>xen</hypervisor>
-                                <networkInterfaceSet/>
-                                <ebsOptimized>false</ebsOptimized>
-                            </item>
-                        </instancesSet>
-                    </item>
-                    <item>
-                        <reservationId>r-c811badd</reservationId>
-                        <ownerId>482693910459</ownerId>
-                        <groupSet>
-                            <item>
-                                <groupId>sg-d3d0f4ce</groupId>
-                                <groupName>puppet-sg</groupName>
-                            </item>
-                        </groupSet>
-                        <instancesSet>
-                            <item>
-                                <instanceId>i-9b70f08e</instanceId>
-                                <imageId>ami-41e85d5c</imageId>
-                                <instanceState>
-                                    <code>16</code>
-                                    <name>running</name>
-                                </instanceState>
-                                <privateDnsName>ip-10-252-20-166.sa-east-1.compute.internal</privateDnsName>
-                                <dnsName>ec2-54-232-4-90.sa-east-1.compute.amazonaws.com</dnsName>
-                                <reason/>
-                                <amiLaunchIndex>0</amiLaunchIndex>
-                                <productCodes/>
-                                <instanceType>c1.medium</instanceType>
-                                <launchTime>2014-10-01T11:58:38.000Z</launchTime>
-                                <placement>
-                                    <availabilityZone>sa-east-1a</availabilityZone>
-                                    <groupName/>
-                                    <tenancy>default</tenancy>
-                                </placement>
-                                <kernelId>aki-5553f448</kernelId>
-                                <monitoring>
-                                    <state>disabled</state>
-                                </monitoring>
-                                <privateIpAddress>10.252.20.166</privateIpAddress>
-                                <ipAddress>54.232.4.90</ipAddress>
-                                <groupSet>
-                                    <item>
-                                        <groupId>sg-d3d0f4ce</groupId>
-                                        <groupName>puppet-sg</groupName>
-                                    </item>
-                                </groupSet>
-                                <architecture>x86_64</architecture>
-                                <rootDeviceType>ebs</rootDeviceType>
-                                <rootDeviceName>/dev/sda1</rootDeviceName>
-                                <blockDeviceMapping>
-                                    <item>
-                                        <deviceName>/dev/sda1</deviceName>
-                                        <ebs>
-                                            <volumeId>vol-2f2d8622</volumeId>
-                                            <status>attached</status>
-                                            <attachTime>2014-10-01T11:58:41.000Z</attachTime>
-                                            <deleteOnTermination>true</deleteOnTermination>
-                                        </ebs>
-                                    </item>
-                                </blockDeviceMapping>
-                                <virtualizationType>paravirtual</virtualizationType>
-                                <clientToken/>
-                                <tagSet>
-                                    <item>
-                                        <key>department</key>
-                                        <value>engineering</value>
-                                    </item>
-                                    <item>
-                                        <key>project</key>
-                                        <value>cloud</value>
-                                    </item>
-                                    <item>
-                                        <key>created_by</key>
-                                        <value>garethr</value>
-                                    </item>
-                                    <item>
-                                        <key>Name</key>
-                                        <value>puppet-1</value>
-                                    </item>
-                                </tagSet>
-                                <hypervisor>xen</hypervisor>
-                                <networkInterfaceSet/>
-                                <ebsOptimized>false</ebsOptimized>
-                            </item>
-                        </instancesSet>
-                    </item>
-                </reservationSet>
-            </DescribeInstancesResponse>
+            <DescribeSubnetsResponse xmlns="http://ec2.amazonaws.com/doc/2014-09-01/">
+                <requestId>bccc46f1-93a5-48cf-91c3-5e8812cb04a4</requestId>
+                <subnetSet>
+                </subnetSet>
+            </DescribeSubnetsResponse>
         http_version: 
-      recorded_at: "Fri, 03 Oct 2014 13:42:56 GMT"
+      recorded_at: "Thu, 07 May 2015 10:47:15 GMT"
     - request: 
         method: post
         uri: "https://ec2.sa-east-1.amazonaws.com/"
         body: 
           encoding: UTF-8
-          string: "AWSAccessKeyId=redacted&Action=DescribeInstances&Filter.1.Name=instance-state-name&Filter.1.Value.1=pending&Filter.1.Value.2=running&Signature=redacted%3D&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-03T13%3A42%3A56Z&Version=2014-06-15"
+          string: "Action=DescribeInstances&Filter.1.Name=instance-state-name&Filter.1.Value.1=pending&Filter.1.Value.2=running&Filter.1.Value.3=stopping&Filter.1.Value.4=stopped&Version=2014-09-01"
         headers: 
           Content-Type: 
             - "application/x-www-form-urlencoded; charset=utf-8"
           Accept-Encoding: 
             - ""
           User-Agent: 
-            - "aws-sdk-ruby2/2.0.1 ruby/2.1.1 x86_64-darwin13.0"
+            - "aws-sdk-ruby2/2.0.5 ruby/2.1.4 x86_64-darwin14.0"
+          X-Amz-Date: 
+            - "20150507T104715Z"
+          Host: 
+            - ec2.sa-east-1.amazonaws.com
+          X-Amz-Content-Sha256: 
+            - "3c4f913045b3ab51b265c5c702a265f74527c4f93cc1ce92140ec283cbd25b40"
+          Authorization: 
+            - "AWS4-HMAC-SHA256 Credential=AKIAJKFCLZAZQRFMXDAA/20150507/sa-east-1/ec2/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=417325a07a39778c900911f4b91b59b6b037f754fc4b3ef133c06977b94d536a"
           Content-Length: 
-            - "301"
+            - "178"
           Accept: 
             - "*/*"
       response: 
@@ -396,342 +88,118 @@
           Vary: 
             - Accept-Encoding
           Date: 
-            - "Fri, 03 Oct 2014 13:42:57 GMT"
+            - "Thu, 07 May 2015 10:47:14 GMT"
           Server: 
             - AmazonEC2
         body: 
           encoding: UTF-8
           string: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <DescribeInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
-                <requestId>5019855b-97c2-4468-89fe-520f40f35a11</requestId>
-                <reservationSet>
-                    <item>
-                        <reservationId>r-1a11ba0f</reservationId>
-                        <ownerId>482693910459</ownerId>
-                        <groupSet>
-                            <item>
-                                <groupId>sg-d5d0f4c8</groupId>
-                                <groupName>web-sg</groupName>
-                            </item>
-                        </groupSet>
-                        <instancesSet>
-                            <item>
-                                <instanceId>i-3171f124</instanceId>
-                                <imageId>ami-41e85d5c</imageId>
-                                <instanceState>
-                                    <code>16</code>
-                                    <name>running</name>
-                                </instanceState>
-                                <privateDnsName>ip-10-252-47-184.sa-east-1.compute.internal</privateDnsName>
-                                <dnsName>ec2-54-207-242-205.sa-east-1.compute.amazonaws.com</dnsName>
-                                <reason/>
-                                <amiLaunchIndex>0</amiLaunchIndex>
-                                <productCodes/>
-                                <instanceType>t1.micro</instanceType>
-                                <launchTime>2014-10-01T12:06:55.000Z</launchTime>
-                                <placement>
-                                    <availabilityZone>sa-east-1a</availabilityZone>
-                                    <groupName/>
-                                    <tenancy>default</tenancy>
-                                </placement>
-                                <kernelId>aki-5553f448</kernelId>
-                                <monitoring>
-                                    <state>disabled</state>
-                                </monitoring>
-                                <privateIpAddress>10.252.47.184</privateIpAddress>
-                                <ipAddress>54.207.242.205</ipAddress>
-                                <groupSet>
-                                    <item>
-                                        <groupId>sg-d5d0f4c8</groupId>
-                                        <groupName>web-sg</groupName>
-                                    </item>
-                                </groupSet>
-                                <architecture>x86_64</architecture>
-                                <rootDeviceType>ebs</rootDeviceType>
-                                <rootDeviceName>/dev/sda1</rootDeviceName>
-                                <blockDeviceMapping>
-                                    <item>
-                                        <deviceName>/dev/sda1</deviceName>
-                                        <ebs>
-                                            <volumeId>vol-cf2d86c2</volumeId>
-                                            <status>attached</status>
-                                            <attachTime>2014-10-01T12:06:57.000Z</attachTime>
-                                            <deleteOnTermination>true</deleteOnTermination>
-                                        </ebs>
-                                    </item>
-                                </blockDeviceMapping>
-                                <virtualizationType>paravirtual</virtualizationType>
-                                <clientToken/>
-                                <tagSet>
-                                    <item>
-                                        <key>project</key>
-                                        <value>cloud</value>
-                                    </item>
-                                    <item>
-                                        <key>Name</key>
-                                        <value>web-2</value>
-                                    </item>
-                                    <item>
-                                        <key>department</key>
-                                        <value>engineering</value>
-                                    </item>
-                                    <item>
-                                        <key>created_by</key>
-                                        <value>garethr</value>
-                                    </item>
-                                </tagSet>
-                                <hypervisor>xen</hypervisor>
-                                <networkInterfaceSet/>
-                                <ebsOptimized>false</ebsOptimized>
-                            </item>
-                        </instancesSet>
-                    </item>
-                    <item>
-                        <reservationId>r-af10bbba</reservationId>
-                        <ownerId>482693910459</ownerId>
-                        <groupSet>
-                            <item>
-                                <groupId>sg-d1d0f4cc</groupId>
-                                <groupName>db-sg</groupName>
-                            </item>
-                        </groupSet>
-                        <instancesSet>
-                            <item>
-                                <instanceId>i-d572f2c0</instanceId>
-                                <imageId>ami-41e85d5c</imageId>
-                                <instanceState>
-                                    <code>16</code>
-                                    <name>running</name>
-                                </instanceState>
-                                <privateDnsName>ip-10-252-22-200.sa-east-1.compute.internal</privateDnsName>
-                                <dnsName>ec2-177-71-132-75.sa-east-1.compute.amazonaws.com</dnsName>
-                                <reason/>
-                                <amiLaunchIndex>0</amiLaunchIndex>
-                                <productCodes/>
-                                <instanceType>t1.micro</instanceType>
-                                <launchTime>2014-10-01T12:07:02.000Z</launchTime>
-                                <placement>
-                                    <availabilityZone>sa-east-1a</availabilityZone>
-                                    <groupName/>
-                                    <tenancy>default</tenancy>
-                                </placement>
-                                <kernelId>aki-5553f448</kernelId>
-                                <monitoring>
-                                    <state>disabled</state>
-                                </monitoring>
-                                <privateIpAddress>10.252.22.200</privateIpAddress>
-                                <ipAddress>177.71.132.75</ipAddress>
-                                <groupSet>
-                                    <item>
-                                        <groupId>sg-d1d0f4cc</groupId>
-                                        <groupName>db-sg</groupName>
-                                    </item>
-                                </groupSet>
-                                <architecture>x86_64</architecture>
-                                <rootDeviceType>ebs</rootDeviceType>
-                                <rootDeviceName>/dev/sda1</rootDeviceName>
-                                <blockDeviceMapping>
-                                    <item>
-                                        <deviceName>/dev/sda1</deviceName>
-                                        <ebs>
-                                            <volumeId>vol-ce2d86c3</volumeId>
-                                            <status>attached</status>
-                                            <attachTime>2014-10-01T12:07:06.000Z</attachTime>
-                                            <deleteOnTermination>true</deleteOnTermination>
-                                        </ebs>
-                                    </item>
-                                </blockDeviceMapping>
-                                <virtualizationType>paravirtual</virtualizationType>
-                                <clientToken/>
-                                <tagSet>
-                                    <item>
-                                        <key>department</key>
-                                        <value>engineering</value>
-                                    </item>
-                                    <item>
-                                        <key>Name</key>
-                                        <value>db-1</value>
-                                    </item>
-                                    <item>
-                                        <key>created_by</key>
-                                        <value>garethr</value>
-                                    </item>
-                                    <item>
-                                        <key>project</key>
-                                        <value>cloud</value>
-                                    </item>
-                                </tagSet>
-                                <hypervisor>xen</hypervisor>
-                                <networkInterfaceSet/>
-                                <ebsOptimized>false</ebsOptimized>
-                            </item>
-                        </instancesSet>
-                    </item>
-                    <item>
-                        <reservationId>r-8f11ba9a</reservationId>
-                        <ownerId>482693910459</ownerId>
-                        <groupSet>
-                            <item>
-                                <groupId>sg-d5d0f4c8</groupId>
-                                <groupName>web-sg</groupName>
-                            </item>
-                        </groupSet>
-                        <instancesSet>
-                            <item>
-                                <instanceId>i-1774f402</instanceId>
-                                <imageId>ami-41e85d5c</imageId>
-                                <instanceState>
-                                    <code>16</code>
-                                    <name>running</name>
-                                </instanceState>
-                                <privateDnsName>ip-10-252-14-59.sa-east-1.compute.internal</privateDnsName>
-                                <dnsName>ec2-54-207-152-222.sa-east-1.compute.amazonaws.com</dnsName>
-                                <reason/>
-                                <amiLaunchIndex>0</amiLaunchIndex>
-                                <productCodes/>
-                                <instanceType>t1.micro</instanceType>
-                                <launchTime>2014-10-01T12:06:56.000Z</launchTime>
-                                <placement>
-                                    <availabilityZone>sa-east-1a</availabilityZone>
-                                    <groupName/>
-                                    <tenancy>default</tenancy>
-                                </placement>
-                                <kernelId>aki-5553f448</kernelId>
-                                <monitoring>
-                                    <state>disabled</state>
-                                </monitoring>
-                                <privateIpAddress>10.252.14.59</privateIpAddress>
-                                <ipAddress>54.207.152.222</ipAddress>
-                                <groupSet>
-                                    <item>
-                                        <groupId>sg-d5d0f4c8</groupId>
-                                        <groupName>web-sg</groupName>
-                                    </item>
-                                </groupSet>
-                                <architecture>x86_64</architecture>
-                                <rootDeviceType>ebs</rootDeviceType>
-                                <rootDeviceName>/dev/sda1</rootDeviceName>
-                                <blockDeviceMapping>
-                                    <item>
-                                        <deviceName>/dev/sda1</deviceName>
-                                        <ebs>
-                                            <volumeId>vol-d32d86de</volumeId>
-                                            <status>attached</status>
-                                            <attachTime>2014-10-01T12:07:01.000Z</attachTime>
-                                            <deleteOnTermination>true</deleteOnTermination>
-                                        </ebs>
-                                    </item>
-                                </blockDeviceMapping>
-                                <virtualizationType>paravirtual</virtualizationType>
-                                <clientToken/>
-                                <tagSet>
-                                    <item>
-                                        <key>project</key>
-                                        <value>cloud</value>
-                                    </item>
-                                    <item>
-                                        <key>department</key>
-                                        <value>engineering</value>
-                                    </item>
-                                    <item>
-                                        <key>created_by</key>
-                                        <value>garethr</value>
-                                    </item>
-                                    <item>
-                                        <key>Name</key>
-                                        <value>web-1</value>
-                                    </item>
-                                </tagSet>
-                                <hypervisor>xen</hypervisor>
-                                <networkInterfaceSet/>
-                                <ebsOptimized>false</ebsOptimized>
-                            </item>
-                        </instancesSet>
-                    </item>
-                    <item>
-                        <reservationId>r-c811badd</reservationId>
-                        <ownerId>482693910459</ownerId>
-                        <groupSet>
-                            <item>
-                                <groupId>sg-d3d0f4ce</groupId>
-                                <groupName>puppet-sg</groupName>
-                            </item>
-                        </groupSet>
-                        <instancesSet>
-                            <item>
-                                <instanceId>i-9b70f08e</instanceId>
-                                <imageId>ami-41e85d5c</imageId>
-                                <instanceState>
-                                    <code>16</code>
-                                    <name>running</name>
-                                </instanceState>
-                                <privateDnsName>ip-10-252-20-166.sa-east-1.compute.internal</privateDnsName>
-                                <dnsName>ec2-54-232-4-90.sa-east-1.compute.amazonaws.com</dnsName>
-                                <reason/>
-                                <amiLaunchIndex>0</amiLaunchIndex>
-                                <productCodes/>
-                                <instanceType>c1.medium</instanceType>
-                                <launchTime>2014-10-01T11:58:38.000Z</launchTime>
-                                <placement>
-                                    <availabilityZone>sa-east-1a</availabilityZone>
-                                    <groupName/>
-                                    <tenancy>default</tenancy>
-                                </placement>
-                                <kernelId>aki-5553f448</kernelId>
-                                <monitoring>
-                                    <state>disabled</state>
-                                </monitoring>
-                                <privateIpAddress>10.252.20.166</privateIpAddress>
-                                <ipAddress>54.232.4.90</ipAddress>
-                                <groupSet>
-                                    <item>
-                                        <groupId>sg-d3d0f4ce</groupId>
-                                        <groupName>puppet-sg</groupName>
-                                    </item>
-                                </groupSet>
-                                <architecture>x86_64</architecture>
-                                <rootDeviceType>ebs</rootDeviceType>
-                                <rootDeviceName>/dev/sda1</rootDeviceName>
-                                <blockDeviceMapping>
-                                    <item>
-                                        <deviceName>/dev/sda1</deviceName>
-                                        <ebs>
-                                            <volumeId>vol-2f2d8622</volumeId>
-                                            <status>attached</status>
-                                            <attachTime>2014-10-01T11:58:41.000Z</attachTime>
-                                            <deleteOnTermination>true</deleteOnTermination>
-                                        </ebs>
-                                    </item>
-                                </blockDeviceMapping>
-                                <virtualizationType>paravirtual</virtualizationType>
-                                <clientToken/>
-                                <tagSet>
-                                    <item>
-                                        <key>department</key>
-                                        <value>engineering</value>
-                                    </item>
-                                    <item>
-                                        <key>project</key>
-                                        <value>cloud</value>
-                                    </item>
-                                    <item>
-                                        <key>created_by</key>
-                                        <value>garethr</value>
-                                    </item>
-                                    <item>
-                                        <key>Name</key>
-                                        <value>puppet-1</value>
-                                    </item>
-                                </tagSet>
-                                <hypervisor>xen</hypervisor>
-                                <networkInterfaceSet/>
-                                <ebsOptimized>false</ebsOptimized>
-                            </item>
-                        </instancesSet>
-                    </item>
-                </reservationSet>
+            <DescribeInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2014-09-01/">
+                <requestId>b2db17bc-6098-4ace-a53e-0aaec30f65a8</requestId>
+                <reservationSet/>
             </DescribeInstancesResponse>
         http_version: 
-      recorded_at: "Fri, 03 Oct 2014 13:42:57 GMT"
+      recorded_at: "Thu, 07 May 2015 10:47:15 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "Action=DescribeSubnets&Version=2014-09-01"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.5 ruby/2.1.4 x86_64-darwin14.0"
+          X-Amz-Date: 
+            - "20150507T104715Z"
+          Host: 
+            - ec2.sa-east-1.amazonaws.com
+          X-Amz-Content-Sha256: 
+            - "3a82620a58eb8a58f422b0762600796f48166b8ce93cb23e176e8d65d498f8c8"
+          Authorization: 
+            - "AWS4-HMAC-SHA256 Credential=AKIAJKFCLZAZQRFMXDAA/20150507/sa-east-1/ec2/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=8d7b66b7271a65519449e9fad67b17c9171c5986282a968eb49f13835df958e4"
+          Content-Length: 
+            - "41"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Thu, 07 May 2015 10:47:16 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeSubnetsResponse xmlns="http://ec2.amazonaws.com/doc/2014-09-01/">
+                <requestId>ae6615a7-01a4-4896-8019-03e2d1d25ddf</requestId>
+                <subnetSet>
+                </subnetSet>
+            </DescribeSubnetsResponse>
+        http_version: 
+      recorded_at: "Thu, 07 May 2015 10:47:16 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "Action=DescribeInstances&Filter.1.Name=instance-state-name&Filter.1.Value.1=pending&Filter.1.Value.2=running&Filter.1.Value.3=stopping&Filter.1.Value.4=stopped&Version=2014-09-01"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.5 ruby/2.1.4 x86_64-darwin14.0"
+          X-Amz-Date: 
+            - "20150507T104716Z"
+          Host: 
+            - ec2.sa-east-1.amazonaws.com
+          X-Amz-Content-Sha256: 
+            - "3c4f913045b3ab51b265c5c702a265f74527c4f93cc1ce92140ec283cbd25b40"
+          Authorization: 
+            - "AWS4-HMAC-SHA256 Credential=AKIAJKFCLZAZQRFMXDAA/20150507/sa-east-1/ec2/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=5c22ded9c3d450eacc36537e851b991ba3a2a0ac93b2f83aaa7784c23ab79161"
+          Content-Length: 
+            - "178"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Thu, 07 May 2015 10:47:17 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2014-09-01/">
+                <requestId>814fd8ab-7206-4dc2-8a66-b8319d2d924a</requestId>
+                <reservationSet/>
+            </DescribeInstancesResponse>
+        http_version: 
+      recorded_at: "Thu, 07 May 2015 10:47:17 GMT"
   recorded_with: "VCR 2.9.3"

--- a/fixtures/vcr_cassettes/instance-with-name.yml
+++ b/fixtures/vcr_cassettes/instance-with-name.yml
@@ -5,16 +5,24 @@
         uri: "https://ec2.sa-east-1.amazonaws.com/"
         body: 
           encoding: UTF-8
-          string: "AWSAccessKeyId=redacted&Action=DescribeInstances&Filter.1.Name=instance-state-name&Filter.1.Value.1=pending&Filter.1.Value.2=running&Signature=redacted&SignatureMethod=HmacSHA256&SignatureVersion=2&Timestamp=2014-10-03T13%3A44%3A24Z&Version=2014-06-15"
+          string: "Action=DescribeSubnets&Version=2014-09-01"
         headers: 
           Content-Type: 
             - "application/x-www-form-urlencoded; charset=utf-8"
           Accept-Encoding: 
             - ""
           User-Agent: 
-            - "aws-sdk-ruby2/2.0.1 ruby/2.1.1 x86_64-darwin13.0"
+            - "aws-sdk-ruby2/2.0.5 ruby/2.0.0 universal.x86_64-darwin14"
+          X-Amz-Date: 
+            - "20150507T105423Z"
+          Host: 
+            - ec2.sa-east-1.amazonaws.com
+          X-Amz-Content-Sha256: 
+            - "3a82620a58eb8a58f422b0762600796f48166b8ce93cb23e176e8d65d498f8c8"
+          Authorization: 
+            - "AWS4-HMAC-SHA256 Credential=redacted/20150507/sa-east-1/ec2/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=2cd0e3f37abe226807bbaa076fd1f9542759b0acc673caec6cce0d588e34a600"
           Content-Length: 
-            - "303"
+            - "41"
           Accept: 
             - "*/*"
       response: 
@@ -29,40 +37,91 @@
           Vary: 
             - Accept-Encoding
           Date: 
-            - "Fri, 03 Oct 2014 13:44:24 GMT"
+            - "Thu, 07 May 2015 10:54:24 GMT"
           Server: 
             - AmazonEC2
         body: 
           encoding: UTF-8
           string: |-
             <?xml version="1.0" encoding="UTF-8"?>
-            <DescribeInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2014-06-15/">
-                <requestId>47d0a928-da42-4d4e-bcaf-dfe34d04f713</requestId>
+            <DescribeSubnetsResponse xmlns="http://ec2.amazonaws.com/doc/2014-09-01/">
+                <requestId>3bf79060-1ad5-4a8b-899c-c5e99a3f7182</requestId>
+                <subnetSet>
+                </subnetSet>
+            </DescribeSubnetsResponse>
+        http_version: 
+      recorded_at: "Thu, 07 May 2015 10:54:25 GMT"
+    - request: 
+        method: post
+        uri: "https://ec2.sa-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "Action=DescribeInstances&Filter.1.Name=instance-state-name&Filter.1.Value.1=pending&Filter.1.Value.2=running&Filter.1.Value.3=stopping&Filter.1.Value.4=stopped&Version=2014-09-01"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.5 ruby/2.0.0 universal.x86_64-darwin14"
+          X-Amz-Date: 
+            - "20150507T105425Z"
+          Host: 
+            - ec2.sa-east-1.amazonaws.com
+          X-Amz-Content-Sha256: 
+            - "3c4f913045b3ab51b265c5c702a265f74527c4f93cc1ce92140ec283cbd25b40"
+          Authorization: 
+            - "AWS4-HMAC-SHA256 Credential=redacted/20150507/sa-east-1/ec2/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=2cc4804317846d2f9b6cd7ea8732c29173e8e33bd861df16f4fe2dd734341745"
+          Content-Length: 
+            - "178"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Content-Type: 
+            - "text/xml;charset=UTF-8"
+          Transfer-Encoding: 
+            - chunked
+          Vary: 
+            - Accept-Encoding
+          Date: 
+            - "Thu, 07 May 2015 10:54:25 GMT"
+          Server: 
+            - AmazonEC2
+        body: 
+          encoding: UTF-8
+          string: |-
+            <?xml version="1.0" encoding="UTF-8"?>
+            <DescribeInstancesResponse xmlns="http://ec2.amazonaws.com/doc/2014-09-01/">
+                <requestId>3f367f83-9367-4856-9995-e5ad3fb845ea</requestId>
                 <reservationSet>
                     <item>
-                        <reservationId>r-1a11ba0f</reservationId>
+                        <reservationId>r-6d5c7678</reservationId>
                         <ownerId>482693910459</ownerId>
                         <groupSet>
                             <item>
-                                <groupId>sg-d5d0f4c8</groupId>
-                                <groupName>web-sg</groupName>
+                                <groupId>sg-2e409f33</groupId>
+                                <groupName>default</groupName>
                             </item>
                         </groupSet>
                         <instancesSet>
                             <item>
-                                <instanceId>i-3171f124</instanceId>
-                                <imageId>ami-41e85d5c</imageId>
+                                <instanceId>i-af73c84c</instanceId>
+                                <imageId>ami-67a60d7a</imageId>
                                 <instanceState>
                                     <code>16</code>
                                     <name>running</name>
                                 </instanceState>
-                                <privateDnsName>ip-10-252-47-184.sa-east-1.compute.internal</privateDnsName>
-                                <dnsName>ec2-54-207-242-205.sa-east-1.compute.amazonaws.com</dnsName>
+                                <privateDnsName>ip-10-252-11-115.sa-east-1.compute.internal</privateDnsName>
+                                <dnsName>ec2-54-94-82-64.sa-east-1.compute.amazonaws.com</dnsName>
                                 <reason/>
                                 <amiLaunchIndex>0</amiLaunchIndex>
                                 <productCodes/>
                                 <instanceType>t1.micro</instanceType>
-                                <launchTime>2014-10-01T12:06:55.000Z</launchTime>
+                                <launchTime>2015-04-16T10:04:42.000Z</launchTime>
                                 <placement>
                                     <availabilityZone>sa-east-1a</availabilityZone>
                                     <groupName/>
@@ -72,12 +131,12 @@
                                 <monitoring>
                                     <state>disabled</state>
                                 </monitoring>
-                                <privateIpAddress>10.252.47.184</privateIpAddress>
-                                <ipAddress>54.207.242.205</ipAddress>
+                                <privateIpAddress>10.252.11.115</privateIpAddress>
+                                <ipAddress>54.94.82.64</ipAddress>
                                 <groupSet>
                                     <item>
-                                        <groupId>sg-d5d0f4c8</groupId>
-                                        <groupName>web-sg</groupName>
+                                        <groupId>sg-2e409f33</groupId>
+                                        <groupName>default</groupName>
                                     </item>
                                 </groupSet>
                                 <architecture>x86_64</architecture>
@@ -87,90 +146,9 @@
                                     <item>
                                         <deviceName>/dev/sda1</deviceName>
                                         <ebs>
-                                            <volumeId>vol-cf2d86c2</volumeId>
+                                            <volumeId>vol-a9e64eb5</volumeId>
                                             <status>attached</status>
-                                            <attachTime>2014-10-01T12:06:57.000Z</attachTime>
-                                            <deleteOnTermination>true</deleteOnTermination>
-                                        </ebs>
-                                    </item>
-                                </blockDeviceMapping>
-                                <virtualizationType>paravirtual</virtualizationType>
-                                <clientToken/>
-                                <tagSet>
-                                    <item>
-                                        <key>project</key>
-                                        <value>cloud</value>
-                                    </item>
-                                    <item>
-                                        <key>Name</key>
-                                        <value>web-2</value>
-                                    </item>
-                                    <item>
-                                        <key>department</key>
-                                        <value>engineering</value>
-                                    </item>
-                                    <item>
-                                        <key>created_by</key>
-                                        <value>garethr</value>
-                                    </item>
-                                </tagSet>
-                                <hypervisor>xen</hypervisor>
-                                <networkInterfaceSet/>
-                                <ebsOptimized>false</ebsOptimized>
-                            </item>
-                        </instancesSet>
-                    </item>
-                    <item>
-                        <reservationId>r-af10bbba</reservationId>
-                        <ownerId>482693910459</ownerId>
-                        <groupSet>
-                            <item>
-                                <groupId>sg-d1d0f4cc</groupId>
-                                <groupName>db-sg</groupName>
-                            </item>
-                        </groupSet>
-                        <instancesSet>
-                            <item>
-                                <instanceId>i-d572f2c0</instanceId>
-                                <imageId>ami-41e85d5c</imageId>
-                                <instanceState>
-                                    <code>16</code>
-                                    <name>running</name>
-                                </instanceState>
-                                <privateDnsName>ip-10-252-22-200.sa-east-1.compute.internal</privateDnsName>
-                                <dnsName>ec2-177-71-132-75.sa-east-1.compute.amazonaws.com</dnsName>
-                                <reason/>
-                                <amiLaunchIndex>0</amiLaunchIndex>
-                                <productCodes/>
-                                <instanceType>t1.micro</instanceType>
-                                <launchTime>2014-10-01T12:07:02.000Z</launchTime>
-                                <placement>
-                                    <availabilityZone>sa-east-1a</availabilityZone>
-                                    <groupName/>
-                                    <tenancy>default</tenancy>
-                                </placement>
-                                <kernelId>aki-5553f448</kernelId>
-                                <monitoring>
-                                    <state>disabled</state>
-                                </monitoring>
-                                <privateIpAddress>10.252.22.200</privateIpAddress>
-                                <ipAddress>177.71.132.75</ipAddress>
-                                <groupSet>
-                                    <item>
-                                        <groupId>sg-d1d0f4cc</groupId>
-                                        <groupName>db-sg</groupName>
-                                    </item>
-                                </groupSet>
-                                <architecture>x86_64</architecture>
-                                <rootDeviceType>ebs</rootDeviceType>
-                                <rootDeviceName>/dev/sda1</rootDeviceName>
-                                <blockDeviceMapping>
-                                    <item>
-                                        <deviceName>/dev/sda1</deviceName>
-                                        <ebs>
-                                            <volumeId>vol-ce2d86c3</volumeId>
-                                            <status>attached</status>
-                                            <attachTime>2014-10-01T12:07:06.000Z</attachTime>
+                                            <attachTime>2015-04-16T10:04:45.000Z</attachTime>
                                             <deleteOnTermination>true</deleteOnTermination>
                                         </ebs>
                                     </item>
@@ -183,178 +161,16 @@
                                         <value>engineering</value>
                                     </item>
                                     <item>
-                                        <key>Name</key>
-                                        <value>db-1</value>
-                                    </item>
-                                    <item>
                                         <key>created_by</key>
-                                        <value>garethr</value>
-                                    </item>
-                                    <item>
-                                        <key>project</key>
-                                        <value>cloud</value>
-                                    </item>
-                                </tagSet>
-                                <hypervisor>xen</hypervisor>
-                                <networkInterfaceSet/>
-                                <ebsOptimized>false</ebsOptimized>
-                            </item>
-                        </instancesSet>
-                    </item>
-                    <item>
-                        <reservationId>r-8f11ba9a</reservationId>
-                        <ownerId>482693910459</ownerId>
-                        <groupSet>
-                            <item>
-                                <groupId>sg-d5d0f4c8</groupId>
-                                <groupName>web-sg</groupName>
-                            </item>
-                        </groupSet>
-                        <instancesSet>
-                            <item>
-                                <instanceId>i-1774f402</instanceId>
-                                <imageId>ami-41e85d5c</imageId>
-                                <instanceState>
-                                    <code>16</code>
-                                    <name>running</name>
-                                </instanceState>
-                                <privateDnsName>ip-10-252-14-59.sa-east-1.compute.internal</privateDnsName>
-                                <dnsName>ec2-54-207-152-222.sa-east-1.compute.amazonaws.com</dnsName>
-                                <reason/>
-                                <amiLaunchIndex>0</amiLaunchIndex>
-                                <productCodes/>
-                                <instanceType>t1.micro</instanceType>
-                                <launchTime>2014-10-01T12:06:56.000Z</launchTime>
-                                <placement>
-                                    <availabilityZone>sa-east-1a</availabilityZone>
-                                    <groupName/>
-                                    <tenancy>default</tenancy>
-                                </placement>
-                                <kernelId>aki-5553f448</kernelId>
-                                <monitoring>
-                                    <state>disabled</state>
-                                </monitoring>
-                                <privateIpAddress>10.252.14.59</privateIpAddress>
-                                <ipAddress>54.207.152.222</ipAddress>
-                                <groupSet>
-                                    <item>
-                                        <groupId>sg-d5d0f4c8</groupId>
-                                        <groupName>web-sg</groupName>
-                                    </item>
-                                </groupSet>
-                                <architecture>x86_64</architecture>
-                                <rootDeviceType>ebs</rootDeviceType>
-                                <rootDeviceName>/dev/sda1</rootDeviceName>
-                                <blockDeviceMapping>
-                                    <item>
-                                        <deviceName>/dev/sda1</deviceName>
-                                        <ebs>
-                                            <volumeId>vol-d32d86de</volumeId>
-                                            <status>attached</status>
-                                            <attachTime>2014-10-01T12:07:01.000Z</attachTime>
-                                            <deleteOnTermination>true</deleteOnTermination>
-                                        </ebs>
-                                    </item>
-                                </blockDeviceMapping>
-                                <virtualizationType>paravirtual</virtualizationType>
-                                <clientToken/>
-                                <tagSet>
-                                    <item>
-                                        <key>project</key>
-                                        <value>cloud</value>
-                                    </item>
-                                    <item>
-                                        <key>department</key>
-                                        <value>engineering</value>
-                                    </item>
-                                    <item>
-                                        <key>created_by</key>
-                                        <value>garethr</value>
-                                    </item>
-                                    <item>
-                                        <key>Name</key>
-                                        <value>web-1</value>
-                                    </item>
-                                </tagSet>
-                                <hypervisor>xen</hypervisor>
-                                <networkInterfaceSet/>
-                                <ebsOptimized>false</ebsOptimized>
-                            </item>
-                        </instancesSet>
-                    </item>
-                    <item>
-                        <reservationId>r-c811badd</reservationId>
-                        <ownerId>482693910459</ownerId>
-                        <groupSet>
-                            <item>
-                                <groupId>sg-d3d0f4ce</groupId>
-                                <groupName>puppet-sg</groupName>
-                            </item>
-                        </groupSet>
-                        <instancesSet>
-                            <item>
-                                <instanceId>i-9b70f08e</instanceId>
-                                <imageId>ami-41e85d5c</imageId>
-                                <instanceState>
-                                    <code>16</code>
-                                    <name>running</name>
-                                </instanceState>
-                                <privateDnsName>ip-10-252-20-166.sa-east-1.compute.internal</privateDnsName>
-                                <dnsName>ec2-54-232-4-90.sa-east-1.compute.amazonaws.com</dnsName>
-                                <reason/>
-                                <amiLaunchIndex>0</amiLaunchIndex>
-                                <productCodes/>
-                                <instanceType>c1.medium</instanceType>
-                                <launchTime>2014-10-01T11:58:38.000Z</launchTime>
-                                <placement>
-                                    <availabilityZone>sa-east-1a</availabilityZone>
-                                    <groupName/>
-                                    <tenancy>default</tenancy>
-                                </placement>
-                                <kernelId>aki-5553f448</kernelId>
-                                <monitoring>
-                                    <state>disabled</state>
-                                </monitoring>
-                                <privateIpAddress>10.252.20.166</privateIpAddress>
-                                <ipAddress>54.232.4.90</ipAddress>
-                                <groupSet>
-                                    <item>
-                                        <groupId>sg-d3d0f4ce</groupId>
-                                        <groupName>puppet-sg</groupName>
-                                    </item>
-                                </groupSet>
-                                <architecture>x86_64</architecture>
-                                <rootDeviceType>ebs</rootDeviceType>
-                                <rootDeviceName>/dev/sda1</rootDeviceName>
-                                <blockDeviceMapping>
-                                    <item>
-                                        <deviceName>/dev/sda1</deviceName>
-                                        <ebs>
-                                            <volumeId>vol-2f2d8622</volumeId>
-                                            <status>attached</status>
-                                            <attachTime>2014-10-01T11:58:41.000Z</attachTime>
-                                            <deleteOnTermination>true</deleteOnTermination>
-                                        </ebs>
-                                    </item>
-                                </blockDeviceMapping>
-                                <virtualizationType>paravirtual</virtualizationType>
-                                <clientToken/>
-                                <tagSet>
-                                    <item>
-                                        <key>department</key>
-                                        <value>engineering</value>
+                                        <value>aws-acceptance</value>
                                     </item>
                                     <item>
                                         <key>project</key>
                                         <value>cloud</value>
                                     </item>
                                     <item>
-                                        <key>created_by</key>
-                                        <value>garethr</value>
-                                    </item>
-                                    <item>
                                         <key>Name</key>
-                                        <value>puppet-1</value>
+                                        <value>1.0.0-b20125-82db3311-ddc2fbf2-6b37-4304-b62b-a72e03f71dde</value>
                                     </item>
                                 </tagSet>
                                 <hypervisor>xen</hypervisor>
@@ -366,5 +182,5 @@
                 </reservationSet>
             </DescribeInstancesResponse>
         http_version: 
-      recorded_at: "Fri, 03 Oct 2014 13:44:25 GMT"
+      recorded_at: "Thu, 07 May 2015 10:54:26 GMT"
   recorded_with: "VCR 2.9.3"

--- a/lib/puppet/provider/cloudwatch_alarm/v2.rb
+++ b/lib/puppet/provider/cloudwatch_alarm/v2.rb
@@ -54,8 +54,7 @@ Puppet::Type.type(:cloudwatch_alarm).provide(:v2, :parent => PuppetX::Puppetlabs
   end
 
   def exists?
-    dest_region = resource[:region] if resource
-    Puppet.info("Checking if alarm #{name} exists in region #{dest_region || region}")
+    Puppet.info("Checking if alarm #{name} exists in region #{target_region}")
     @property_hash[:ensure] == :present
   end
 
@@ -103,8 +102,8 @@ Puppet::Type.type(:cloudwatch_alarm).provide(:v2, :parent => PuppetX::Puppetlabs
   end
 
   def destroy
-    Puppet.info("Deleting alarm #{name} in region #{resource[:region]}")
-    cloudwatch_client(resource[:region]).delete_alarms(
+    Puppet.info("Deleting alarm #{name} in region #{target_region}")
+    cloudwatch_client(target_region).delete_alarms(
       alarm_names: [name],
     )
     @property_hash[:ensure] = :absent

--- a/lib/puppet/provider/ec2_scalingpolicy/v2.rb
+++ b/lib/puppet/provider/ec2_scalingpolicy/v2.rb
@@ -44,19 +44,18 @@ Puppet::Type.type(:ec2_scalingpolicy).provide(:v2, :parent => PuppetX::Puppetlab
   end
 
   def exists?
-    dest_region = resource[:region] if resource
-    Puppet.info("Checking if scaling policy #{name} exists in region #{dest_region || region}")
+    Puppet.info("Checking if scaling policy #{name} exists in region #{target_region}")
     @property_hash[:ensure] == :present
   end
 
   def create
-    Puppet.info("Creating scaling policy #{name} in region #{resource[:region]}")
+    Puppet.info("Creating scaling policy #{name} in region #{target_region}")
     update
     @property_hash[:ensure] = :present
   end
 
   def update
-    autoscaling_client(resource[:region]).put_scaling_policy(
+    autoscaling_client(target_region).put_scaling_policy(
       policy_name: name,
       auto_scaling_group_name: resource[:auto_scaling_group],
       scaling_adjustment: resource[:scaling_adjustment],
@@ -69,12 +68,11 @@ Puppet::Type.type(:ec2_scalingpolicy).provide(:v2, :parent => PuppetX::Puppetlab
   end
 
   def destroy
-    Puppet.info("Deleting scaling policy #{name} in region #{resource[:region]}")
-    autoscaling_client(resource[:region]).delete_policy(
+    Puppet.info("Deleting scaling policy #{name} in region #{target_region}")
+    autoscaling_client(target_region).delete_policy(
       auto_scaling_group_name: resource[:auto_scaling_group],
       policy_name: name,
     )
     @property_hash[:ensure] = :absent
   end
 end
-

--- a/lib/puppet/provider/ec2_vpc/v2.rb
+++ b/lib/puppet/provider/ec2_vpc/v2.rb
@@ -34,14 +34,6 @@ Puppet::Type.type(:ec2_vpc).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) do
   end
 
   def self.vpc_to_hash(region, vpc)
-    options_name = unless vpc.dhcp_options_id.nil? || vpc.dhcp_options_id.empty?
-      response = ec2_client(region).describe_dhcp_options(
-        dhcp_options_ids: [vpc.dhcp_options_id]
-      )
-      name_from_tag(response.dhcp_options.first)
-    else
-      nil
-    end
     {
       name: name_from_tag(vpc),
       id: vpc.vpc_id,
@@ -50,19 +42,18 @@ Puppet::Type.type(:ec2_vpc).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) do
       ensure: :present,
       region: region,
       tags: tags_for(vpc),
-      dhcp_options: options_name,
+      dhcp_options: options_name_from_id(region, vpc.dhcp_options_id),
     }
   end
 
   def exists?
-    dest_region = resource[:region] if resource
-    Puppet.info("Checking if VPC #{name} exists in #{dest_region || region}")
+    Puppet.info("Checking if VPC #{name} exists in #{target_region}")
     @property_hash[:ensure] == :present
   end
 
   def create
-    Puppet.info("Creating VPC #{name}")
-    ec2 = ec2_client(resource[:region])
+    Puppet.info("Creating VPC #{name} in #{target_region}")
+    ec2 = ec2_client(target_region)
     response = ec2.create_vpc(
       cidr_block: resource[:cidr_block],
       instance_tenancy: resource[:instance_tenancy]
@@ -103,9 +94,8 @@ Puppet::Type.type(:ec2_vpc).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) do
   end
 
   def destroy
-    region = @property_hash[:region]
-    Puppet.info("Deleting VPC #{name} in #{region}")
-    ec2_client(region).delete_vpc(
+    Puppet.info("Deleting VPC #{name} in #{target_region}")
+    ec2_client(target_region).delete_vpc(
       vpc_id: @property_hash[:id]
     )
     @property_hash[:ensure] = :absent

--- a/lib/puppet/provider/ec2_vpc/v2.rb
+++ b/lib/puppet/provider/ec2_vpc/v2.rb
@@ -34,8 +34,10 @@ Puppet::Type.type(:ec2_vpc).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) do
   end
 
   def self.vpc_to_hash(region, vpc)
+    name = name_from_tag(vpc)
+    return {} unless name
     {
-      name: name_from_tag(vpc),
+      name: name,
       id: vpc.vpc_id,
       cidr_block: vpc.cidr_block,
       instance_tenancy: vpc.instance_tenancy,

--- a/lib/puppet/provider/ec2_vpc_customer_gateway/v2.rb
+++ b/lib/puppet/provider/ec2_vpc_customer_gateway/v2.rb
@@ -49,14 +49,13 @@ Puppet::Type.type(:ec2_vpc_customer_gateway).provide(:v2, :parent => PuppetX::Pu
   end
 
   def exists?
-    dest_region = resource[:region] if resource
-    Puppet.info("Checking if Customer gateway #{name} exists in #{dest_region || region}")
+    Puppet.info("Checking if Customer gateway #{name} exists in #{target_region}")
     @property_hash[:ensure] == :present
   end
 
   def create
-    Puppet.info("Creating Customer gateway #{name} in #{resource[:region]}")
-    ec2 = ec2_client(resource[:region])
+    Puppet.info("Creating Customer gateway #{name} in #{target_region}")
+    ec2 = ec2_client(target_region)
 
     response = ec2.create_customer_gateway(
       type: resource[:type],
@@ -75,12 +74,10 @@ Puppet::Type.type(:ec2_vpc_customer_gateway).provide(:v2, :parent => PuppetX::Pu
   end
 
   def destroy
-    region = @property_hash[:region]
-    Puppet.info("Destroying Customer gateway #{name} in #{region}")
-    ec2_client(region).delete_customer_gateway(
+    Puppet.info("Destroying Customer gateway #{name} in #{target_region}")
+    ec2_client(target_region).delete_customer_gateway(
       customer_gateway_id: @property_hash[:id]
     )
     @property_hash[:ensure] = :absent
   end
 end
-

--- a/lib/puppet/provider/ec2_vpc_dhcp_options/v2.rb
+++ b/lib/puppet/provider/ec2_vpc_dhcp_options/v2.rb
@@ -55,14 +55,13 @@ Puppet::Type.type(:ec2_vpc_dhcp_options).provide(:v2, :parent => PuppetX::Puppet
   end
 
   def exists?
-    dest_region = resource[:region] if resource
-    Puppet.info("Checking if DHCP options #{name} exists in region #{dest_region || region}")
+    Puppet.info("Checking if DHCP options #{name} exists in region #{target_region}")
     @property_hash[:ensure] == :present
   end
 
   def create
-    Puppet.info("Creating DHCP options #{name} in region #{resource[:region]}")
-    ec2 = ec2_client(resource[:region])
+    Puppet.info("Creating DHCP options #{name} in region #{target_region}")
+    ec2 = ec2_client(target_region)
 
     options = []
     ['domain_name', 'ntp_servers', 'domain_name_servers', 'netbios_name_servers', 'netbios_node_type'].each do |key|
@@ -85,12 +84,10 @@ Puppet::Type.type(:ec2_vpc_dhcp_options).provide(:v2, :parent => PuppetX::Puppet
   end
 
   def destroy
-    region = @property_hash[:region]
-    Puppet.info("Destroying DHCP options #{name} in #{region}")
-    ec2_client(region).delete_dhcp_options(
+    Puppet.info("Destroying DHCP options #{name} in #{target_region}")
+    ec2_client(target_region).delete_dhcp_options(
       dhcp_options_id: @property_hash[:id]
     )
     @property_hash[:ensure] = :absent
   end
 end
-

--- a/lib/puppet/provider/ec2_vpc_internet_gateway/v2.rb
+++ b/lib/puppet/provider/ec2_vpc_internet_gateway/v2.rb
@@ -35,6 +35,7 @@ Puppet::Type.type(:ec2_vpc_internet_gateway).provide(:v2, :parent => PuppetX::Pu
 
   def self.gateway_to_hash(region, gateway)
     assigned_name = name_from_tag(gateway)
+    return {} unless assigned_name
     vpc_name = nil
     vpc_id = nil
     if assigned_name

--- a/lib/puppet/provider/ec2_vpc_routetable/v2.rb
+++ b/lib/puppet/provider/ec2_vpc_routetable/v2.rb
@@ -43,11 +43,13 @@ Puppet::Type.type(:ec2_vpc_routetable).provide(:v2, :parent => PuppetX::Puppetla
   end
 
   def self.route_table_to_hash(region, table)
+    name = name_from_tag(table)
+    return {} unless name
     routes = table.routes.collect do |route|
       route_to_hash(region, route)
     end.compact
     {
-      name: name_from_tag(table),
+      name: name,
       id: table.route_table_id,
       vpc: vpc_name_from_id(region, table.vpc_id),
       ensure: :present,

--- a/lib/puppet/provider/ec2_vpc_subnet/v2.rb
+++ b/lib/puppet/provider/ec2_vpc_subnet/v2.rb
@@ -34,6 +34,8 @@ Puppet::Type.type(:ec2_vpc_subnet).provide(:v2, :parent => PuppetX::Puppetlabs::
   end
 
   def self.subnet_to_hash(region, subnet)
+    name = name_from_tag(subnet)
+    return {} unless name
     ec2 = ec2_client(region)
     table_response = ec2.describe_route_tables(filters: [
       {name: 'association.subnet-id', values: [subnet.subnet_id]},
@@ -42,8 +44,8 @@ Puppet::Type.type(:ec2_vpc_subnet).provide(:v2, :parent => PuppetX::Puppetlabs::
     table_name = table_response.data.route_tables.empty? ? nil : name_from_tag(table_response.data.route_tables.first)
 
     {
-      name: name_from_tag(subnet),
-      route_table: table_name_tag ? table_name_tag.value : nil,
+      name: name,
+      route_table: table_name,
       id: subnet.subnet_id,
       cidr_block: subnet.cidr_block,
       availability_zone: subnet.availability_zone,

--- a/lib/puppet/provider/ec2_vpc_subnet/v2.rb
+++ b/lib/puppet/provider/ec2_vpc_subnet/v2.rb
@@ -35,15 +35,11 @@ Puppet::Type.type(:ec2_vpc_subnet).provide(:v2, :parent => PuppetX::Puppetlabs::
 
   def self.subnet_to_hash(region, subnet)
     ec2 = ec2_client(region)
-    vpc_response = ec2.describe_vpcs(vpc_ids: [subnet.vpc_id])
-    vpc_name_tag = vpc_response.data.vpcs.first.tags.detect { |tag| tag.key == 'Name' }
-
     table_response = ec2.describe_route_tables(filters: [
       {name: 'association.subnet-id', values: [subnet.subnet_id]},
       {name: 'vpc-id', values: [subnet.vpc_id]},
     ])
-    tables = table_response.data.route_tables
-    table_name_tag = tables.empty? ? nil : tables.first.tags.detect { |tag| tag.key == 'Name' }
+    table_name = table_response.data.route_tables.empty? ? nil : name_from_tag(table_response.data.route_tables.first)
 
     {
       name: name_from_tag(subnet),
@@ -51,7 +47,7 @@ Puppet::Type.type(:ec2_vpc_subnet).provide(:v2, :parent => PuppetX::Puppetlabs::
       id: subnet.subnet_id,
       cidr_block: subnet.cidr_block,
       availability_zone: subnet.availability_zone,
-      vpc: vpc_name_tag ? vpc_name_tag.value : nil,
+      vpc: vpc_name_from_id(region, subnet.vpc_id),
       ensure: :present,
       region: region,
       map_public_ip_on_launch: subnet.map_public_ip_on_launch,
@@ -60,14 +56,13 @@ Puppet::Type.type(:ec2_vpc_subnet).provide(:v2, :parent => PuppetX::Puppetlabs::
   end
 
   def exists?
-    dest_region = resource[:region] if resource
-    Puppet.info("Checking if subnet #{name} exists in #{dest_region || region }")
+    Puppet.info("Checking if subnet #{name} exists in #{target_region}")
     @property_hash[:ensure] == :present
   end
 
   def create
-    Puppet.info("Creating subnet #{name}")
-    ec2 = ec2_client(resource[:region])
+    Puppet.info("Creating subnet #{name} in #{target_region}")
+    ec2 = ec2_client(target_region)
     vpc_response = ec2.describe_vpcs(filters: [
       {name: "tag:Name", values: [resource[:vpc]]},
     ])
@@ -106,9 +101,8 @@ Puppet::Type.type(:ec2_vpc_subnet).provide(:v2, :parent => PuppetX::Puppetlabs::
   end
 
   def destroy
-    region = @property_hash[:region]
-    Puppet.info("Deleting subnet #{name} in #{region}")
-    ec2_client(region).delete_subnet(
+    Puppet.info("Deleting subnet #{name} in #{target_region}")
+    ec2_client(target_region).delete_subnet(
       subnet_id: @property_hash[:id]
     )
     @property_hash[:ensure] = :absent

--- a/lib/puppet/provider/ec2_vpc_vpn/v2.rb
+++ b/lib/puppet/provider/ec2_vpc_vpn/v2.rb
@@ -37,6 +37,9 @@ Puppet::Type.type(:ec2_vpc_vpn).provide(:v2, :parent => PuppetX::Puppetlabs::Aws
   end
 
   def self.connection_to_hash(region, connection)
+    name = name_from_tag(connection)
+    return {} unless name
+
     customer_gateway_name = customer_gateway_name_from_id(region, connection.customer_gateway_id)
     vpn_gateway_name = vpn_gateway_name_from_id(region, connection.vpn_gateway_id)
 
@@ -44,7 +47,7 @@ Puppet::Type.type(:ec2_vpc_vpn).provide(:v2, :parent => PuppetX::Puppetlabs::Aws
     static_routes = connection.options.nil? ? nil : connection.options.static_routes_only
 
     {
-      :name             => name_from_tag(connection),
+      :name             => name,
       :id               => connection.vpn_connection_id,
       :customer_gateway => customer_gateway_name,
       :ensure           => :present,

--- a/lib/puppet/provider/ec2_vpc_vpn/v2.rb
+++ b/lib/puppet/provider/ec2_vpc_vpn/v2.rb
@@ -37,31 +37,8 @@ Puppet::Type.type(:ec2_vpc_vpn).provide(:v2, :parent => PuppetX::Puppetlabs::Aws
   end
 
   def self.connection_to_hash(region, connection)
-    ec2 = ec2_client(region)
-
-    customer_response = ec2.describe_customer_gateways(
-      customer_gateway_ids: [connection.customer_gateway_id]
-    )
-
-    customer_gateways = customer_response.data.customer_gateways
-    customer_gateway_name = unless customer_gateways.empty?
-      customer_name_tag = customer_gateways.first.tags.detect { |tag| tag.key == 'Name' }
-      customer_name_tag ? customer_name_tag.value : nil
-    else
-      nil
-    end
-
-    vpn_response = ec2.describe_vpn_gateways(
-      vpn_gateway_ids: [connection.vpn_gateway_id]
-    )
-
-    vpn_gateways = vpn_response.data.vpn_gateways
-    vpn_gateway_name = unless vpn_gateways.empty?
-      vpn_name_tag = vpn_gateways.first.tags.detect { |tag| tag.key == 'Name' }
-      vpn_name_tag ? vpn_name_tag.value : nil
-    else
-      nil
-    end
+    customer_gateway_name = customer_gateway_name_from_id(region, connection.customer_gateway_id)
+    vpn_gateway_name = vpn_gateway_name_from_id(region, connection.vpn_gateway_id)
 
     routes = connection.routes.collect { |route| route.destination_cidr_block }
     static_routes = connection.options.nil? ? nil : connection.options.static_routes_only
@@ -81,14 +58,13 @@ Puppet::Type.type(:ec2_vpc_vpn).provide(:v2, :parent => PuppetX::Puppetlabs::Aws
   end
 
   def exists?
-    dest_region = resource[:region] if resource
-    Puppet.info("Checking if VPN #{name} exists in region #{dest_region || region}")
+    Puppet.info("Checking if VPN #{name} exists in region #{target_region}")
     @property_hash[:ensure] == :present
   end
 
   def create
-    Puppet.info("Creating VPN gateway #{name} in region #{resource[:region]}")
-    ec2 = ec2_client(resource[:region])
+    Puppet.info("Creating VPN gateway #{name} in region #{target_region}")
+    ec2 = ec2_client(target_region)
 
     vpn_response = ec2.describe_vpn_gateways(filters: [
       {name: "tag:Name", values: [resource[:vpn_gateway]]},
@@ -133,9 +109,8 @@ Puppet::Type.type(:ec2_vpc_vpn).provide(:v2, :parent => PuppetX::Puppetlabs::Aws
   end
 
   def destroy
-    region = @property_hash[:region]
-    Puppet.info("Destroying VPN #{name} in region #{region}")
-    ec2 = ec2_client(region)
+    Puppet.info("Destroying VPN #{name} in region #{target_region}")
+    ec2 = ec2_client(target_region)
     ec2.delete_vpn_connection(
       vpn_connection_id: @property_hash[:id]
     )
@@ -146,4 +121,3 @@ Puppet::Type.type(:ec2_vpc_vpn).provide(:v2, :parent => PuppetX::Puppetlabs::Aws
     @property_hash[:ensure] = :absent
   end
 end
-

--- a/lib/puppet/provider/ec2_vpc_vpn_gateway/v2.rb
+++ b/lib/puppet/provider/ec2_vpc_vpn_gateway/v2.rb
@@ -37,6 +37,8 @@ Puppet::Type.type(:ec2_vpc_vpn_gateway).provide(:v2, :parent => PuppetX::Puppetl
   end
 
   def self.gateway_to_hash(region, gateway)
+    name = name_from_tag(gateway)
+    return {} unless name
     attached = gateway.vpc_attachments.detect { |vpc| vpc.state == 'attached' }
     vpc_name = nil
     vpc_id = nil
@@ -45,7 +47,7 @@ Puppet::Type.type(:ec2_vpc_vpn_gateway).provide(:v2, :parent => PuppetX::Puppetl
       vpc_id = vpc_name.nil? ? nil : attached.vpc_id
     end
     {
-      :name   => name_from_tag(gateway),
+      :name   => name,
       :id     => gateway.vpn_gateway_id,
       :vpc    => vpc_name,
       :vpc_id => vpc_id,

--- a/lib/puppet/provider/elb_loadbalancer/v2.rb
+++ b/lib/puppet/provider/elb_loadbalancer/v2.rb
@@ -94,13 +94,12 @@ Puppet::Type.type(:elb_loadbalancer).provide(:v2, :parent => PuppetX::Puppetlabs
   end
 
   def exists?
-    dest_region = resource[:region] if resource
-    Puppet.info("Checking if load balancer #{name} exists in region #{dest_region || region}")
+    Puppet.info("Checking if load balancer #{name} exists in region #{target_region}")
     @property_hash[:ensure] == :present
   end
 
   def create
-    Puppet.info("Creating load balancer #{name} in region #{resource[:region]}")
+    Puppet.info("Creating load balancer #{name} in region #{target_region}")
     subnets = subnet_ids_from_names(resource[:subnets])
     security_groups = security_group_ids_from_names(resource[:security_groups])
     zones = resource[:availability_zones]
@@ -121,7 +120,7 @@ Puppet::Type.type(:elb_loadbalancer).provide(:v2, :parent => PuppetX::Puppetlabs
       }
     end
 
-    elb_client(resource[:region]).create_load_balancer(
+    elb_client(target_region).create_load_balancer(
       load_balancer_name: name,
       listeners: listeners_for_api,
       availability_zones: zones,
@@ -233,8 +232,8 @@ Puppet::Type.type(:elb_loadbalancer).provide(:v2, :parent => PuppetX::Puppetlabs
   end
 
   def destroy
-    Puppet.info("Destroying load balancer #{name} in region #{resource[:region]}")
-    elb_client(resource[:region]).delete_load_balancer(
+    Puppet.info("Destroying load balancer #{name} in region #{target_region}")
+    elb_client(target_region).delete_load_balancer(
       load_balancer_name: name,
     )
     @property_hash[:ensure] = :absent

--- a/lib/puppet/provider/route53_zone/v2.rb
+++ b/lib/puppet/provider/route53_zone/v2.rb
@@ -42,10 +42,8 @@ Puppet::Type.type(:route53_zone).provide(:v2, :parent => PuppetX::Puppetlabs::Aw
   def destroy
     Puppet.info("Deleting zone #{name}")
     zones = route53_client.list_hosted_zones.data.hosted_zones.select { |zone| zone.name == name }
-    if zones
-      zones.each do |zone|
-        route53_client.delete_hosted_zone(id: zone.id)
-      end
+    zones.each do |zone|
+      route53_client.delete_hosted_zone(id: zone.id)
     end
     @property_hash[:ensure] = :absent
   end

--- a/lib/puppet_x/puppetlabs/aws.rb
+++ b/lib/puppet_x/puppetlabs/aws.rb
@@ -55,8 +55,16 @@ This could be because some other process is modifying AWS at the same time."""
         end
       end
 
+      def self.logger
+        if ENV['PUPPET_AWS_DEBUG_LOG'] and not ENV['PUPPET_AWS_DEBUG_LOG'].empty?
+          Logger.new('puppet-aws-debug.log')
+        else
+          nil
+        end
+      end
+
       def self.ec2_client(region = default_region)
-        ::Aws::EC2::Client.new({region: region})
+        ::Aws::EC2::Client.new({region: region, logger: logger})
       end
 
       def ec2_client(region = default_region)
@@ -73,7 +81,7 @@ This could be because some other process is modifying AWS at the same time."""
       end
 
       def self.elb_client(region = default_region)
-        ::Aws::ElasticLoadBalancing::Client.new({region: region})
+        ::Aws::ElasticLoadBalancing::Client.new({region: region, logger: logger})
       end
 
       def elb_client(region = default_region)
@@ -81,7 +89,7 @@ This could be because some other process is modifying AWS at the same time."""
       end
 
       def self.autoscaling_client(region = default_region)
-        ::Aws::AutoScaling::Client.new({region: region})
+        ::Aws::AutoScaling::Client.new({region: region, logger: logger})
       end
 
       def autoscaling_client(region = default_region)
@@ -89,7 +97,7 @@ This could be because some other process is modifying AWS at the same time."""
       end
 
       def self.cloudwatch_client(region = default_region)
-        ::Aws::CloudWatch::Client.new({region: region})
+        ::Aws::CloudWatch::Client.new({region: region, logger: logger})
       end
 
       def cloudwatch_client(region = default_region)
@@ -97,7 +105,7 @@ This could be because some other process is modifying AWS at the same time."""
       end
 
       def self.route53_client(region = default_region)
-        ::Aws::Route53::Client.new({region: region})
+        ::Aws::Route53::Client.new({region: region, logger: logger})
       end
 
       def route53_client(region = default_region)

--- a/spec/unit/provider/ec2_securitygroup/v2_spec.rb
+++ b/spec/unit/provider/ec2_securitygroup/v2_spec.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 
 provider_class = Puppet::Type.type(:ec2_securitygroup).provider(:v2)
 
-#ENV['AWS_ACCESS_KEY_ID'] = 'redacted'
-#ENV['AWS_SECRET_ACCESS_KEY'] = 'redacted'
+ENV['AWS_ACCESS_KEY_ID'] = 'redacted'
+ENV['AWS_SECRET_ACCESS_KEY'] = 'redacted'
 ENV['AWS_REGION'] = 'sa-east-1'
 
 describe provider_class do


### PR DESCRIPTION
This commit moves a bunch of functionality from the providers to the
base class. This centralisation allows for some basic caching.
Specically we regularly look up the name (often in a tag) of a resource
by it's AWS id.

This cuts down on the number of API calls made, especially as the
resource count increases.