### PR TITLE
Add delete_on_termination and volume_type to block_devices parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,13 +366,15 @@ The name of the key pair associated with this instance. This must be an existing
 *Optional* Whether the instance stops or terminates when you initiate shutdown from the instance. This parameter is set at creation only; it is not affected by updates. Valid values are 'stop', 'terminate'. Defaults to 'stop'.
 
 #####`block_devices`
-*Optional* A list of block devices to associate with the instance. This parameter is set at creation only; it is not affected by updates. Accepts an array of hashes with the device name and volume size specified:
+*Optional* A list of block devices to associate with the instance. This parameter is set at creation only; it is not affected by updates. Accepts an array of hashes with the device name, volume size, delete on termination flag, and volume type specified:
 
 ~~~
 block_devices => [
   {
-    device_name  => '/dev/sda1',
-    volume_size  => 8,
+    device_name           => '/dev/sda1',
+    volume_size           => 8,
+    delete_on_termination => 'true',
+    volume_type'          => 'gp2',
   }
 ]
 ~~~


### PR DESCRIPTION
Updating documentation to expose two already functioning settings for the block_devices parameter of the ec2_instance type
