### PR TITLE
(MAINT) We shouldn't care about the return order of availability zones

### DIFF
--- a/spec/acceptance/loadbalancer_spec.rb
+++ b/spec/acceptance/loadbalancer_spec.rb
@@ -160,7 +160,7 @@ describe "ec2_loadbalancer" do
         end
 
         it 'availablity_zones' do
-          regex = /(availability_zones)(\s*)(=>)(\s*)(\[\'sa\-east\-1a\', \'sa\-east\-1b\'\])/
+          regex = /availability_zones\s*=>\s*\[(\'sa\-east\-1a\', \'sa\-east\-1b\'|\'sa\-east\-1b\', \'sa\-east\-1a\')\]/
           expect(@result.stdout).to match(regex)
         end
 


### PR DESCRIPTION
This test just started failing in Jenkins. The test is overly
prescriptive in that we want both availability zones returned but we
don't care about the order. On the other hand this has to my knowledge
never failed before so it's fixed order, just whatever is fixing it has
changed.

This change makes the test more robust, simply allowing both possible
options.