### PR TITLE
(CLOUD-412, CLOUD-411) Support specifying backup retention

### DIFF
--- a/README.md
+++ b/README.md
@@ -909,6 +909,9 @@ parameter is set at creation only; it is not affected by updates.
 The name of the snapshot created when the instance is terminated. Note
 that skip_final_snapshot must be set to false.
 
+#####`backup_retention_period`
+The number of days to retain backups. Defaults to 30 days.
+
 #### Type: route53
 
 The route53 types set up various types of Route53 records:

--- a/lib/puppet/provider/rds_instance/v2.rb
+++ b/lib/puppet/provider/rds_instance/v2.rb
@@ -23,7 +23,7 @@ Puppet::Type.type(:rds_instance).provide(:v2, :parent => PuppetX::Puppetlabs::Aw
   read_only(:iops, :master_username, :multi_az, :license_model,
             :db_name, :region, :db_instance_class, :availability_zone,
             :engine, :engine_version, :allocated_storage, :storage_type,
-            :db_security_groups, :db_parameter_group)
+            :db_security_groups, :db_parameter_group, :backup_retention_period)
 
   def self.prefetch(resources)
     instances.each do |prov|
@@ -50,6 +50,7 @@ Puppet::Type.type(:rds_instance).provide(:v2, :parent => PuppetX::Puppetlabs::Aw
       iops: instance.iops,
       db_parameter_group: instance.db_parameter_groups.collect(&:db_parameter_group_name).first,
       db_security_groups: instance.db_security_groups.collect(&:db_security_group_name),
+      backup_retention_period: instance.backup_retention_period
     }
     if instance.respond_to?('endpoint') && !instance.endpoint.nil?
       config[:endpoint] = instance.endpoint.address
@@ -82,6 +83,7 @@ Puppet::Type.type(:rds_instance).provide(:v2, :parent => PuppetX::Puppetlabs::Aw
       subnet_group_name: resource[:db_subnet],
       db_security_groups: resource[:db_security_groups],
       db_parameter_group_name: resource[:db_parameter_group],
+      backup_retention_period: resource[:backup_retention_period],
     }
 
     rds_client(resource[:region]).create_db_instance(config)

--- a/lib/puppet/type/rds_instance.rb
+++ b/lib/puppet/type/rds_instance.rb
@@ -95,9 +95,11 @@ Not applicable. Must be null.'
 
   newproperty(:allocated_storage) do
     desc 'The size of the DB.'
+    munge do |value|
+      value.to_i
+    end
     validate do |value|
-      fail 'allocated_storage type should not contains spaces' if value =~ /\s/
-      fail 'allocated_storage should not be blank' if value == ''
+      fail 'allocated_storage must be an integer' unless value.to_i.to_s == value.to_s
     end
   end
 
@@ -193,6 +195,17 @@ Not applicable. Must be null.'
     validate do |value|
       fail 'final_db_snapshot_identifier should be a String' unless value.is_a?(String)
       fail 'final_db_snapshot_identifier should not be blank' if value == ''
+    end
+  end
+
+  newproperty(:backup_retention_period) do
+    desc 'The number of days to retain backups. Defaults to 30 days.'
+    defaultto 30
+    munge do |value|
+      value.to_i
+    end
+    validate do |value|
+      fail 'backup_retention_period must be an integer' unless value.to_i.to_s == value.to_s
     end
   end
 

--- a/spec/acceptance/fixtures/rds.pp.tmpl
+++ b/spec/acceptance/fixtures/rds.pp.tmpl
@@ -12,4 +12,5 @@ rds_instance { '{{name}}':
   master_user_password => '{{master_user_password}}',
   multi_az => '{{multi_az}}',
   skip_final_snapshot => '{{skip_final_snapshot}}',
+  backup_retention_period => '{{backup_retention_period}}',
 }

--- a/spec/acceptance/rds_spec.rb
+++ b/spec/acceptance/rds_spec.rb
@@ -33,10 +33,10 @@ describe "rds_instance" do
         :master_user_password => 'pullth3stringz',
         :multi_az => false,
         :skip_final_snapshot => true,
+        :backup_retention_period => 5,
       }
 
