### PR TITLE
invalid Policy "Version" per IAM Policy Grammar Doc

### DIFF
--- a/examples/iam-profile/README.md
+++ b/examples/iam-profile/README.md
@@ -24,7 +24,7 @@ add to this profile.
 
 ```json
 {
-  "Version": "2015-02-13",
+  "Version": "2012-10-17",
   "Statement": [
     {
       "Action": [

--- a/examples/iam-profile/profile.json
+++ b/examples/iam-profile/profile.json
@@ -1,5 +1,5 @@
 {
-  "Version": "2015-02-13",
+  "Version": "2012-10-17",
   "Statement": [
     {
       "Action": [


### PR DESCRIPTION
The "Version" field in the Profile policy doc is not free-form but is used to specify the version of the Profile specification syntax. Adjusted the value to match one of the valid values per the Amazon Profile specification Grammar Doc here: 

https://docs.aws.amazon.com/IAM/latest/UserGuide/policies-grammar.html

This now passed the IAM Policy validator.