### PR TITLE
(WIP, CLOUD-179) Terminate the run if we get inconsistent data from AWS

### DIFF
--- a/lib/puppet/provider/ec2_securitygroup/v2.rb
+++ b/lib/puppet/provider/ec2_securitygroup/v2.rb
@@ -9,13 +9,17 @@ Puppet::Type.type(:ec2_securitygroup).provide(:v2, :parent => PuppetX::Puppetlab
 
   def self.instances
     regions.collect do |region|
-      groups = []
-      ec2_client(region).describe_security_groups.each do |response|
-        response.data.security_groups.collect do |group|
-          groups << new(security_group_to_hash(region, group))
+      begin
+        groups = []
+        ec2_client(region).describe_security_groups.each do |response|
+          response.data.security_groups.collect do |group|
+            groups << new(security_group_to_hash(region, group))
+          end
         end
+        groups
+      rescue StandardError => e
+        raise PuppetX::Puppetlabs::FetchingAWSDataError.new(region, 'ec2_securitygroup', e.message)
       end
-      groups
     end.flatten
   end
 

--- a/lib/puppet_x/puppetlabs/aws.rb
+++ b/lib/puppet_x/puppetlabs/aws.rb
@@ -1,5 +1,25 @@
 module PuppetX
   module Puppetlabs
+    # We purposefully inherit from Exception here due to PUP-3656
+    # If we throw something based on StandardError prior to Puppet 4
+    # the exception will prevent the prefetch, but the provider will
+    # continue to run with incorrect data.
+    class FetchingAWSDataError < Exception
+      def initialize(region, type, message=nil)
+        @message = message
+        @region = region
+        @type = type
+      end
+
+      def to_s
+        """Puppet detected a problem with the information returned from AWS
+when looking up #{@type} in #{@region}. The specific error was:
+#{@message}
+Rather than report on #{@type} resources in an inconsistent state we have exited.
+This could be because some other process is modifying AWS at the same time."""
+      end
+    end
+
     class Aws < Puppet::Provider
       def self.regions
         if ENV['AWS_REGION'] and not ENV['AWS_REGION'].empty?


### PR DESCRIPTION
If we query AWS for a resource (by id) that doesn't exist we will raise
an exception. Due to PUP-3656 that prevents prefetch but lets the
provider continue with incorrect data.

This changes that behaviour to stop the provider run if we discover
inconsistent data, it also provides information to help debug the
problem - although in many cases running a second time will fix the
issue.

Common causes of inconnsistency are:

* what appears to be eventual consistency within AWS
* other clients acting on the API at the same time