### PR TITLE
(MAINT) Correct use of confine for loading ruby libraries

### DIFF
--- a/lib/puppet/provider/ec2_instance/v2.rb
+++ b/lib/puppet/provider/ec2_instance/v2.rb
@@ -1,6 +1,5 @@
 require_relative '../../../puppet_x/puppetlabs/aws.rb'
 require 'base64'
-require 'retries'
 
 Puppet::Type.type(:ec2_instance).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) do
   confine feature: :aws

--- a/lib/puppet/provider/ec2_vpc/v2.rb
+++ b/lib/puppet/provider/ec2_vpc/v2.rb
@@ -1,8 +1,8 @@
 require_relative '../../../puppet_x/puppetlabs/aws.rb'
-require 'retries'
 
 Puppet::Type.type(:ec2_vpc).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) do
   confine feature: :aws
+  confine feature: :retries
 
   mk_resource_methods
   remove_method :tags=

--- a/lib/puppet/provider/ec2_vpc_customer_gateway/v2.rb
+++ b/lib/puppet/provider/ec2_vpc_customer_gateway/v2.rb
@@ -1,8 +1,8 @@
 require_relative '../../../puppet_x/puppetlabs/aws.rb'
-require 'retries'
 
 Puppet::Type.type(:ec2_vpc_customer_gateway).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) do
   confine feature: :aws
+  confine feature: :retries
 
   mk_resource_methods
   remove_method :tags=

--- a/lib/puppet/provider/ec2_vpc_dhcp_options/v2.rb
+++ b/lib/puppet/provider/ec2_vpc_dhcp_options/v2.rb
@@ -1,8 +1,8 @@
 require_relative '../../../puppet_x/puppetlabs/aws.rb'
-require 'retries'
 
 Puppet::Type.type(:ec2_vpc_dhcp_options).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) do
   confine feature: :aws
+  confine feature: :retries
 
   mk_resource_methods
   remove_method :tags=

--- a/lib/puppet/provider/ec2_vpc_internet_gateway/v2.rb
+++ b/lib/puppet/provider/ec2_vpc_internet_gateway/v2.rb
@@ -1,8 +1,8 @@
 require_relative '../../../puppet_x/puppetlabs/aws.rb'
-require 'retries'
 
 Puppet::Type.type(:ec2_vpc_internet_gateway).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) do
   confine feature: :aws
+  confine feature: :retries
 
   mk_resource_methods
   remove_method :tags=

--- a/lib/puppet/provider/ec2_vpc_routetable/v2.rb
+++ b/lib/puppet/provider/ec2_vpc_routetable/v2.rb
@@ -1,8 +1,8 @@
 require_relative '../../../puppet_x/puppetlabs/aws.rb'
-require 'retries'
 
 Puppet::Type.type(:ec2_vpc_routetable).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) do
   confine feature: :aws
+  confine feature: :retries
 
   mk_resource_methods
   remove_method :tags=

--- a/lib/puppet/provider/ec2_vpc_subnet/v2.rb
+++ b/lib/puppet/provider/ec2_vpc_subnet/v2.rb
@@ -1,8 +1,8 @@
 require_relative '../../../puppet_x/puppetlabs/aws.rb'
-require 'retries'
 
 Puppet::Type.type(:ec2_vpc_subnet).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) do
   confine feature: :aws
+  confine feature: :retries
 
   mk_resource_methods
   remove_method :tags=

--- a/lib/puppet/provider/ec2_vpc_vpn/v2.rb
+++ b/lib/puppet/provider/ec2_vpc_vpn/v2.rb
@@ -1,8 +1,8 @@
 require_relative '../../../puppet_x/puppetlabs/aws.rb'
-require 'retries'
 
 Puppet::Type.type(:ec2_vpc_vpn).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) do
   confine feature: :aws
+  confine feature: :retries
 
   mk_resource_methods
   remove_method :tags=

--- a/lib/puppet/provider/ec2_vpc_vpn_gateway/v2.rb
+++ b/lib/puppet/provider/ec2_vpc_vpn_gateway/v2.rb
@@ -1,8 +1,8 @@
 require_relative '../../../puppet_x/puppetlabs/aws.rb'
-require 'retries'
 
 Puppet::Type.type(:ec2_vpc_vpn_gateway).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) do
   confine feature: :aws
+  confine feature: :retries
 
   mk_resource_methods
   remove_method :tags=

--- a/lib/puppet_x/puppetlabs/aws.rb
+++ b/lib/puppet_x/puppetlabs/aws.rb
@@ -1,5 +1,3 @@
-require 'aws-sdk-core'
-
 module PuppetX
   module Puppetlabs
     class Aws < Puppet::Provider


### PR DESCRIPTION
Confine will automatically load the libraries so we don't need to
explicitly require them. If we do the code will fail with a Ruby error
before confine has a chance to kick in.