### PR TITLE
ec2_elastic_ip instance_id support bug fix for autoscaling.

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,6 +532,9 @@ Specifies that basic state of the resource. Valid values are 'attached', 'detach
 #####`instance`
 *Required* The name of the instance associated with the Elastic IP. This is the value of the AWS Name tag.
 
+#####`instance_id`
+*Optional* The id of the instance_id associated with the Elastic IP. This is the value of the AWS EC2 Instance ID.
+
 
 #### Type: ec2_launchconfiguration
 

--- a/examples/elastic-ip-addresses/README.md
+++ b/examples/elastic-ip-addresses/README.md
@@ -28,12 +28,28 @@ a different account, and IP addresses are unique.
 
 With the module installed as described in the README, from this directory run:
 
-    puppet apply init.pp
+	puppet apply ec2_create.pp
 
-This creates the instances and associates the IP address to the one
-called `web-1`. We can see that by running:
+This creates the EC2 instances called web-1 and web-2.
 
-    puppet resource ec2_elastic_ip
+From here you need to get the Instance ID of the EC2 instance.
+The easiest ways of doing that are from the AWS console, or from the
+command line tools like so:
+
+	aws ec2 describe-instances --filters "Name=tag:Name,Values=web-1"
+
+	aws ec2 describe-instances --filters "Name=tag:Name,Values=web-2"
+
+Once you have the Instance ID's of the two web instances you need to modify the manifest in `init.pp`.
+This is because the Instance ID present in the file is an example and ID's are unique to your account.
+
+With the module installed as described in the README, from this directory run:
+
+	puppet apply init.pp
+
+This associates the IP address to the one called web-1, We can see that by running:
+
+	puppet resource ec2_elastic_ip
 
 Which should return something like:
 
@@ -45,6 +61,11 @@ ec2_elastic_ip { '177.71.189.57':
 }
 ~~~
 
