### PR TITLE
(WIP- DO NOT MERGE) refactor tests to use Beaker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,8 @@ group :test do
   gem 'vcr'
   gem 'rspec-puppet', :git => 'https://github.com/rodjek/rspec-puppet.git'
   gem 'metadata-json-lint'
+  gem 'beaker-rspec'
+  gem 'beaker-puppet_install_helper'
 end
 
 group :development do

--- a/spec/acceptance/autoscaling_spec.rb
+++ b/spec/acceptance/autoscaling_spec.rb
@@ -69,7 +69,7 @@ describe "ec2_autoscalinggroup" do
         :alarm_actions        => "#{name}-policy",
       }
       r = PuppetManifest.new(@asg_template, @asg_config).apply
-      expect(r[:output].any?{ |o| o.include?('Error:')}).to eq(false)
+      expect(r.stderr).not_to match(/error/i)
       # launch duplicate resources
       @duplicate_asg_config = {
         :region       => @default_region,
@@ -77,7 +77,7 @@ describe "ec2_autoscalinggroup" do
         :lc_name      => "#{name}-lc2",
       }
       r2 = PuppetManifest.new(@duplicate_asg_template, @duplicate_asg_config).apply
-      expect(r2[:output].any?{ |o| o.include?('Error:')}).to eq(false)
+      expect(r2.stderr).not_to match(/error/i)
     end
 
     after(:all) do
@@ -87,7 +87,7 @@ describe "ec2_autoscalinggroup" do
       duplicate_delete = 'duplicate_asg_delete.pp.tmpl'
       r = PuppetManifest.new(@asg_template_delete, @asg_config).apply
       # assert that none of the results contain 'Error:'
-      expect(r[:output].any?{ |o| o.include?('Error:')}).to eq(false)
+      expect(r.stderr).not_to match(/error/i)
       response = @aws.autoscaling_client.describe_auto_scaling_groups(
         auto_scaling_group_names: [@asg_config[:asg_name]],
       )
@@ -104,10 +104,10 @@ describe "ec2_autoscalinggroup" do
       }
       ENV['AWS_REGION'] = @default_region
       r2 = TestExecutor.puppet_resource('ec2_securitygroup', options, '--modulepath ../')
-      expect(r2.stdout).not_to match(/Error:/)
+      expect(r2.stderr).not_to match(/error/i)
       # terminate duplicate resources
       r3 = PuppetManifest.new(duplicate_delete, @duplicate_asg_config).apply
-      expect(r3[:output].any?{ |o| o.include?('Error:')}).to eq(false)
+      expect(r3.stderr).not_to match(/error/i)
     end
 
     it 'should run idempotently' do
@@ -356,7 +356,7 @@ describe "ec2_autoscalinggroup" do
         config = @asg_config.clone
         config[:metric] = 'NetworkIn'
         r = PuppetManifest.new(@asg_template, config).apply
-        expect(r[:output].any?{ |o| o.include?('Error:')}).to eq(false)
+        expect(r.stderr).not_to match(/error/i)
         cloudwatch = find_alarm(@asg_config[:alarm_name])
         expect(cloudwatch.metric_name).to eq('NetworkIn')
       end
@@ -367,7 +367,7 @@ describe "ec2_autoscalinggroup" do
         config[:metric] = 'AWS/ELB'
         config[:namespace] = 'HealthyHostCount'
         r = PuppetManifest.new(@asg_template, config).apply
-        expect(r[:output].any?{ |o| o.include?('Error:')}).to eq(false)
+        expect(r.stderr).not_to match(/error/i)
         cloudwatch = find_alarm(@asg_config[:alarm_name])
         expect(cloudwatch.metric_name).to eq('AWS/ELB')
         expect(cloudwatch.namespace).to eq('HealthyHostCount')
@@ -377,7 +377,7 @@ describe "ec2_autoscalinggroup" do
         config = @asg_config.clone
         config[:statistic] = 'Sum'
         r = PuppetManifest.new(@asg_template, config).apply
-        expect(r[:output].any?{ |o| o.include?('Error:')}).to eq(false)
+        expect(r.stderr).not_to match(/error/i)
         cloudwatch = find_alarm(@asg_config[:alarm_name])
         expect(cloudwatch.statistic).to eq('Sum')
       end
@@ -386,7 +386,7 @@ describe "ec2_autoscalinggroup" do
         config = @asg_config.clone
         config[:period] = 180
         r = PuppetManifest.new(@asg_template, config).apply
