### PR TITLE
Add support for region and proxy facts

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ region using an environment variable.
 export AWS_REGION=eu-west-1
 ~~~
 
+Alternatively, an `aws_region` fact can be used when environment variables 
+aren't accessible (such as during Puppet agent runs).
+
 #### A note on proxies
 
 By default the module accesses the AWS API directly, but if you're in an
@@ -110,6 +113,8 @@ setting for all traffic like so:
 export PUPPET_AWS_PROXY=http://localhost:8888
 ~~~
 
+Alternatively, a `puppet_aws_proxy` fact can be used when environment 
+variables aren't accessible (such as during Puppet agent runs).
 
 ##Getting Started with aws
 

--- a/lib/puppet_x/puppetlabs/aws.rb
+++ b/lib/puppet_x/puppetlabs/aws.rb
@@ -27,7 +27,7 @@ This could be because some other process is modifying AWS at the same time."""
         if ENV['AWS_REGION'] and not ENV['AWS_REGION'].empty?
           [ENV['AWS_REGION']]
         elsif Facter.value(:aws_region)
-          Facter.value(:aws_region)
+          [Facter.value(:aws_region)]
         else
           ec2_client(default_region).describe_regions.data.regions.map(&:region_name)
         end

--- a/lib/puppet_x/puppetlabs/aws.rb
+++ b/lib/puppet_x/puppetlabs/aws.rb
@@ -26,6 +26,8 @@ This could be because some other process is modifying AWS at the same time."""
       def self.regions
         if ENV['AWS_REGION'] and not ENV['AWS_REGION'].empty?
           [ENV['AWS_REGION']]
+        elsif Facter.value(:aws_region)
+          Facter.value(:aws_region)
         else
           ec2_client(default_region).describe_regions.data.regions.map(&:region_name)
         end
@@ -67,6 +69,8 @@ This could be because some other process is modifying AWS at the same time."""
         config = {region: region, logger: logger}
         if ENV['PUPPET_AWS_PROXY'] and not ENV['PUPPET_AWS_PROXY'].empty?
           config[:http_proxy] = ENV['PUPPET_AWS_PROXY']
+        elsif Facter.value(:puppet_aws_proxy)
+          config[:http_proxy] = Facter.value(:puppet_aws_proxy)
         end
         config
       end


### PR DESCRIPTION
When using this module during a Puppet agent run, the environment variables AWS_REGION and PUPPET_AWS_PROXY are not available to Puppet.  This adds support for facts named aws_region and puppet_aws_proxy that can be used for the same purpose.