### PR TITLE
[BUGFIX] rds_instance with VPC db_subnet

### DIFF
--- a/lib/puppet/provider/rds_instance/v2.rb
+++ b/lib/puppet/provider/rds_instance/v2.rb
@@ -79,7 +79,7 @@ Puppet::Type.type(:rds_instance).provide(:v2, :parent => PuppetX::Puppetlabs::Aw
       iops: resource[:iops],
       master_username: resource[:master_username],
       master_user_password: resource[:master_user_password],
-      subnet_group_name: resource[:db_subnet],
+      db_subnet_group_name: resource[:db_subnet],
       db_security_groups: resource[:db_security_groups],
       db_parameter_group_name: resource[:db_parameter_group],
     }

--- a/lib/puppet/type/rds_instance.rb
+++ b/lib/puppet/type/rds_instance.rb
@@ -152,8 +152,8 @@ Not applicable. Must be null.'
   newparam(:db_subnet) do
     desc 'The VPC DB subnet for this instance.'
     validate do |value|
-      fail 'subnet_group_name should be a String' unless value.is_a?(String)
-      fail 'subnet_group_name should not be blank' if value == ''
+      fail 'db_subnet_group_name should be a String' unless value.is_a?(String)
+      fail 'db_subnet_group_name should not be blank' if value == ''
     end
   end
 


### PR DESCRIPTION
Trying to create an `rds_instance` with the `db_subnet` parameter failed with:
```
Error: Could not set 'present' on ensure: unexpected value at params[:subnet_group_name]
```
The AWS CLI manual for `rds create-db-instance` specifies the parameter as `[--db-subnet-group-name <value>]`.

Updating the parameter to the correct name fixes the error and results in
correct creation of an RDS instance within the VPC subnet group.