-        expect(r[:output].any?{ |o| o.include?('Error:')}).to eq(false)
+        expect(r.stderr).not_to match(/error/i)
         cloudwatch = find_alarm(@asg_config[:alarm_name])
         expect(cloudwatch.period).to eq(180)
       end
@@ -395,7 +395,7 @@ describe "ec2_autoscalinggroup" do
         config = @asg_config.clone
         config[:evaluation_periods] = 4
         r = PuppetManifest.new(@asg_template, config).apply
-        expect(r[:output].any?{ |o| o.include?('Error:')}).to eq(false)
+        expect(r.stderr).not_to match(/error/i)
         cloudwatch = find_alarm(@asg_config[:alarm_name])
         expect(cloudwatch.evaluation_periods).to eq(4)
       end
@@ -404,7 +404,7 @@ describe "ec2_autoscalinggroup" do
         config = @asg_config.clone
         config[:threshold] = 50
         r = PuppetManifest.new(@asg_template, config).apply
-        expect(r[:output].any?{ |o| o.include?('Error:')}).to eq(false)
+        expect(r.stderr).not_to match(/error/i)
         cloudwatch = find_alarm(@asg_config[:alarm_name])
         expect(cloudwatch.threshold).to eq(50.0)
       end
@@ -413,7 +413,7 @@ describe "ec2_autoscalinggroup" do
         config = @asg_config.clone
         config[:comparison_operator] = 'GreaterThanThreshold'
         r = PuppetManifest.new(@asg_template, config).apply
-        expect(r[:output].any?{ |o| o.include?('Error:')}).to eq(false)
+        expect(r.stderr).not_to match(/error/i)
         cloudwatch = find_alarm(@asg_config[:alarm_name])
         expect(cloudwatch.comparison_operator).to eq('GreaterThanThreshold')
       end
@@ -426,7 +426,7 @@ describe "ec2_autoscalinggroup" do
         config = @asg_config.clone
         config[:scaling_adjustment] = 40
         r = PuppetManifest.new(@asg_template, config).apply
-        expect(r[:output].any?{ |o| o.include?('Error:')}).to eq(false)
+        expect(r.stderr).not_to match(/error/i)
         policy = find_scaling_policy(@asg_config[:policy_name], @asg_config[:asg_name])
         expect(policy.scaling_adjustment).to eq(40)
       end
@@ -435,7 +435,7 @@ describe "ec2_autoscalinggroup" do
         config = @asg_config.clone
         config[:adjustment_type] = 'ExactCapacity'
         r = PuppetManifest.new(@asg_template, config).apply
-        expect(r[:output].any?{ |o| o.include?('Error:')}).to eq(false)
+        expect(r.stderr).not_to match(/error/i)
         policy = find_scaling_policy(@asg_config[:policy_name], @asg_config[:asg_name])
         expect(policy.adjustment_type).to eq('ExactCapacity')
       end
@@ -448,7 +448,7 @@ describe "ec2_autoscalinggroup" do
         config = @asg_config.clone
         config[:min_size] = 3
         r = PuppetManifest.new(@asg_template, config).apply
-        expect(r[:output].any?{ |o| o.include?('Error:')}).to eq(false)
+        expect(r.stderr).not_to match(/error/i)
         group = find_autoscaling_group(@asg_config[:asg_name])
         expect(group.min_size).to eq(3)
       end
@@ -457,7 +457,7 @@ describe "ec2_autoscalinggroup" do
         config = @asg_config.clone
         config[:max_size] = 5
         r = PuppetManifest.new(@asg_template, config).apply
-        expect(r[:output].any?{ |o| o.include?('Error:')}).to eq(false)
+        expect(r.stderr).not_to match(/error/i)
         group = find_autoscaling_group(@asg_config[:asg_name])
         expect(group.max_size).to eq(5)
       end
@@ -466,7 +466,7 @@ describe "ec2_autoscalinggroup" do
         config = @asg_config.clone
         config[:lc_setting] = @duplicate_asg_config[:lc_name]
         r = PuppetManifest.new(@asg_template, config).apply
-        expect(r[:output].any?{ |o| o.include?('Error:')}).to eq(false)
+        expect(r.stderr).not_to match(/error/i)
         group = find_autoscaling_group(@asg_config[:asg_name])
         expect(group.launch_configuration_name).to eq(@duplicate_asg_config[:lc_name])
       end
@@ -475,7 +475,7 @@ describe "ec2_autoscalinggroup" do
         config = @asg_config.clone
         config[:availability_zones] = ["#{@default_region}b"]
         r = PuppetManifest.new(@asg_template, config).apply
