### PR TITLE
(CLOUD-257) Add support for AAAA, CNAME, MX, SRV and SPF records

### DIFF
--- a/lib/puppet/provider/route53_aaaa_record/v2.rb
+++ b/lib/puppet/provider/route53_aaaa_record/v2.rb
@@ -1,0 +1,15 @@
+require_relative '../route53_record'
+
+Puppet::Type.type(:route53_aaaa_record).provide(:v2, :parent => Puppet::Provider::Route53Record) do
+  confine feature: :aws
+
+  mk_resource_methods
+
+  def self.record_type
+    'AAAA'
+  end
+
+  def flush
+    update unless @property_hash[:ensure] == :absent
+  end
+end

--- a/lib/puppet/provider/route53_cname_record/v2.rb
+++ b/lib/puppet/provider/route53_cname_record/v2.rb
@@ -1,0 +1,15 @@
+require_relative '../route53_record'
+
+Puppet::Type.type(:route53_cname_record).provide(:v2, :parent => Puppet::Provider::Route53Record) do
+  confine feature: :aws
+
+  mk_resource_methods
+
+  def self.record_type
+    'CNAME'
+  end
+
+  def flush
+    update unless @property_hash[:ensure] == :absent
+  end
+end

--- a/lib/puppet/provider/route53_mx_record/v2.rb
+++ b/lib/puppet/provider/route53_mx_record/v2.rb
@@ -1,0 +1,15 @@
+require_relative '../route53_record'
+
+Puppet::Type.type(:route53_mx_record).provide(:v2, :parent => Puppet::Provider::Route53Record) do
+  confine feature: :aws
+
+  mk_resource_methods
+
+  def self.record_type
+    'MX'
+  end
+
+  def flush
+    update unless @property_hash[:ensure] == :absent
+  end
+end

--- a/lib/puppet/provider/route53_spf_record/v2.rb
+++ b/lib/puppet/provider/route53_spf_record/v2.rb
@@ -1,0 +1,15 @@
+require_relative '../route53_record'
+
+Puppet::Type.type(:route53_spf_record).provide(:v2, :parent => Puppet::Provider::Route53Record) do
+  confine feature: :aws
+
+  mk_resource_methods
+
+  def self.record_type
+    'SPF'
+  end
+
+  def flush
+    update unless @property_hash[:ensure] == :absent
+  end
+end

--- a/lib/puppet/provider/route53_srv_record/v2.rb
+++ b/lib/puppet/provider/route53_srv_record/v2.rb
@@ -1,0 +1,15 @@
+require_relative '../route53_record'
+
+Puppet::Type.type(:route53_srv_record).provide(:v2, :parent => Puppet::Provider::Route53Record) do
+  confine feature: :aws
+
+  mk_resource_methods
+
+  def self.record_type
+    'SRV'
+  end
+
+  def flush
+    update unless @property_hash[:ensure] == :absent
+  end
+end

--- a/lib/puppet/type/route53_aaaa_record.rb
+++ b/lib/puppet/type/route53_aaaa_record.rb
@@ -1,0 +1,8 @@
+require_relative '../../puppet_x/puppetlabs/route53_record'
+
+Puppet::Type.newtype(:route53_aaaa_record) do
+  extend PuppetX::Puppetlabs::Route53Record
+  @doc = 'Type representing a Route53 DNS AAAA record.'
+  create_properties_and_params()
+end
+

--- a/lib/puppet/type/route53_cname_record.rb
+++ b/lib/puppet/type/route53_cname_record.rb
@@ -1,0 +1,8 @@
+require_relative '../../puppet_x/puppetlabs/route53_record'
+
+Puppet::Type.newtype(:route53_cname_record) do
+  extend PuppetX::Puppetlabs::Route53Record
+  @doc = 'Type representing a Route53 CNAME record.'
+  create_properties_and_params()
+end
+

--- a/lib/puppet/type/route53_mx_record.rb
+++ b/lib/puppet/type/route53_mx_record.rb
@@ -1,0 +1,8 @@
+require_relative '../../puppet_x/puppetlabs/route53_record'
+
+Puppet::Type.newtype(:route53_mx_record) do
+  extend PuppetX::Puppetlabs::Route53Record
+  @doc = 'Type representing a Route53 MX record.'
+  create_properties_and_params()
+end
+

