### PR TITLE
Filter subnet search based on AZ

### DIFF
--- a/lib/puppet/provider/ec2_instance/v2.rb
+++ b/lib/puppet/provider/ec2_instance/v2.rb
@@ -123,7 +123,7 @@ Puppet::Type.type(:ec2_instance).provide(:v2, :parent => PuppetX::Puppetlabs::Aw
     ec2 = ec2_client(resource[:region])
     # filter by VPC, since describe_subnets doesn't work on empty tag:Name
     subnet_response = ec2.describe_subnets(filters: [
-      {name: "vpc-id", values: vpc_ids}])
+      {name: "vpc-id", values: vpc_ids}, { name: "availability-zone:", values: resource[:availability_zone] ])
 
     # then find the name in the VPC subnets that we have
     subnets = subnet_response.data.subnets.select do |s|


### PR DESCRIPTION
At our organisation we have our subnets with a common name across AZs (not interested in the pros and cons of this - it wasn't my decision!). However, it means that often puppet finds the wrong subnet.

Considering it's necessary to specify the AZ on ec2_instance creation, it's okay to filter the subnet search based on the AZ.
