### PR TITLE
Prefetch subnets info in one call - quite big performance boost

### DIFF
--- a/lib/puppet/provider/ec2_instance/v2.rb
+++ b/lib/puppet/provider/ec2_instance/v2.rb
@@ -11,12 +11,22 @@ Puppet::Type.type(:ec2_instance).provide(:v2, :parent => PuppetX::Puppetlabs::Aw
     regions.collect do |region|
       begin
         instances = []
+        subnets = Hash.new()
+
+        subnets_response = ec2_client(region).describe_subnets()
+        subnets_response.data.subnets.each do |subnet|
+          name_tag = subnet.tags.detect { |tag| tag.key == 'Name' }
+          if name_tag then
+            subnets[subnet.subnet_id] = name_tag.value
+          end
+        end
+
         ec2_client(region).describe_instances(filters: [
           {name: 'instance-state-name', values: ['pending', 'running', 'stopping', 'stopped']}
         ]).each do |response|
           response.data.reservations.each do |reservation|
             reservation.instances.each do |instance|
-              hash = instance_to_hash(region, instance)
+              hash = instance_to_hash(region, instance, subnets)
               instances << new(hash) if has_name?(hash)
             end
           end
@@ -40,7 +50,7 @@ Puppet::Type.type(:ec2_instance).provide(:v2, :parent => PuppetX::Puppetlabs::Aw
     end
   end
 
-  def self.instance_to_hash(region, instance)
+  def self.instance_to_hash(region, instance, subnets)
     name_tag = instance.tags.detect { |tag| tag.key == 'Name' }
     monitoring = instance.monitoring.state == "enabled" ? true : false
     tags = {}
@@ -49,10 +59,8 @@ Puppet::Type.type(:ec2_instance).provide(:v2, :parent => PuppetX::Puppetlabs::Aw
     end
     subnet_name = nil
     if instance.subnet_id
-      subnet_response = ec2_client(region).describe_subnets(subnet_ids: [instance.subnet_id])
-      subnet_name_tag = subnet_response.data.subnets.first.tags.detect { |tag| tag.key == 'Name' }
+      subnet_name = subnets[instance.subnet_id] ? subnets[instance.subnet_id] : nil
     end
-    subnet_name = subnet_name_tag ? subnet_name_tag.value : nil
 
     devices = instance.block_device_mappings.collect do |mapping|
       {


### PR DESCRIPTION
This helped me with issue #144 when when i was hitting `Request limit exceeded` error after  couple of minutes (our env is quite big - 1k+ instances in given region). Now it seems to work as expected and finish in about 10 seconds in this environment (I was trying just to list resources with `puppet resource ec2_instance` command).

This should be properly tested though as I don't have environment to do so. Currently 3 VCR test will fail (1 of those used to fail for me even before my change), which I guess is expected, and I'm unable to run beaker tests currently (don't have AWS environment ready for it).