-      manifest = PuppetManifest.new(@template, @config)
-      manifest.apply
+      @result = PuppetManifest.new(@template, @config).apply
       @rds_instance = get_rds_instance(@config[:name])
     end
 
@@ -45,12 +45,25 @@ describe "rds_instance" do
       PuppetManifest.new(@template, new_config).apply
     end
 
+    it 'should run with changes' do
+      expect(@result.exit_code).to eq(2)
+    end
+
+    it 'should run idempotently' do
+      result = PuppetManifest.new(@template, @config).apply
+      expect(result.exit_code).to eq(0)
+    end
+
     it 'with the specified name' do
       expect(@rds_instance.db_instance_identifier).to eq(@config[:name])
     end
 
     it 'with the specified db_name' do
       expect(@rds_instance.db_name).to eq(@config[:db_name])
+    end
+
+    it 'with the specified backup_retention_period' do
+      expect(@rds_instance.backup_retention_period).to eq(@config[:backup_retention_period])
     end
 
     it 'with the specified engine' do
@@ -135,6 +148,11 @@ describe "rds_instance" do
 
       it 'storage type is correct' do
         regex = /(storage_type)(\s*)(=>)(\s*)('#{@config[:storage_type]}')/
+        expect(@result.stdout).to match(regex)
+      end
+
+      it 'backup retention is correct' do
+        regex = /(backup_retention_period)(\s*)(=>)(\s*)('#{@config[:backup_retention_period]}')/
         expect(@result.stdout).to match(regex)
       end
     end

--- a/spec/unit/type/rds_instance_spec.rb
+++ b/spec/unit/type/rds_instance_spec.rb
@@ -33,6 +33,7 @@ describe type_class do
       :endpoint,
       :port,
       :db_parameter_group,
+      :backup_retention_period,
     ]
   end
 
@@ -71,7 +72,7 @@ describe type_class do
     expect(srv[:skip_final_snapshot]).to eq(:false)
   end
 
-  it 'should default mult_az to false' do
+  it 'should default multi_az to false' do
     srv = type_class.new(:name => 'sample')
     expect(srv[:multi_az]).to eq(:false)
   end
@@ -108,4 +109,44 @@ describe type_class do
     end
   end
 
+  it 'backup_retention_period must be an integer' do
+    expect {
+      type_class.new(:name => 'sample', :backup_retention_period => 'Ten')
+    }.to raise_error(Puppet::ResourceError, /backup_retention_period must be an integer/)
+  end
+
+  context 'with the backup_retention_period set to an integer' do
+    let(:machine) { type_class.new(:name => 'sample', :backup_retention_period => 40) }
+
+    it 'should be happy with strings for backup_retention_period' do
+      expect(machine.property(:backup_retention_period).insync?('40')).to be true
+    end
+
+    it 'should be happy with integers for backup_retention_period' do
+      expect(machine.property(:backup_retention_period).insync?(40)).to be true
+    end
+  end
+
+  it 'should default backup_retention_period to 30' do
+    srv = type_class.new(:name => 'sample')
+    expect(srv[:backup_retention_period]).to eq(30)
+  end
+
+  it 'allocated_storage must be an integer' do
+    expect {
+      type_class.new(:name => 'sample', :allocated_storage => 'Ten')
+    }.to raise_error(Puppet::ResourceError, /allocated_storage must be an integer/)
+  end
+
+  context 'with the allocated_storage set to an integer' do
+    let(:machine) { type_class.new(:name => 'sample', :allocated_storage => 40) }
+
+    it 'should be happy with strings for allocated_storage' do
+      expect(machine.property(:allocated_storage).insync?('40')).to be true
+    end
+
+    it 'should be happy with integers for allocated_storage' do
+      expect(machine.property(:allocated_storage).insync?(40)).to be true
+    end
+  end
 end


### PR DESCRIPTION
It was pointed out that the AWS console defaults the backup retention to
30 days, however the API defaults it to 1 day. Because we we're exposing
that parameter this was both impossible to change and a bit invisible.

This change adds the ability to manage the backup retention period for
new RDS instances.

In the process of testing that change to ensure it was idempotent I
added the relevant (missing) test. This passed for the new property but
failed for another one (allocated_storage). This was reported separately
in CLOUD-411. This commit fixes that too.