### PR TITLE
Ignore ELB instance order

### DIFF
--- a/lib/puppet/type/elb_loadbalancer.rb
+++ b/lib/puppet/type/elb_loadbalancer.rb
@@ -77,6 +77,9 @@ Puppet::Type.newtype(:elb_loadbalancer) do
     validate do |value|
       fail 'instances should be a String' unless value.is_a?(String)
     end
+    def insync?(is)
+      is.to_set == should.to_set
+    end
   end
 
   newproperty(:scheme) do

--- a/spec/unit/type/elb_loadbalancer_spec.rb
+++ b/spec/unit/type/elb_loadbalancer_spec.rb
@@ -130,7 +130,7 @@ describe type_class do
     expect(elb[:scheme]).to eq(:internal)
   end
 
-  ['subnets', 'security_groups'].each do |property|
+  ['instances', 'subnets', 'security_groups'].each do |property|
     it "should ignore the order of #{property} for matching" do
       values = ['a', 'b']
       config = {:name => 'sample'}


### PR DESCRIPTION
`Elb_loadbalancer` should ignore the order of instances for comparison. 

After creating an ELB with a definition like this...:

````puppet
elb_loadbalancer { 'web':
  ...
  instances => [
    'web-1',
    'web-2',
  ],
  ...
}
````

...subsequent runs failed without modification to the manifest, because the AWS API returned the instances in a different order:

    Notice: /Stage[main]/Elb_loadbalancer[web]/instances: current_value ["web-2", "web-1"],
    should be web-1 web-2

This change ignores the array's order for comparison, matching behavior of the `subnets` and `security_groups` parameters.