### PR TITLE
Allow snapshot to be specified in block mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,13 +366,22 @@ The name of the key pair associated with this instance. This must be an existing
 *Optional* Whether the instance stops or terminates when you initiate shutdown from the instance. This parameter is set at creation only; it is not affected by updates. Valid values are 'stop', 'terminate'. Defaults to 'stop'.
 
 #####`block_devices`
-*Optional* A list of block devices to associate with the instance. This parameter is set at creation only; it is not affected by updates. Accepts an array of hashes with the device name and volume size specified:
+*Optional* A list of block devices to associate with the instance. This parameter is set at creation only; it is not affected by updates. Accepts an array of hashes with the device name and either the volume size or snapshot id specified:
 
 ~~~
 block_devices => [
   {
     device_name  => '/dev/sda1',
     volume_size  => 8,
+  }
+]
+~~~
+
+~~~
+block_devices => [
+  {
+    device_name  => '/dev/sda1',
+    snapshot_id => 'snap-29a6ca13',
   }
 ]
 ~~~

--- a/lib/puppet/provider/ec2_instance/v2.rb
+++ b/lib/puppet/provider/ec2_instance/v2.rb
@@ -211,6 +211,7 @@ Found #{matching_groups.length}:
         device_name: device['device_name'],
         ebs: {
           volume_size: device['volume_size'],
+          snapshot_id: device['snapshot_id'],
           delete_on_termination: device['delete_on_termination'] || true,
           volume_type: device['volume_type'] || 'standard',
           iops: device['iops'],

--- a/lib/puppet/type/ec2_instance.rb
+++ b/lib/puppet/type/ec2_instance.rb
@@ -212,9 +212,9 @@ Puppet::Type.newtype(:ec2_instance) do
     validate do |value|
       devices = value.is_a?(Array) ? value : [value]
       devices.each do |device|
-        ['device_name', 'volume_size'].each do |key|
-          fail "block device must include #{key}" unless value.keys.include?(key)
-        end
+        fail "block device must be named" unless value.keys.include?('device_name')
+        choices = ['volume_size', 'snapshot_id']
+        fail "block device must include at least one of: " + choices.join(' ') if (value.keys & choices).empty?
         if value['volume_type'] == 'io1'
           fail 'must specify iops if using provisioned iops volumes' unless value.keys.include?('iops')
         end

--- a/spec/unit/type/ec2_instance_spec.rb
+++ b/spec/unit/type/ec2_instance_spec.rb
@@ -80,15 +80,15 @@ describe type_class do
       type_class.new({:name => 'sample', :block_devices => [
         {'volume_size' => 8}
       ]})
-    }.to raise_error(Puppet::Error, /block device must include device_name/)
+    }.to raise_error(Puppet::Error, /block device must be named/)
   end
 
-  it 'if block device included must include a volume size' do
+  it 'if block device included must include a volume size or snapshot' do
     expect {
       type_class.new({:name => 'sample', :block_devices => [
         {'device_name' => '/dev/sda1'}
       ]})
-    }.to raise_error(Puppet::Error, /block device must include volume_size/)
+    }.to raise_error(Puppet::Error, /block device must include at least one of: volume_size snapshot_id/)
   end
 
   it 'if private IP included must be a valid IP' do


### PR DESCRIPTION
This change makes it possible to attach volumes based on snapshots to new ec2
instances.