### PR TITLE
(MAINT) Routes that are blackholed aren't active

### DIFF
--- a/lib/puppet/provider/ec2_vpc_routetable/v2.rb
+++ b/lib/puppet/provider/ec2_vpc_routetable/v2.rb
@@ -31,18 +31,20 @@ Puppet::Type.type(:ec2_vpc_routetable).provide(:v2, :parent => PuppetX::Puppetla
 
   def self.route_to_hash(region, route)
     ec2 = ec2_client(region)
-    gateway = if route.gateway_id == 'local'
-      'local'
-    else
-      begin
-        igw_response = ec2.describe_internet_gateways(internet_gateway_ids: [route.gateway_id])
-        name_from_tag(igw_response.data.internet_gateways.first)
-      rescue Aws::EC2::Errors::InvalidInternetGatewayIDNotFound
+    if route.state == 'active'
+      gateway = if route.gateway_id == 'local'
+        'local'
+      else
         begin
-          vgw_response = ec2.describe_vpn_gateways(vpn_gateway_ids: [route.gateway_id])
-          name_from_tag(vgw_response.data.vpn_gateways.first)
-        rescue Aws::EC2::Errors::InvalidVpnGatewayIDNotFound
-          nil
+          igw_response = ec2.describe_internet_gateways(internet_gateway_ids: [route.gateway_id])
+          name_from_tag(igw_response.data.internet_gateways.first)
+        rescue Aws::EC2::Errors::InvalidInternetGatewayIDNotFound
+          begin
+            vgw_response = ec2.describe_vpn_gateways(vpn_gateway_ids: [route.gateway_id])
+            name_from_tag(vgw_response.data.vpn_gateways.first)
+          rescue Aws::EC2::Errors::InvalidVpnGatewayIDNotFound
+            nil
+          end
         end
       end
     end


### PR DESCRIPTION
Avoid querying for gateways that don't exist. Once routes are
writable this could be improved.