### PR TITLE
(WIP)(CLOUD-184, CLOUD-205) Make the region param and ENV var interchangable

### DIFF
--- a/lib/puppet/type/ec2_securitygroup.rb
+++ b/lib/puppet/type/ec2_securitygroup.rb
@@ -1,4 +1,5 @@
 require_relative '../../puppet_x/puppetlabs/property/tag.rb'
+require_relative '../../puppet_x/puppetlabs/property/region'
 require_relative '../../puppet_x/puppetlabs/aws_ingress_rules_parser'
 
 Puppet::Type.newtype(:ec2_securitygroup) do
@@ -13,11 +14,8 @@ Puppet::Type.newtype(:ec2_securitygroup) do
     end
   end
 
-  newproperty(:region) do
+  newproperty(:region, :parent => PuppetX::Property::AwsRegion) do
     desc 'the region in which to launch the security group'
-    validate do |value|
-      fail 'region should not contains spaces' if value =~ /\s/
-    end
   end
 
   newproperty(:ingress, :array_matching => :all) do

--- a/lib/puppet_x/puppetlabs/aws.rb
+++ b/lib/puppet_x/puppetlabs/aws.rb
@@ -96,6 +96,12 @@ module PuppetX
         tags
       end
 
+      def target_region
+        target = resource ? resource[:region] || region : region
+        target = nil if target == :absent
+        target || ENV['AWS_REGION']
+      end
+
       def tags=(value)
         Puppet.info("Updating tags for #{name} in region #{region}")
         ec2 = ec2_client(resource[:region])

--- a/lib/puppet_x/puppetlabs/property/region.rb
+++ b/lib/puppet_x/puppetlabs/property/region.rb
@@ -1,0 +1,13 @@
+module PuppetX
+  module Property
+    class AwsRegion < Puppet::Property
+      validate do |value|
+        name = resource[:name]
+        fail "region for #{name} should not contains spaces" if value =~ /\s/
+        if !ENV['AWS_REGION'].nil? && ENV['AWS_REGION'] != value
+          fail "if using AWS_REGION environment variable it must match the specified region value for #{name}"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
(Note that I've put this up just applying to security groups so as to get feedback on whether we should do some/all/none this as much as the implementation)

This allows for creating and deleting resources from puppet resource by
passing the environment variable (which is already used for scoping).

Prior to this change you would have to pass the information twice. If
you do pass both we maintain the same approach as previous, giving the
param a higher precedence.

This also allows for not specifying the region in the DSL, and instead
using the AWS_REGION variable. This matches the standard behaviour of
other AWS tools, and means in the case of not providing anything the
correct error bubbles through.