### PR TITLE
Add function to return the content of a file from an s3 bucket

### DIFF
--- a/lib/puppet/parser/functions/s3_file_content.rb
+++ b/lib/puppet/parser/functions/s3_file_content.rb
@@ -1,0 +1,35 @@
+require_relative '../../../puppet_x/puppetlabs/aws.rb'
+
+module Puppet::Parser::Functions
+  newfunction(:s3_file_content, :type => :rvalue, :doc => <<-ENDHEREDOC
+              Downloads a file from aws s3 and returns the contents
+
+              Requires three parameters:
+                Bucket
+                File
+                Region
+
+              ENDHEREDOC
+             ) do |args|
+
+     unless args.length == 3 then
+       raise Puppet::ParseError, ("s3_file_content(): wrong number of arguments (#{args.length}; must be 3)")
+     end
+
+     bucket = args[0]
+     filename = args[1]
+     region = args[2]
+
+     ["bucket", "filename", "region"].each do |param_name|
+       var = eval(param_name)
+        unless var.instance_of?(String) then
+          raise Puppet::ParseError, ("Parameter [#{param_name}] is not a string.  It looks to be a #{var.class}")
+        end
+        if var.to_s == "" then
+          raise Puppet::ParseError, ("Parameter [#{param_name}] cannot be blank")
+        end
+     end
+
+     PuppetX::Puppetlabs::Aws.s3_client(region).get_object( bucket: bucket, key: filename).body.read
+   end
+end

--- a/lib/puppet_x/puppetlabs/aws.rb
+++ b/lib/puppet_x/puppetlabs/aws.rb
@@ -80,6 +80,14 @@ module PuppetX
         self.class.route53_client(region)
       end
 
+      def self.s3_client(region = default_region)
+        ::Aws::S3::Client.new({region: region})
+      end
+
+      def s3_client(region = default_region)
+        self.class.s3_client(region)
+      end
+
       def tags_for_resource
         tags = resource[:tags] ? resource[:tags].map { |k,v| {key: k, value: v} } : []
         tags << {key: 'Name', value: name}


### PR DESCRIPTION
I would like to have the ability to pull a file from an s3 bucket and manage it via the built in puppet file type resource.  I have raised a puppet ticket asking for this to be considered - https://tickets.puppetlabs.com/browse/PUP-4080

I created a PR to the puppet code based to add this capability to puppet core (https://github.com/puppetlabs/puppet/pull/3675)

Quite rightly it was suggested this capability be added to the puppetlabs-aws module, the only issue is there is no mechanism to allow a module to extend the core puppet file type to pull content from another source.

As a temporary mechanism until it is possible to extend the puppet file type, I have created a function that will download a file from aws s3 and return the raw content to the file type.  Essentially a user would use this function like so:

```puppet
file { '/tmp/example.txt':
        content => s3_file_content('foo-bucket', 'bar-file', 'ap-southeast-2'),
	replace => false,
}
```

One thing that I am not sure if it is a puppet bug, a limitation in the puppet language or by design - the s3_file_content function is called every puppet run regardless if the file exists or not.  Which means it will make a call to s3 (which does cost money each 1000 api calls) Thoughts?