-        expect(r[:output].any?{ |o| o.include?('Error:')}).to eq(false)
+        expect(r.stderr).not_to match(/error/i)
         group = find_autoscaling_group(@asg_config[:asg_name])
         expect(group.availability_zones.sort).to eq(config[:availability_zones].sort)
       end
@@ -499,18 +499,18 @@ describe "ec2_autoscalinggroup" do
         :subnet_cidr => '10.0.0.0/24',
       }
       r = PuppetManifest.new(@template, @config).apply
-      expect(r[:output].any?{ |o| o.include?('Error:')}).to eq(false)
+      expect(r.stderr).not_to match(/error/i)
     end
 
     after(:all) do
       @config[:ensure] = 'absent'
       r = PuppetManifest.new(@template_delete, @config).apply
-      expect(r[:output].any?{ |o| o.include?('Error:')}).to eq(false)
+      expect(r.stderr).not_to match(/error/i)
     end
 
     it 'should run idempotently' do
-      success = PuppetManifest.new(@template, @config).apply[:exit_status].success?
-      expect(success).to eq(true)
+      result = PuppetManifest.new(@template, @config).apply
+      expect(result.exit_code.to_s).to eq('0')
     end
 
     context 'should create' do

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -1,0 +1,25 @@
+HOSTS:
+  centos-7-x86_86-master:
+    roles:
+      - master
+      - dashboard
+      - database
+      - agent
+    platform: el-7-x86_64
+    template: Delivery/Quality Assurance/Templates/vCloud/centos-7-x86_64
+    hypervisor: vcloud
+  centos-7-x86_86-agent:
+    roles:
+      - agent
+      - default
+    platform: el-7-x86_64
+    template: Delivery/Quality Assurance/Templates/vCloud/centos-7-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vmpooler.delivery.puppetlabs.net/
+  forge_host: api-module-staging.puppetlabs.com

--- a/spec/acceptance/securitygroup_spec.rb
+++ b/spec/acceptance/securitygroup_spec.rb
@@ -132,8 +132,8 @@ describe "ec2_securitygroup" do
         :cidr     => '0.0.0.0/0'
       }]
       new_config = @config.dup.update({:ingress => new_rules})
-      success = PuppetManifest.new(@template, new_config).apply[:exit_status].success?
-      expect(success).to eq(false)
+      result = PuppetManifest.new(@template, new_config).apply
+      expect(result.exit_code).to eq('0')
 
       # should still have the original rules
       @group = get_group(@config[:name])
@@ -170,8 +170,8 @@ describe "ec2_securitygroup" do
       end
 
       it 'and should not fail to be applied multiple times' do
-        success = PuppetManifest.new(@template, @config_2).apply[:exit_status].success?
-        expect(success).to eq(true)
+        result = PuppetManifest.new(@template, @config_2).apply
+        expect(result.exit_code).to eq('0')
       end
     end
   end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -32,7 +32,7 @@ class PuppetManifest < Mustache
   end
 
   def apply
-    Toggle_switch.shell(self.render)
+    ToggleSwitch.shell(self.render)
   end
 
   def self.to_generalized_data(val)
@@ -269,14 +269,14 @@ class TestExecutor
     cmd << options
     cmd << " #{command_flags}"
     # apply the command
-    response = Toggle_switch.shell(cmd)
+    response = ToggleSwitch.shell(cmd)
     response
   end
 
 end
 
 # a common class to use to switch between local shell access and an Agent as SUT
-class Toggle_switch
+class ToggleSwitch
 
   def self.shell(cmd)
     if ENV['DEVELOPMENT']
@@ -307,7 +307,7 @@ class Toggle_switch
       @error = read_stream(stderr)
       @code = /(exit)(\s)(\d+)/.match(wait_thr.value.to_s)[3]
     end
-    Toggle_switch::Beaker_like_response.new(@out, @error, @code, cmd)
+    ToggleSwitch::Beaker_like_response.new(@out, @error, @code, cmd)
   end
 
   def self.read_stream(stream)
@@ -321,7 +321,7 @@ class Toggle_switch
 
 end
 
-class Toggle_switch::Beaker_like_response
+class ToggleSwitch::Beaker_like_response
   attr_reader :stdout , :stderr, :exit_code, :command
 
   def initialize(standard_out, standard_error, exit, cmd)


### PR DESCRIPTION
These tests should now work with beaker and without beaker.  
To run without beaker:
DEVELOPMENT=true bundle exec rspec spec/acceptance 
To run with beaker 
bundle exec rspec spec/acceptance 

All beaker-rspec env vars work.  The tests assume that the agent used to do the provisioning will have the default role.  A default nodeset is provided with this PR.  