### PR TITLE
(CLOUD-256) Deal with blank name tags for all resources

### DIFF
--- a/lib/puppet/provider/ec2_instance/v2.rb
+++ b/lib/puppet/provider/ec2_instance/v2.rb
@@ -17,7 +17,7 @@ Puppet::Type.type(:ec2_instance).provide(:v2, :parent => PuppetX::Puppetlabs::Aw
         response.data.reservations.each do |reservation|
           reservation.instances.each do |instance|
             hash = instance_to_hash(region, instance)
-            instances << new(hash) if (hash[:name] and ! hash[:name].empty?)
+            instances << new(hash) if has_name?(hash)
           end
         end
       end

--- a/lib/puppet/provider/ec2_vpc/v2.rb
+++ b/lib/puppet/provider/ec2_vpc/v2.rb
@@ -13,7 +13,7 @@ Puppet::Type.type(:ec2_vpc).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) do
       vpcs = []
       response.data.vpcs.each do |vpc|
         hash = vpc_to_hash(region, vpc)
-        vpcs << new(hash) if hash[:name]
+        vpcs << new(hash) if has_name?(hash)
       end
       vpcs
     end.flatten

--- a/lib/puppet/provider/ec2_vpc_dhcp_options/v2.rb
+++ b/lib/puppet/provider/ec2_vpc_dhcp_options/v2.rb
@@ -13,7 +13,7 @@ Puppet::Type.type(:ec2_vpc_dhcp_options).provide(:v2, :parent => PuppetX::Puppet
       ec2_client(region).describe_dhcp_options.collect do |response|
         response.data.dhcp_options.each do |item|
           hash = dhcp_option_to_hash(region, item)
-          options << new(hash) if hash[:name]
+          options << new(hash) if has_name?(hash)
         end
       end
       options

--- a/lib/puppet/provider/ec2_vpc_internet_gateway/v2.rb
+++ b/lib/puppet/provider/ec2_vpc_internet_gateway/v2.rb
@@ -13,7 +13,7 @@ Puppet::Type.type(:ec2_vpc_internet_gateway).provide(:v2, :parent => PuppetX::Pu
       gateways = []
       response.data.internet_gateways.each do |gateway|
         hash = gateway_to_hash(region, gateway)
-        gateways << new(hash) if hash[:name]
+        gateways << new(hash) if has_name?(hash)
       end
       gateways
     end.flatten

--- a/lib/puppet/provider/ec2_vpc_routetable/v2.rb
+++ b/lib/puppet/provider/ec2_vpc_routetable/v2.rb
@@ -13,7 +13,7 @@ Puppet::Type.type(:ec2_vpc_routetable).provide(:v2, :parent => PuppetX::Puppetla
       tables = []
       response.data.route_tables.each do |table|
         hash = route_table_to_hash(region, table)
-        tables << new(hash) if hash[:name]
+        tables << new(hash) if has_name?(hash)
       end
       tables
     end.flatten

--- a/lib/puppet/provider/ec2_vpc_subnet/v2.rb
+++ b/lib/puppet/provider/ec2_vpc_subnet/v2.rb
@@ -13,7 +13,7 @@ Puppet::Type.type(:ec2_vpc_subnet).provide(:v2, :parent => PuppetX::Puppetlabs::
       subnets = []
       response.data.subnets.each do |subnet|
         hash = subnet_to_hash(region, subnet)
-        subnets << new(hash) if hash[:name]
+        subnets << new(hash) if has_name?(hash)
       end
       subnets
     end.flatten

--- a/lib/puppet/provider/ec2_vpc_vpn/v2.rb
+++ b/lib/puppet/provider/ec2_vpc_vpn/v2.rb
@@ -15,7 +15,7 @@ Puppet::Type.type(:ec2_vpc_vpn).provide(:v2, :parent => PuppetX::Puppetlabs::Aws
       ]).each do |response|
         response.data.vpn_connections.each do |connection|
           hash = connection_to_hash(region, connection)
-          connections << new(hash) if hash[:name]
+          connections << new(hash) if has_name?(hash)
         end
       end
       connections

--- a/lib/puppet/provider/ec2_vpc_vpn_gateway/v2.rb
+++ b/lib/puppet/provider/ec2_vpc_vpn_gateway/v2.rb
@@ -15,9 +15,7 @@ Puppet::Type.type(:ec2_vpc_vpn_gateway).provide(:v2, :parent => PuppetX::Puppetl
       ]).each do |response|
         response.data.vpn_gateways.each do |gateway|
           hash = gateway_to_hash(region, gateway)
-          if hash[:name]
-            gateways << new(hash)
-          end
+          gateways << new(hash) if has_name?(hash)
         end
       end
       gateways

--- a/lib/puppet_x/puppetlabs/aws.rb
+++ b/lib/puppet_x/puppetlabs/aws.rb
@@ -112,6 +112,10 @@ module PuppetX
         ) unless missing_tags.empty?
       end
 
+      def self.has_name?(hash)
+        !hash[:name].nil? && !hash[:name].empty?
+      end
+
     end
   end
 end


### PR DESCRIPTION
This was previously fixed for instances only but this commit generalises
the fix to other resources. Tags do not have to contain content, so it's
possible for an account to contain resources with a Name tag which is
blank. Previously we checked for the presence of name, and not whether
it was empty.