### PR TITLE
(MAINT) deal with issues with invalid names in RDS tests

### DIFF
--- a/spec/acceptance/rds_spec.rb
+++ b/spec/acceptance/rds_spec.rb
@@ -19,7 +19,7 @@ describe "rds_instance" do
 
     before(:all) do
       @config = {
-        :name => "#{PuppetManifest.rds_id}-#{SecureRandom.hex}",
+        :name => "v#{PuppetManifest.rds_id}-#{SecureRandom.hex}",
         :ensure => 'present',
         :region => @default_region,
         :db_name =>  'puppet',

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -73,7 +73,7 @@ class PuppetManifest < Mustache
     @rds_id ||= (
       ENV['BUILD_DISPLAY_NAME'] ||
       (ENV['USER'])
-    ).gsub(/'/, '')
+    ).gsub(/\W+/, '')
   end
 
   def self.env_dns_id


### PR DESCRIPTION
CI generates names that start with numbers. Also, the errors and naming
requirements from different RDS types are different.