### PR TITLE
WIP - Add ability to setup Route 53 private hosted zones

### DIFF
--- a/lib/puppet/provider/ec2_vpc/v2.rb
+++ b/lib/puppet/provider/ec2_vpc/v2.rb
@@ -34,7 +34,6 @@ Puppet::Type.type(:ec2_vpc).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) do
   end
 
   def self.vpc_to_hash(region, vpc)
-
     response = ec2_client(region).describe_vpc_attribute(
       vpc_id: vpc.vpc_id,
       attribute: 'enableDnsHostnames'
@@ -102,7 +101,6 @@ Puppet::Type.type(:ec2_vpc).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) do
     vpc_attribute = resource[:enable_dns_hostnames]
     if not vpc_attribute.nil?
       value = vpc_attribute == :true ? true : false
-      puts "hostnames"
       ec2.modify_vpc_attribute(
         vpc_id: vpc_id,
         enable_dns_hostnames: {
@@ -114,7 +112,6 @@ Puppet::Type.type(:ec2_vpc).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) do
     vpc_attribute = resource[:enable_dns_support]
     if not vpc_attribute.nil?
       value = vpc_attribute == :true ? true : false
-      puts "support"
       ec2.modify_vpc_attribute(
         vpc_id: vpc_id,
         enable_dns_support: {

--- a/lib/puppet/provider/ec2_vpc/v2.rb
+++ b/lib/puppet/provider/ec2_vpc/v2.rb
@@ -34,6 +34,19 @@ Puppet::Type.type(:ec2_vpc).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) do
   end
 
   def self.vpc_to_hash(region, vpc)
+
+    response = ec2_client(region).describe_vpc_attribute(
+      vpc_id: vpc.vpc_id,
+      attribute: 'enableDnsHostnames'
+    )
+    dns_hostnames = response.enable_dns_hostnames.value
+
+    response = ec2_client(region).describe_vpc_attribute(
+      vpc_id: vpc.vpc_id,
+      attribute: 'enableDnsSupport'
+    )
+    dns_support = response.enable_dns_support.value
+
     options_name = unless vpc.dhcp_options_id.nil? || vpc.dhcp_options_id.empty?
       response = ec2_client(region).describe_dhcp_options(
         dhcp_options_ids: [vpc.dhcp_options_id]
@@ -51,6 +64,8 @@ Puppet::Type.type(:ec2_vpc).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) do
       region: region,
       tags: tags_for(vpc),
       dhcp_options: options_name,
+      enable_dns_support: dns_support,
+      enable_dns_hostnames: dns_hostnames,
     }
   end
 
@@ -81,6 +96,30 @@ Puppet::Type.type(:ec2_vpc).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) do
       ec2.associate_dhcp_options(
         dhcp_options_id: options_response.data.dhcp_options.first.dhcp_options_id,
         vpc_id: vpc_id,
+      )
+    end
+
+    vpc_attribute = resource[:enable_dns_hostnames]
+    if not vpc_attribute.nil?
+      value = vpc_attribute == :true ? true : false
+      puts "hostnames"
+      ec2.modify_vpc_attribute(
+        vpc_id: vpc_id,
+        enable_dns_hostnames: {
+          value: value,
+        },
+    )
+    end
+
+    vpc_attribute = resource[:enable_dns_support]
+    if not vpc_attribute.nil?
+      value = vpc_attribute == :true ? true : false
+      puts "support"
+      ec2.modify_vpc_attribute(
+        vpc_id: vpc_id,
+        enable_dns_support: {
+          value: value,
+        },
       )
     end
 

--- a/lib/puppet/type/ec2_vpc.rb
+++ b/lib/puppet/type/ec2_vpc.rb
@@ -42,6 +42,22 @@ Puppet::Type.newtype(:ec2_vpc) do
     desc 'The tags to assign to the VPC.'
   end
 
+  newproperty(:enable_dns_support) do
+    desc 'Whether to use the Amazon provided DNS service.'
+    newvalues(:true, :'false')
+    def insync?(is)
+      is.to_s == should.to_s
+    end
+  end
+
+  newproperty(:enable_dns_hostnames) do
+    desc 'Whether the instances launched in the VPC get DNS hostnames allocated.'
+    newvalues(:true, :'false')
+    def insync?(is)
+      is.to_s == should.to_s
+    end
+  end
+
   autorequire(:ec2_vpc_dhcp_options) do
     self[:dhcp_options]
   end


### PR DESCRIPTION
I am working to extend the ec2_vpc type to support Route 53 private hosted zones

For more information see - http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/hosted-zones-private.html

I have added two properties to support setting enableDNSHostnames and enableDNSSupport.

**Looking for input**

The code is working when creating a brand new VPC.  However I am unsure why it is not working when I try to update the boolean value after it has been created.

**Create Sample-VPC**

``` shell
22:52 - root@atom: infrastructure/aws-config
$ puppet resource ec2_vpc sample-vpc ensure=present region=ap-southeast-2 cidr_block='10.0.0.0/16' --modulepath ~/dev/puppet-modules-development
Notice: /Ec2_vpc[sample-vpc]/ensure: created
ec2_vpc { 'sample-vpc':
  ensure => 'absent',
}
```

**Show that Sample-VPC has been created**

``` bash
22:53 - root@atom: infrastructure/aws-config
$ puppet resource ec2_vpc --modulepath ~/dev/puppet-modules-development
ec2_vpc { 'sample-vpc':
  ensure               => 'present',
  cidr_block           => '10.0.0.0/16',
  enable_dns_hostnames => 'false',
  enable_dns_support   => 'true',
  instance_tenancy     => 'default',
  region               => 'ap-southeast-2',
}
```

**Attempt to modify the two boolean values**
Note: Puppet does detect that some values are different and says it will change them.

``` bash
22:54 - root@atom: infrastructure/aws-config
$ puppet resource ec2_vpc sample-vpc ensure=present region=ap-southeast-2 cidr_block='10.0.0.0/16' enable_dns_hostnames=true enable_dns_support=false --modulepath ~/dev/puppet-modules-development
Notice: /Ec2_vpc[sample-vpc]/enable_dns_support: enable_dns_support changed 'true' to 'false'
Notice: /Ec2_vpc[sample-vpc]/enable_dns_hostnames: enable_dns_hostnames changed 'false' to 'true'
ec2_vpc { 'sample-vpc':
  ensure               => 'present',
  cidr_block           => '10.0.0.0/16',
  enable_dns_hostnames => 'true',
  enable_dns_support   => 'false',
  instance_tenancy     => 'default',
  region               => 'ap-southeast-2',
}
```

**Show that it has not updated the two values**

``` bash
22:56 - root@atom: infrastructure/aws-config
$ puppet resource ec2_vpc --modulepath ~/dev/puppet-modules-development
ec2_vpc { 'sample-vpc':
  ensure               => 'present',
  cidr_block           => '10.0.0.0/16',
  enable_dns_hostnames => 'false',
  enable_dns_support   => 'true',
  instance_tenancy     => 'default',
  region               => 'ap-southeast-2',
}
```

Any thoughts on why this is not working?