-We can now use `puppet resource` to switch the IP to the `web-2` instance:
+We can now use `puppet resource` to switch the IP to the `web-2` instance (Don't forget to change the IP and instance_id):
 
+<<<<<<< HEAD
+    puppet resource ec2_elastic_ip 177.71.189.57 region=sa-east-1 instance=web-2 instance_id=i-c07c4f3
+
+=======
     puppet resource ec2_elastic_ip 177.71.189.57 region=sa-east-1 region=sa-east-1 instance=web-2
+>>>>>>> parent of 0ef4a58... Revert "Merge branch 'puppetlabs/master'"

--- a/examples/elastic-ip-addresses/ec2_create.pp
+++ b/examples/elastic-ip-addresses/ec2_create.pp
@@ -1,0 +1,6 @@
+ec2_instance { ['web-1', 'web-2']:
+  ensure        => present,
+  region        => 'sa-east-1',
+  image_id      => 'ami-67a60d7a',
+  instance_type => 't1.micro',
+}

--- a/examples/elastic-ip-addresses/init.pp
+++ b/examples/elastic-ip-addresses/init.pp
@@ -2,11 +2,5 @@ ec2_elastic_ip { '177.71.189.57':
   ensure   => 'attached',
   region   => 'sa-east-1',
   instance => 'web-1',
-}
-
-ec2_instance { ['web-1', 'web-2']:
-  ensure        => present,
-  region        => 'sa-east-1',
-  image_id      => 'ami-67a60d7a',
-  instance_type => 't1.micro',
+  instance_id => 'i-c07c4f3',
 }

--- a/lib/puppet/provider/ec2_elastic_ip/v2.rb
+++ b/lib/puppet/provider/ec2_elastic_ip/v2.rb
@@ -61,9 +61,17 @@ Puppet::Type.type(:ec2_elastic_ip).provide(:v2, :parent => PuppetX::Puppetlabs::
     instance_ids = response.reservations.map(&:instances).flatten.map(&:instance_id)
 
     fail "No instance found named #{resource[:instance]}" if instance_ids.empty?
-    if instance_ids.count > 1
-      Puppet.warning "Multiple instances found named #{resource[:instance]}, using #{instance_ids.first}"
+
+    if instance_ids.include?(resource[:instance_id])
+      Puppet.info("Found an instance with a name of #{resource[:instance]} and matches the id of #{resource[:instance_id]}")
+      instance_ids.delete_if {|x| x != resource[:instance_id]}
+    else
+      if instance_ids.count > 1
+        Puppet.warning "Multiple instances found named #{resource[:instance]}, using #{instance_ids.first}"
+      end
+      fail "No instance found named #{resource[:instance]} with an id of #{resource[:instance_id]}" if instance_ids.empty?
     end
+
 
     config = if @property_hash[:domain] == 'vpc'
       {

--- a/lib/puppet/type/ec2_elastic_ip.rb
+++ b/lib/puppet/type/ec2_elastic_ip.rb
@@ -35,6 +35,14 @@ Puppet::Type.newtype(:ec2_elastic_ip) do
     end
   end
 
+  newproperty(:instance_id) do
+    desc 'The id of the instance associated with the Elastic IP'
+    validate do |value|
+      fail 'instance_id should be a String' unless value.is_a?(String)
+      fail 'You must provide an instance_id for the Elastic IP association' if value.nil? || value.empty?
+    end
+  end
+
   autorequire(:ec2_instance) do
     self[:instance]
   end

--- a/spec/acceptance/fixtures/eip.pp.tmpl
+++ b/spec/acceptance/fixtures/eip.pp.tmpl
@@ -2,4 +2,5 @@ ec2_elastic_ip { '{{ip_address}}':
   ensure   => {{ensure_eip}},
   region   => '{{region}}',
   instance => '{{name}}',
+  instance_id => '{{instance_id}}'
 }

--- a/spec/unit/provider/ec2_elastic_ip/v2_spec.rb
+++ b/spec/unit/provider/ec2_elastic_ip/v2_spec.rb
@@ -13,6 +13,7 @@ describe provider_class do
       name: '177.71.189.57',
       region: 'sa-east-1',
       instance: 'web-1',
+      instance_id: 'i-c07c4f3',
     )}
 
     let(:provider) { resource.provider }

--- a/spec/unit/type/ec2_elastic_ip_spec.rb
+++ b/spec/unit/type/ec2_elastic_ip_spec.rb
@@ -15,6 +15,7 @@ describe type_class do
       :ensure,
       :instance,
       :region,
+      :instance_id,
     ]
   end
 
@@ -54,6 +55,12 @@ describe type_class do
     }.to raise_error(Puppet::Error, /You must provide an instance for the Elastic IP association/)
   end
 
+  it 'should require an instance_id to be specified' do
+    expect {
+      type_class.new({ name: '10.0.0.1', region: 'us-east-1', instance: 'web-1', instance_id: '' })
+    }.to raise_error(Puppet::Error, /You must provide an instance_id for the Elastic IP association/)
+  end
+
   it 'should not work with :present' do
     expect {
       type_class.new({ name: '10.0.0.1', :ensure => :present })
@@ -76,7 +83,7 @@ describe type_class do
 
   context 'with valid properties' do
     it 'should create a valid elastic ip ' do
-      type_class.new({ name: '10.0.0.1', region: 'us-east-1', instance: 'web-1' })
+      type_class.new({ name: '10.0.0.1', region: 'us-east-1', instance: 'web-1', instance_id: 'i-c07c4f3'})
     end
   end
 


### PR DESCRIPTION
Changing the c2_elastic_ip module to support instance_id because if two
ec2 instances exist with the same name like in AutoScaling the module
fails because of duplicate names. Now with instance_id you can target a
specific instance along with the name. This is referenced in issue:
ec2_elastic_ip fails in autoscaling (same name) #160