### PR TITLE
Filter on vpc-id for sec groups in EC2-VPC

### DIFF
--- a/lib/puppet/provider/ec2_securitygroup/v2.rb
+++ b/lib/puppet/provider/ec2_securitygroup/v2.rb
@@ -131,11 +131,15 @@ Puppet::Type.type(:ec2_securitygroup).provide(:v2, :parent => PuppetX::Puppetlab
     to_create.reject(&:nil?).each do |rule|
       if rule.key? 'security_group'
         source_group_name = rule['security_group']
-        group_response = ec2.describe_security_groups(filters: [
-          {name: 'group-name', values: [source_group_name]},
-        ])
+        filters = [ {name: 'group-name', values: [source_group_name]} ]
+        if vpc_only_account?
+          response = ec2.describe_security_groups(group_ids: [@property_hash[:id]])
+          vpc_id = response.data.security_groups.first.vpc_id
+          filters.push( {name: 'vpc-id', values: [vpc_id]} )
+        end
+        group_response = ec2.describe_security_groups(filters: filters)
         fail("No groups found called #{source_group_name}") if group_response.data.security_groups.count == 0
-        source_group_id = group_response.data.security_groups.first.group_id
+        source_group_id = group_response.data.security_groups.find { |g| g.group_name == source_group_name }.group_id
         Puppet.warning "Multiple groups found called #{source_group_name}, using #{source_group_id}" if group_response.data.security_groups.count > 1
 
         permissions = ['tcp', 'udp', 'icmp'].collect do |protocol|


### PR DESCRIPTION
When adding security_group ingress rules to a security group resource
upon creation, a VPC-only account may have multiple groups with the
same name, often 'default', to select from. Without this change, the
ec2_securitygroup provider will simply select the first that it finds.
If the one it selects is not in the VPC to which the security group
puppet resource was added, it will raise an error and fail to add the
ingress rule. This change ensures that the correct security group for
the resource's ingress rule is selected by retrieving the VPC ID of the
security group that was added and using it as part of the filter for
selecting possible security groups to use for the ingress rule.