--- a/lib/puppet/type/route53_spf_record.rb
+++ b/lib/puppet/type/route53_spf_record.rb
@@ -1,0 +1,15 @@
+require_relative '../../puppet_x/puppetlabs/route53_record'
+
+Puppet::Type.newtype(:route53_spf_record) do
+  extend PuppetX::Puppetlabs::Route53Record
+  @doc = 'Type representing a Route53 SPF record.'
+  create_properties_and_params()
+
+  # SPF records should always be wrapped in double quotes
+  # this munge avoids the need to pass in a '"value"' to Puppet
+  values_property = self.properties.find { |item| item == Puppet::Type::Route53_spf_record::Values }
+  values_property.munge do |value|
+    value =~ /^".+"$/ ? value : "\"#{value}\""
+  end
+end
+

--- a/lib/puppet/type/route53_srv_record.rb
+++ b/lib/puppet/type/route53_srv_record.rb
@@ -1,0 +1,8 @@
+require_relative '../../puppet_x/puppetlabs/route53_record'
+
+Puppet::Type.newtype(:route53_srv_record) do
+  extend PuppetX::Puppetlabs::Route53Record
+  @doc = 'Type representing a Route53 SRV record.'
+  create_properties_and_params()
+end
+

--- a/spec/acceptance/fixtures/route53_create.pp.tmpl
+++ b/spec/acceptance/fixtures/route53_create.pp.tmpl
@@ -9,9 +9,44 @@ route53_a_record { '{{a_record_name}}':
   values => [{{#a_values}}'{{.}}',{{/a_values}}],
 }
 
+route53_mx_record { '{{mx_record_name}}':
+  ensure => present,
+  zone   => '{{name}}',
+  ttl    => {{mx_ttl}},
+  values => [{{#mx_values}}'{{.}}',{{/mx_values}}],
+}
+
+route53_aaaa_record { '{{aaaa_record_name}}':
+  ensure => present,
+  zone   => '{{name}}',
+  ttl    => {{aaaa_ttl}},
+  values => [{{#aaaa_values}}'{{.}}',{{/aaaa_values}}],
+}
+
+route53_cname_record { '{{cname_record_name}}':
+  ensure => present,
+  zone   => '{{name}}',
+  ttl    => {{cname_ttl}},
+  values => [{{#cname_values}}'{{.}}',{{/cname_values}}],
+}
+
+route53_srv_record { '{{srv_record_name}}':
+  ensure => present,
+  zone   => '{{name}}',
+  ttl    => {{srv_ttl}},
+  values => [{{#srv_values}}'{{.}}',{{/srv_values}}],
+}
+
 route53_txt_record { '{{txt_record_name}}':
   ensure => present,
   zone   => '{{name}}',
   ttl    => {{txt_ttl}},
   values => '{{txt_value}}',
+}
+
+route53_spf_record { '{{spf_record_name}}':
+  ensure => present,
+  zone   => '{{name}}',
+  ttl    => {{spf_ttl}},
+  values => '{{spf_value}}',
 }

--- a/spec/acceptance/fixtures/route53_create_minimal.pp.tmpl
+++ b/spec/acceptance/fixtures/route53_create_minimal.pp.tmpl
@@ -1,0 +1,17 @@
+route53_zone { '{{name}}':
+  ensure => present,
+}
+
+route53_a_record { '{{a_record_name}}':
+  ensure => present,
+  zone   => '{{name}}',
+  ttl    => {{a_ttl}},
+  values => [{{#a_values}}'{{.}}',{{/a_values}}],
+}
+
+route53_txt_record { '{{txt_record_name}}':
+  ensure => present,
+  zone   => '{{name}}',
+  ttl    => {{txt_ttl}},
+  values => '{{txt_value}}',
+}

--- a/spec/acceptance/fixtures/route53_delete.pp.tmpl
+++ b/spec/acceptance/fixtures/route53_delete.pp.tmpl
@@ -10,6 +10,36 @@ route53_txt_record { '{{txt_record_name}}':
   before => Route53_zone['{{name}}'],
 }
 
+route53_aaaa_record { '{{aaaa_record_name}}':
+  ensure => absent,
+  zone   => '{{name}}',
+  before => Route53_zone['{{name}}'],
+}
+
+route53_mx_record { '{{mx_record_name}}':
+  ensure => absent,
+  zone   => '{{name}}',
+  before => Route53_zone['{{name}}'],
+}
+
+route53_cname_record { '{{cname_record_name}}':
+  ensure => absent,
+  zone   => '{{name}}',
+  before => Route53_zone['{{name}}'],
+}
+
+route53_srv_record { '{{srv_record_name}}':
+  ensure => absent,
+  zone   => '{{name}}',
+  before => Route53_zone['{{name}}'],
+}
+
+route53_spf_record { '{{spf_record_name}}':
+  ensure => absent,
+  zone   => '{{name}}',
+  before => Route53_zone['{{name}}'],
+}
+
 route53_zone { '{{name}}':
   ensure => absent,
 }

--- a/spec/acceptance/route53_spec.rb
+++ b/spec/acceptance/route53_spec.rb
@@ -32,6 +32,21 @@ describe "route53_zone" do
         :txt_record_name => "local.#{@name}",
         :txt_ttl => 17000,
         :txt_value => 'message',
+        :spf_record_name => "local.#{@name}",
+        :spf_ttl => 300,
+        :spf_value => 'v=spf1 a -all',
+        :cname_record_name => "local2.#{@name}",
+        :cname_ttl => 304,
+        :cname_values => ["local3.#{@name}"],
+        :mx_record_name => "local.#{@name}",
+        :mx_ttl => 303,
+        :mx_values => ["10 mail.local.#{@name}", "20 mail.local.#{@name}"],
+        :aaaa_record_name => "local.#{@name}",
+        :aaaa_ttl => 302,
+        :aaaa_values => ['2001:0db8:85a3:0:0:8a2e:0370:7334'],
+        :srv_record_name => "local.#{@name}",
+        :srv_ttl => 301,
+        :srv_values => ["1 10 5269 xmpp-server.#{@name}",  "2 12 5060 sip-server.#{@name}"],
       }
 
       @template = 'route53_create.pp.tmpl'
@@ -41,6 +56,11 @@ describe "route53_zone" do
       @ns_record = find_record(@config[:name], @zone, 'NS')
       @soa_record = find_record(@config[:name], @zone, 'SOA')
       @txt_record = find_record(@config[:txt_record_name], @zone, 'TXT')
+      @spf_record = find_record(@config[:spf_record_name], @zone, 'SPF')
+      @cname_record = find_record(@config[:cname_record_name], @zone, 'CNAME')
+      @mx_record = find_record(@config[:mx_record_name], @zone, 'MX')
+      @aaaa_record = find_record(@config[:aaaa_record_name], @zone, 'AAAA')
+      @srv_record = find_record(@config[:srv_record_name], @zone, 'SRV')
     end
 
     after(:all) do
@@ -97,6 +117,126 @@ describe "route53_zone" do
       end
     end
 
+    it 'should create an MX record with the relevant ttl' do
+      expect(@mx_record.ttl).to eq(@config[:mx_ttl])
+    end
+
+    it 'should create an MX record with the relevant values' do
+      expect(@mx_record.resource_records.map(&:value)).to eq(@config[:mx_values])
+    end
+
+    describe 'using puppet resource on the MX record' do
+      before(:all) do
+        ENV['AWS_REGION'] = @default_region
+        options = {:name => @config[:mx_record_name]}
+        @result = TestExecutor.puppet_resource('route53_mx_record', options, '--modulepath ../')
+      end
+
+      it 'should show the correct TTL' do
+        regex = /ttl\s*=>\s*'#{@config[:mx_ttl]}'/
+        expect(@result.stdout).to match(regex)
+      end
+
+      it 'should show the correct zone' do
+        regex = /zone\s*=>\s*'#{@config[:name]}'/
+        expect(@result.stdout).to match(regex)
+      end
+
+      it 'should show the correct values' do
+        regex = /values\s*=>\s*\['#{@config[:mx_values].first}', '#{@config[:mx_values][1]}'\]/
+        expect(@result.stdout).to match(regex)
+      end
+    end
+
+    it 'should create a CNAME record with the relevant ttl' do
+      expect(@cname_record.ttl).to eq(@config[:cname_ttl])
+    end
+
+    it 'should create a CNAME record with the relevant values' do
+      expect(@cname_record.resource_records.map(&:value)).to eq(@config[:cname_values])
+    end
+
+    describe 'using puppet resource on the CNAME record' do
+      before(:all) do
+        ENV['AWS_REGION'] = @default_region
+        options = {:name => @config[:cname_record_name]}
+        @result = TestExecutor.puppet_resource('route53_cname_record', options, '--modulepath ../')
+      end
+
+      it 'should show the correct TTL' do
+        regex = /ttl\s*=>\s*'#{@config[:cname_ttl]}'/
+        expect(@result.stdout).to match(regex)
+      end
+
+      it 'should show the correct zone' do
+        regex = /zone\s*=>\s*'#{@config[:name]}'/
+        expect(@result.stdout).to match(regex)
+      end
+
+      it 'should show the correct values' do
+        regex = /values\s*=>\s*\['#{@config[:cname_values].first}'\]/
+        expect(@result.stdout).to match(regex)
+      end
+    end
+
+    it 'should create an SRV record with the relevant ttl' do
+      expect(@srv_record.ttl).to eq(@config[:srv_ttl])
+    end
+
+    it 'should create an SRV record with the relevant values' do
+      expect(@srv_record.resource_records.map(&:value)).to eq(@config[:srv_values])
+    end
+
+    describe 'using puppet resource on the SRV record' do
+      before(:all) do
+        ENV['AWS_REGION'] = @default_region
+        options = {:name => @config[:srv_record_name]}
+        @result = TestExecutor.puppet_resource('route53_srv_record', options, '--modulepath ../')
+      end
+
+      it 'should show the correct TTL' do
+        regex = /ttl\s*=>\s*'#{@config[:srv_ttl]}'/
+        expect(@result.stdout).to match(regex)
+      end
+
+      it 'should show the correct zone' do
+        regex = /zone\s*=>\s*'#{@config[:name]}'/
+        expect(@result.stdout).to match(regex)
+      end
+
+    end
+
+    it 'should create an AAAA record with the relevant ttl' do
+      expect(@aaaa_record.ttl).to eq(@config[:aaaa_ttl])
+    end
+
+    it 'should create an AAAA record with the relevant values' do
+      expect(@aaaa_record.resource_records.map(&:value)).to eq(@config[:aaaa_values])
+    end
+
+    describe 'using puppet resource on the AAAA record' do
+      before(:all) do
+        ENV['AWS_REGION'] = @default_region
+        options = {:name => @config[:aaaa_record_name]}
+        @result = TestExecutor.puppet_resource('route53_aaaa_record', options, '--modulepath ../')
+      end
+
+      it 'should show the correct TTL' do
+        regex = /ttl\s*=>\s*'#{@config[:aaaa_ttl]}'/
+        expect(@result.stdout).to match(regex)
+      end
+
+      it 'should show the correct zone' do
+        regex = /zone\s*=>\s*'#{@config[:name]}'/
+        expect(@result.stdout).to match(regex)
+      end
+
+      it 'should show the correct values' do
+        regex = /values\s*=>\s*\['#{@config[:aaaa_values].first}'\]/
+        expect(@result.stdout).to match(regex)
+      end
+    end
+
     describe 'using puppet resource on the TXT record' do
       before(:all) do
         ENV['AWS_REGION'] = @default_region
@@ -106,6 +246,32 @@ describe "route53_zone" do
 
       it 'should show the correct TTL' do
         regex = /ttl\s*=>\s*'#{@config[:txt_ttl]}'/
+        expect(@result.stdout).to match(regex)
+      end
+
+      it 'should show the correct zone' do
+        regex = /zone\s*=>\s*'#{@config[:name]}'/
+        expect(@result.stdout).to match(regex)
+      end
+    end
+
+    it 'should create an SPF record with the relevant ttl' do
+      expect(@spf_record.ttl).to eq(@config[:spf_ttl])
+    end
+
+    it 'should create an SPF record with the relevant values' do
+      expect(@spf_record.resource_records.map(&:value)).to eq(["\"v=spf1 a -all\""])
+    end
+
+    describe 'using puppet resource on the SPF record' do
+      before(:all) do
+        ENV['AWS_REGION'] = @default_region
+        options = {:name => @config[:spf_record_name]}
+        @result = TestExecutor.puppet_resource('route53_spf_record', options, '--modulepath ../')
+      end
+
+      it 'should show the correct TTL' do
+        regex = /ttl\s*=>\s*'#{@config[:spf_ttl]}'/
         expect(@result.stdout).to match(regex)
       end
 
@@ -251,7 +417,7 @@ describe "route53_zone" do
         :txt_ttl => 17000,
         :txt_value => 'message',
       }
-      @template = 'route53_create.pp.tmpl'
+      @template = 'route53_create_minimal.pp.tmpl'
     end
 
     it 'with puppet resource' do

--- a/spec/unit/type/route53_record_spec.rb
+++ b/spec/unit/type/route53_record_spec.rb
@@ -4,6 +4,11 @@ require 'spec_helper'
   :route53_a_record,
   :route53_txt_record,
   :route53_ns_record,
+  :route53_aaaa_record,
+  :route53_cname_record,
+  :route53_mx_record,
+  :route53_spf_record,
+  :route53_srv_record,
 ].each do |type|
 
   type_class = Puppet::Type.type(type)


### PR DESCRIPTION
This addresses the extra resources requested by @danieldreier in https://github.com/puppetlabs/puppetlabs-aws/issues/100