### PR TITLE
Modifying Route 53 Provider

### DIFF
--- a/lib/puppet/provider/route53_record.rb
+++ b/lib/puppet/provider/route53_record.rb
@@ -7,7 +7,7 @@ class Puppet::Provider::Route53Record < PuppetX::Puppetlabs::Aws
       zones_response = route53_client.list_hosted_zones()
       records = []
       zones_response.data.hosted_zones.each do |zone|
-        records_response = route53_client.list_resource_record_sets(hosted_zone_id: zone.id)
+        route53_client.list_resource_record_sets(hosted_zone_id: zone.id).each do |records_response|
         records_response.data.resource_record_sets.each do |record|
           records << new({
             name: record.name,
@@ -18,6 +18,8 @@ class Puppet::Provider::Route53Record < PuppetX::Puppetlabs::Aws
           }) if record.type == record_type
         end
       end
+    end
+      
       records
     rescue StandardError => e
       raise PuppetX::Puppetlabs::FetchingAWSDataError.new(region, self.resource_type.name.to_s, e.message)


### PR DESCRIPTION
Resolving a bug in the route53 provider that was preventing the
retrieval of more than 100 resource_record_sets in any given zone.
The Change enumerates the aws response object, allowing the client to page
through the responses.  I have been able to test this against a route53 zone with over 900 records. Provider now returns all values. 