### PR TITLE
(Cloud-297) ec2_instances should support tenancy

### DIFF
--- a/lib/puppet/provider/ec2_instance/v2.rb
+++ b/lib/puppet/provider/ec2_instance/v2.rb
@@ -258,6 +258,7 @@ Found #{matching_groups.length}:
         instance_initiated_shutdown_behavior: resource[:instance_initiated_shutdown_behavior].to_s,
         placement: {
           availability_zone: resource[:availability_zone]
+          tenancy: resource[:instance_tenancy]
         },
         monitoring: {
           enabled: resource[:monitoring].to_s,

--- a/lib/puppet/type/ec2_instance.rb
+++ b/lib/puppet/type/ec2_instance.rb
@@ -114,6 +114,12 @@ Puppet::Type.newtype(:ec2_instance) do
     end
   end
 
+  newproperty(:instance_tenancy) do
+    desc 'The instance tenancy: default or dedicated.'
+    defaultto :default
+    newvalues(:default, :dedicated)
+  end
+
   newproperty(:instance_id) do
     desc 'The AWS generated id for the instance.'
     validate do |value|


### PR DESCRIPTION
adds the instance_tenancy parameter to ec2_instance, enabling individual
nodes to be added to dedicated hardware as needed. The only way to
accomplish this previously was thru creating a VPC where this was the
default behavior instead.