### PR TITLE
Introduce new feature: Manage SQS queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ You can use the aws module to audit AWS resources, launch autoscaling groups in 
 * `route53_srv_record`: Sets up a Route53 SRV record.
 * `route53_txt_record`: Sets up a Route53 TXT record.
 * `route53_zone`: Sets up a Route53 DNS zone.
+* `sqs_queue`: Sets up an SQS queue.
 
 ###Parameters
 
@@ -967,6 +968,22 @@ All Route53 record types use the same parameters:
 
 #####`name`
 *Required* The name of DNS zone group. This is the value of the AWS Name tag.
+
+#### Type: sqs_queue
+#####`name`
+*Required* The name of the SQS queue.
+
+#####`region`
+*Required* The region in which to create the SQS Queue. For valid values, see [AWS Regions](http://docs.aws.amazon.com/general/latest/gr/rande.html#ec2_region).
+
+#####`delay_seconds`
+*Optional* The time in seconds that the delivery of all messages in the queue will be delayed. Default value: 0
+
+#####`message_retention_period`
+*Optional* The number of seconds Amazon SQS retains a message. Default value: 345600
+
+#####`maximum_message_size`
+*Optional* The limit of how many bytes a message can contain before Amazon SQS rejects it.
 
 
 ##Limitations

--- a/fixtures/vcr_cassettes/create-named-queue.yml
+++ b/fixtures/vcr_cassettes/create-named-queue.yml
@@ -1,0 +1,48 @@
+--- 
+  http_interactions: 
+    - request: 
+        method: post
+        uri: "https://sqs.us-east-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "Action=CreateQueue&Attribute.1.Name=DelaySeconds&Attribute.1.Value=0&Attribute.2.Name=MessageRetentionPeriod&Attribute.2.Value=345600&Attribute.3.Name=MaximumMessageSize&Attribute.3.Value=262144&QueueName=queue&Version=2012-11-05"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.5 ruby/1.9.3 x86_64-darwin13.4.0"
+          X-Amz-Date: 
+            - "20151102T185456Z"
+          X-Amz-Content-Sha256: 
+            - ed9f0ba97216a562b1c1c31775652b4e1b127edcbebd5c9a7713f0ff3dca707d
+          Authorization: 
+            - "AWS4-HMAC-SHA256 Credential=redacted/20151102/us-east-1/sqs/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=777940b7a14c286132d4cd46d6163dc20edc44ccf28680212b92b33c1a02bedb"
+          Content-Length: 
+            - "229"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Server: 
+            - Server
+          Date: 
+            - "Mon, 02 Nov 2015 18:52:58 GMT"
+          Content-Type: 
+            - text/xml
+          Content-Length: 
+            - "325"
+          Connection: 
+            - keep-alive
+          X-Amzn-Requestid: 
+            - a093bbce-3eb9-5479-8020-f57f8df3d988
+        body: 
+          encoding: US-ASCII
+          string: "<?xml version=\x221.0\x22?><CreateQueueResponse xmlns=\x22http://queue.amazonaws.com/doc/2012-11-05/\x22><CreateQueueResult><QueueUrl>https://sqs.us-east-1.amazonaws.com/854330369555/queue</QueueUrl></CreateQueueResult><ResponseMetadata><RequestId>a093bbce-3eb9-5479-8020-f57f8df3d988</RequestId></ResponseMetadata></CreateQueueResponse>"
+        http_version: 
+      recorded_at: "Mon, 02 Nov 2015 18:54:57 GMT"
+  recorded_with: "VCR 2.9.3"

--- a/fixtures/vcr_cassettes/create-named-queue.yml
+++ b/fixtures/vcr_cassettes/create-named-queue.yml
@@ -2,7 +2,7 @@
   http_interactions: 
     - request: 
         method: post
-        uri: "https://sqs.us-east-1.amazonaws.com/"
+        uri: "https://sqs.sa-east-1.amazonaws.com/"
         body: 
           encoding: UTF-8
           string: "Action=CreateQueue&Attribute.1.Name=DelaySeconds&Attribute.1.Value=0&Attribute.2.Name=MessageRetentionPeriod&Attribute.2.Value=345600&Attribute.3.Name=MaximumMessageSize&Attribute.3.Value=262144&QueueName=queue&Version=2012-11-05"
@@ -14,11 +14,11 @@
           User-Agent: 
             - "aws-sdk-ruby2/2.0.5 ruby/1.9.3 x86_64-darwin13.4.0"
           X-Amz-Date: 
-            - "20151102T185456Z"
+            - "20151103T154201Z"
           X-Amz-Content-Sha256: 
             - ed9f0ba97216a562b1c1c31775652b4e1b127edcbebd5c9a7713f0ff3dca707d
           Authorization: 
-            - "AWS4-HMAC-SHA256 Credential=redacted/20151102/us-east-1/sqs/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=777940b7a14c286132d4cd46d6163dc20edc44ccf28680212b92b33c1a02bedb"
+            - "AWS4-HMAC-SHA256 Credential=redacted/20151103/sa-east-1/sqs/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=a88abd2eb6fc357ea2d7769762819bd9891bdcc12fbce199fe63a6e9dcde25f1"
           Content-Length: 
             - "229"
           Accept: 
@@ -31,7 +31,7 @@
           Server: 
             - Server
           Date: 
-            - "Mon, 02 Nov 2015 18:52:58 GMT"
+            - "Tue, 03 Nov 2015 15:40:03 GMT"
           Content-Type: 
             - text/xml
           Content-Length: 
@@ -39,10 +39,10 @@
           Connection: 
             - keep-alive
           X-Amzn-Requestid: 
-            - a093bbce-3eb9-5479-8020-f57f8df3d988
+            - fca7d6db-f58b-53a2-8e03-98692218fc01
         body: 
           encoding: US-ASCII
-          string: "<?xml version=\x221.0\x22?><CreateQueueResponse xmlns=\x22http://queue.amazonaws.com/doc/2012-11-05/\x22><CreateQueueResult><QueueUrl>https://sqs.us-east-1.amazonaws.com/854330369555/queue</QueueUrl></CreateQueueResult><ResponseMetadata><RequestId>a093bbce-3eb9-5479-8020-f57f8df3d988</RequestId></ResponseMetadata></CreateQueueResponse>"
+          string: "<?xml version=\x221.0\x22?><CreateQueueResponse xmlns=\x22http://queue.amazonaws.com/doc/2012-11-05/\x22><CreateQueueResult><QueueUrl>https://sqs.sa-east-1.amazonaws.com/854330369555/queue</QueueUrl></CreateQueueResult><ResponseMetadata><RequestId>fca7d6db-f58b-53a2-8e03-98692218fc01</RequestId></ResponseMetadata></CreateQueueResponse>"
         http_version: 
-      recorded_at: "Mon, 02 Nov 2015 18:54:57 GMT"
+      recorded_at: "Tue, 03 Nov 2015 15:42:03 GMT"
   recorded_with: "VCR 2.9.3"

--- a/fixtures/vcr_cassettes/destroy-queue.yml
+++ b/fixtures/vcr_cassettes/destroy-queue.yml
@@ -2,10 +2,10 @@
   http_interactions: 
     - request: 
         method: post
-        uri: "https://sqs.us-west-1.amazonaws.com/854330369555/71b3ac187342696888a9"
+        uri: "https://sqs.sa-east-1.amazonaws.com/854330369555/queue"
         body: 
           encoding: UTF-8
-          string: "Action=DeleteQueue&QueueUrl=https%3A%2F%2Fsqs.us-west-1.amazonaws.com%2F854330369555%2F71b3ac187342696888a9&Version=2012-11-05"
+          string: "Action=DeleteQueue&QueueUrl=https%3A%2F%2Fsqs.sa-east-1.amazonaws.com%2F854330369555%2Fqueue&Version=2012-11-05"
         headers: 
           Content-Type: 
             - "application/x-www-form-urlencoded; charset=utf-8"
@@ -14,13 +14,13 @@
           User-Agent: 
             - "aws-sdk-ruby2/2.0.5 ruby/1.9.3 x86_64-darwin13.4.0"
           X-Amz-Date: 
-            - "20151102T185502Z"
+            - "20151103T154207Z"
           X-Amz-Content-Sha256: 
-            - b2dc2023a7d5de0d4755975cb9531bbe1efebd591b56e9bb38f14e2475bc8f68
+            - "98de8e2f5d31c76eb11dbf00e1e8fabe120b2b7e84f632bd24a968bf9eab45fb"
           Authorization: 
-            - "AWS4-HMAC-SHA256 Credential=redacted/20151102/us-west-1/sqs/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=211e2e4b541ebdc2773f185bb6bb28daf7b1e9611f29708131073ecd7d65c434"
+            - "AWS4-HMAC-SHA256 Credential=redacted/20151103/sa-east-1/sqs/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=2d3dba0eceb5d2f37a1471396d49380bfeb7792b776f827ce7fafce0730b1966"
           Content-Length: 
-            - "126"
+            - "111"
           Accept: 
             - "*/*"
       response: 
@@ -31,7 +31,7 @@
           Server: 
             - Server
           Date: 
-            - "Mon, 02 Nov 2015 18:53:05 GMT"
+            - "Tue, 03 Nov 2015 15:40:08 GMT"
           Content-Type: 
             - text/xml
           Content-Length: 
@@ -39,10 +39,10 @@
           Connection: 
             - keep-alive
           X-Amzn-Requestid: 
-            - "62c20961-66bd-5973-a56f-47d0d5ec9edc"
+            - b1e0732b-261d-5498-9df2-3d99f18587d9
         body: 
           encoding: US-ASCII
-          string: "<?xml version=\x221.0\x22?><DeleteQueueResponse xmlns=\x22http://queue.amazonaws.com/doc/2012-11-05/\x22><ResponseMetadata><RequestId>62c20961-66bd-5973-a56f-47d0d5ec9edc</RequestId></ResponseMetadata></DeleteQueueResponse>"
+          string: "<?xml version=\x221.0\x22?><DeleteQueueResponse xmlns=\x22http://queue.amazonaws.com/doc/2012-11-05/\x22><ResponseMetadata><RequestId>b1e0732b-261d-5498-9df2-3d99f18587d9</RequestId></ResponseMetadata></DeleteQueueResponse>"
         http_version: 
-      recorded_at: "Mon, 02 Nov 2015 18:55:04 GMT"
+      recorded_at: "Tue, 03 Nov 2015 15:42:08 GMT"
   recorded_with: "VCR 2.9.3"

--- a/fixtures/vcr_cassettes/destroy-queue.yml
+++ b/fixtures/vcr_cassettes/destroy-queue.yml
@@ -1,0 +1,48 @@
+--- 
+  http_interactions: 
+    - request: 
+        method: post
+        uri: "https://sqs.us-west-1.amazonaws.com/854330369555/71b3ac187342696888a9"
+        body: 
+          encoding: UTF-8
+          string: "Action=DeleteQueue&QueueUrl=https%3A%2F%2Fsqs.us-west-1.amazonaws.com%2F854330369555%2F71b3ac187342696888a9&Version=2012-11-05"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.5 ruby/1.9.3 x86_64-darwin13.4.0"
+          X-Amz-Date: 
+            - "20151102T185502Z"
+          X-Amz-Content-Sha256: 
+            - b2dc2023a7d5de0d4755975cb9531bbe1efebd591b56e9bb38f14e2475bc8f68
+          Authorization: 
+            - "AWS4-HMAC-SHA256 Credential=redacted/20151102/us-west-1/sqs/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=211e2e4b541ebdc2773f185bb6bb28daf7b1e9611f29708131073ecd7d65c434"
+          Content-Length: 
+            - "126"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Server: 
+            - Server
+          Date: 
+            - "Mon, 02 Nov 2015 18:53:05 GMT"
+          Content-Type: 
+            - text/xml
+          Content-Length: 
+            - "211"
+          Connection: 
+            - keep-alive
+          X-Amzn-Requestid: 
+            - "62c20961-66bd-5973-a56f-47d0d5ec9edc"
+        body: 
+          encoding: US-ASCII
+          string: "<?xml version=\x221.0\x22?><DeleteQueueResponse xmlns=\x22http://queue.amazonaws.com/doc/2012-11-05/\x22><ResponseMetadata><RequestId>62c20961-66bd-5973-a56f-47d0d5ec9edc</RequestId></ResponseMetadata></DeleteQueueResponse>"
+        http_version: 
+      recorded_at: "Mon, 02 Nov 2015 18:55:04 GMT"
+  recorded_with: "VCR 2.9.3"

--- a/fixtures/vcr_cassettes/get_queue.yml
+++ b/fixtures/vcr_cassettes/get_queue.yml
@@ -1,0 +1,228 @@
+--- 
+  http_interactions: 
+    - request: 
+        method: post
+        uri: "https://sqs.us-west-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "Action=ListQueues&Version=2012-11-05"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.5 ruby/1.9.3 x86_64-darwin13.4.0"
+          X-Amz-Date: 
+            - "20151102T185457Z"
+          X-Amz-Content-Sha256: 
+            - "48a38266faf90970d6c7fea9b15e6ba366e5f6397c2970fc893f8a7b5e207bd0"
+          Authorization: 
+            - "AWS4-HMAC-SHA256 Credential=redacted/20151102/us-west-1/sqs/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=ec4b7dc7da7661a385f0f56d2486bcac81083e653480027b37d9e875c67492bf"
+          Content-Length: 
+            - "36"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Server: 
+            - Server
+          Date: 
+            - "Mon, 02 Nov 2015 18:52:59 GMT"
+          Content-Type: 
+            - text/xml
+          Content-Length: 
+            - "501"
+          Connection: 
+            - keep-alive
+          X-Amzn-Requestid: 
+            - f659f9de-a5e6-57b2-a0fb-b76f16adac07
+        body: 
+          encoding: US-ASCII
+          string: "<?xml version=\x221.0\x22?><ListQueuesResponse xmlns=\x22http://queue.amazonaws.com/doc/2012-11-05/\x22><ListQueuesResult><QueueUrl>https://sqs.us-west-1.amazonaws.com/854330369555/71b3ac187342696888a9</QueueUrl><QueueUrl>https://sqs.us-west-1.amazonaws.com/854330369555/fc9501e5636022c597f7</QueueUrl><QueueUrl>https://sqs.us-west-1.amazonaws.com/854330369555/queue</QueueUrl></ListQueuesResult><ResponseMetadata><RequestId>f659f9de-a5e6-57b2-a0fb-b76f16adac07</RequestId></ResponseMetadata></ListQueuesResponse>"
+        http_version: 
+      recorded_at: "Mon, 02 Nov 2015 18:54:58 GMT"
+    - request: 
+        method: post
+        uri: "https://sqs.us-west-1.amazonaws.com/854330369555/71b3ac187342696888a9"
+        body: 
+          encoding: UTF-8
+          string: "Action=GetQueueAttributes&AttributeName.1=All&QueueUrl=https%3A%2F%2Fsqs.us-west-1.amazonaws.com%2F854330369555%2F71b3ac187342696888a9&Version=2012-11-05"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.5 ruby/1.9.3 x86_64-darwin13.4.0"
+          X-Amz-Date: 
+            - "20151102T185458Z"
+          X-Amz-Content-Sha256: 
+            - "104390c3abbbec8f25f0bf9598054cf0d088acf7162166f36d13650b4e03927c"
+          Authorization: 
+            - "AWS4-HMAC-SHA256 Credential=redacted/20151102/us-west-1/sqs/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=c896eb3ea26ba18559d9dd2d6c8958f307c93266dd82128a259668d6be37f287"
+          Content-Length: 
+            - "153"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Server: 
+            - Server
+          Date: 
+            - "Mon, 02 Nov 2015 18:53:00 GMT"
+          Content-Type: 
+            - text/xml
+          Content-Length: 
+            - "1173"
+          Connection: 
+            - keep-alive
+          X-Amzn-Requestid: 
+            - ebfd4c23-b231-5317-8191-0292017d64b8
+        body: 
+          encoding: US-ASCII
+          string: "<?xml version=\x221.0\x22?><GetQueueAttributesResponse xmlns=\x22http://queue.amazonaws.com/doc/2012-11-05/\x22><GetQueueAttributesResult><Attribute><Name>QueueArn</Name><Value>arn:aws:sqs:us-west-1:854330369555:71b3ac187342696888a9</Value></Attribute><Attribute><Name>ApproximateNumberOfMessages</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesNotVisible</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesDelayed</Name><Value>0</Value></Attribute><Attribute><Name>CreatedTimestamp</Name><Value>1446489955</Value></Attribute><Attribute><Name>LastModifiedTimestamp</Name><Value>1446489955</Value></Attribute><Attribute><Name>VisibilityTimeout</Name><Value>30</Value></Attribute><Attribute><Name>MaximumMessageSize</Name><Value>262144</Value></Attribute><Attribute><Name>MessageRetentionPeriod</Name><Value>120</Value></Attribute><Attribute><Name>DelaySeconds</Name><Value>100</Value></Attribute><Attribute><Name>ReceiveMessageWaitTimeSeconds</Name><Value>0</Value></Attribute></GetQueueAttributesResult><ResponseMetadata><RequestId>ebfd4c23-b231-5317-8191-0292017d64b8</RequestId></ResponseMetadata></GetQueueAttributesResponse>"
+        http_version: 
+      recorded_at: "Mon, 02 Nov 2015 18:54:59 GMT"
+    - request: 
+        method: post
+        uri: "https://sqs.us-west-1.amazonaws.com/854330369555/fc9501e5636022c597f7"
+        body: 
+          encoding: UTF-8
+          string: "Action=GetQueueAttributes&AttributeName.1=All&QueueUrl=https%3A%2F%2Fsqs.us-west-1.amazonaws.com%2F854330369555%2Ffc9501e5636022c597f7&Version=2012-11-05"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.5 ruby/1.9.3 x86_64-darwin13.4.0"
+          X-Amz-Date: 
+            - "20151102T185459Z"
+          X-Amz-Content-Sha256: 
+            - "82a518cbdd75de72e95f29ef74f466b308bf2247813520945154370f98904086"
+          Authorization: 
+            - "AWS4-HMAC-SHA256 Credential=redacted/20151102/us-west-1/sqs/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=e3b44d8c8b569a018841a8834485aa78cc9e7728a6cdc46ce615f6876c39e1cf"
+          Content-Length: 
+            - "153"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Server: 
+            - Server
+          Date: 
+            - "Mon, 02 Nov 2015 18:53:02 GMT"
+          Content-Type: 
+            - text/xml
+          Content-Length: 
+            - "1173"
+          Connection: 
+            - keep-alive
+          X-Amzn-Requestid: 
+            - "5af2a60f-9513-526d-bbb2-e8be265d3da6"
+        body: 
+          encoding: US-ASCII
+          string: "<?xml version=\x221.0\x22?><GetQueueAttributesResponse xmlns=\x22http://queue.amazonaws.com/doc/2012-11-05/\x22><GetQueueAttributesResult><Attribute><Name>QueueArn</Name><Value>arn:aws:sqs:us-west-1:854330369555:fc9501e5636022c597f7</Value></Attribute><Attribute><Name>ApproximateNumberOfMessages</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesNotVisible</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesDelayed</Name><Value>0</Value></Attribute><Attribute><Name>CreatedTimestamp</Name><Value>1446490059</Value></Attribute><Attribute><Name>LastModifiedTimestamp</Name><Value>1446490059</Value></Attribute><Attribute><Name>VisibilityTimeout</Name><Value>30</Value></Attribute><Attribute><Name>MaximumMessageSize</Name><Value>262144</Value></Attribute><Attribute><Name>MessageRetentionPeriod</Name><Value>120</Value></Attribute><Attribute><Name>DelaySeconds</Name><Value>100</Value></Attribute><Attribute><Name>ReceiveMessageWaitTimeSeconds</Name><Value>0</Value></Attribute></GetQueueAttributesResult><ResponseMetadata><RequestId>5af2a60f-9513-526d-bbb2-e8be265d3da6</RequestId></ResponseMetadata></GetQueueAttributesResponse>"
+        http_version: 
+      recorded_at: "Mon, 02 Nov 2015 18:55:00 GMT"
+    - request: 
+        method: post
+        uri: "https://sqs.us-west-1.amazonaws.com/854330369555/queue"
+        body: 
+          encoding: UTF-8
+          string: "Action=GetQueueAttributes&AttributeName.1=All&QueueUrl=https%3A%2F%2Fsqs.us-west-1.amazonaws.com%2F854330369555%2Fqueue&Version=2012-11-05"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.5 ruby/1.9.3 x86_64-darwin13.4.0"
+          X-Amz-Date: 
+            - "20151102T185500Z"
+          X-Amz-Content-Sha256: 
+            - db1e111d346eeac4860326380f0d4b58130b9fb08f40f0769b2e305704acc49f
+          Authorization: 
+            - "AWS4-HMAC-SHA256 Credential=redacted/20151102/us-west-1/sqs/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=16b6b0cca5a209aa62290ad08cf180b51837178c349dbe2dc0a2278d1915b951"
+          Content-Length: 
+            - "138"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Server: 
+            - Server
+          Date: 
+            - "Mon, 02 Nov 2015 18:53:03 GMT"
+          Content-Type: 
+            - text/xml
+          Content-Length: 
+            - "1159"
+          Connection: 
+            - keep-alive
+          X-Amzn-Requestid: 
+            - "9bf9d5ae-a2ca-5862-88a3-9b1f118529d0"
+        body: 
+          encoding: US-ASCII
+          string: "<?xml version=\x221.0\x22?><GetQueueAttributesResponse xmlns=\x22http://queue.amazonaws.com/doc/2012-11-05/\x22><GetQueueAttributesResult><Attribute><Name>QueueArn</Name><Value>arn:aws:sqs:us-west-1:854330369555:queue</Value></Attribute><Attribute><Name>ApproximateNumberOfMessages</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesNotVisible</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesDelayed</Name><Value>0</Value></Attribute><Attribute><Name>CreatedTimestamp</Name><Value>1446473434</Value></Attribute><Attribute><Name>LastModifiedTimestamp</Name><Value>1446473434</Value></Attribute><Attribute><Name>VisibilityTimeout</Name><Value>30</Value></Attribute><Attribute><Name>MaximumMessageSize</Name><Value>262144</Value></Attribute><Attribute><Name>MessageRetentionPeriod</Name><Value>345600</Value></Attribute><Attribute><Name>DelaySeconds</Name><Value>0</Value></Attribute><Attribute><Name>ReceiveMessageWaitTimeSeconds</Name><Value>0</Value></Attribute></GetQueueAttributesResult><ResponseMetadata><RequestId>9bf9d5ae-a2ca-5862-88a3-9b1f118529d0</RequestId></ResponseMetadata></GetQueueAttributesResponse>"
+        http_version: 
+      recorded_at: "Mon, 02 Nov 2015 18:55:01 GMT"
+    - request: 
+        method: post
+        uri: "https://sqs.us-west-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "Action=GetQueueUrl&QueueName=71b3ac187342696888a9&Version=2012-11-05"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.5 ruby/1.9.3 x86_64-darwin13.4.0"
+          X-Amz-Date: 
+            - "20151102T185501Z"
+          X-Amz-Content-Sha256: 
+            - "05b46e23bfea3f99af037c5b2f2a872030b0038205d41ecf3a369e9f8be60d44"
+          Authorization: 
+            - "AWS4-HMAC-SHA256 Credential=redacted/20151102/us-west-1/sqs/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=48f67eefeec2ad4219219e9edd6a121fd3b494b99c15ecc34c8dbc42653d6e64"
+          Content-Length: 
+            - "68"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Server: 
+            - Server
+          Date: 
+            - "Mon, 02 Nov 2015 18:53:04 GMT"
+          Content-Type: 
+            - text/xml
+          Content-Length: 
+            - "340"
+          Connection: 
+            - keep-alive
+          X-Amzn-Requestid: 
+            - "743fc4bc-bf0c-5ddd-ae73-8a0d0c5c5e0c"
+        body: 
+          encoding: US-ASCII
+          string: "<?xml version=\x221.0\x22?><GetQueueUrlResponse xmlns=\x22http://queue.amazonaws.com/doc/2012-11-05/\x22><GetQueueUrlResult><QueueUrl>https://sqs.us-west-1.amazonaws.com/854330369555/71b3ac187342696888a9</QueueUrl></GetQueueUrlResult><ResponseMetadata><RequestId>743fc4bc-bf0c-5ddd-ae73-8a0d0c5c5e0c</RequestId></ResponseMetadata></GetQueueUrlResponse>"
+        http_version: 
+      recorded_at: "Mon, 02 Nov 2015 18:55:02 GMT"
+  recorded_with: "VCR 2.9.3"

--- a/fixtures/vcr_cassettes/get_queue.yml
+++ b/fixtures/vcr_cassettes/get_queue.yml
@@ -2,7 +2,7 @@
   http_interactions: 
     - request: 
         method: post
-        uri: "https://sqs.us-west-1.amazonaws.com/"
+        uri: "https://sqs.sa-east-1.amazonaws.com/"
         body: 
           encoding: UTF-8
           string: "Action=ListQueues&Version=2012-11-05"
@@ -14,11 +14,11 @@
           User-Agent: 
             - "aws-sdk-ruby2/2.0.5 ruby/1.9.3 x86_64-darwin13.4.0"
           X-Amz-Date: 
-            - "20151102T185457Z"
+            - "20151103T154203Z"
           X-Amz-Content-Sha256: 
             - "48a38266faf90970d6c7fea9b15e6ba366e5f6397c2970fc893f8a7b5e207bd0"
           Authorization: 
-            - "AWS4-HMAC-SHA256 Credential=redacted/20151102/us-west-1/sqs/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=ec4b7dc7da7661a385f0f56d2486bcac81083e653480027b37d9e875c67492bf"
+            - "AWS4-HMAC-SHA256 Credential=redacted/20151103/sa-east-1/sqs/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=08ed184d6d9f136e0ccb2db5e13b4ef7f1835ec426a27cced4b3986eb8367253"
           Content-Length: 
             - "36"
           Accept: 
@@ -31,26 +31,26 @@
           Server: 
             - Server
           Date: 
-            - "Mon, 02 Nov 2015 18:52:59 GMT"
+            - "Tue, 03 Nov 2015 15:40:04 GMT"
           Content-Type: 
             - text/xml
           Content-Length: 
-            - "501"
+            - "321"
           Connection: 
             - keep-alive
           X-Amzn-Requestid: 
-            - f659f9de-a5e6-57b2-a0fb-b76f16adac07
+            - bc7a4d3d-a580-553c-aa18-038f7214d69d
         body: 
           encoding: US-ASCII
-          string: "<?xml version=\x221.0\x22?><ListQueuesResponse xmlns=\x22http://queue.amazonaws.com/doc/2012-11-05/\x22><ListQueuesResult><QueueUrl>https://sqs.us-west-1.amazonaws.com/854330369555/71b3ac187342696888a9</QueueUrl><QueueUrl>https://sqs.us-west-1.amazonaws.com/854330369555/fc9501e5636022c597f7</QueueUrl><QueueUrl>https://sqs.us-west-1.amazonaws.com/854330369555/queue</QueueUrl></ListQueuesResult><ResponseMetadata><RequestId>f659f9de-a5e6-57b2-a0fb-b76f16adac07</RequestId></ResponseMetadata></ListQueuesResponse>"
+          string: "<?xml version=\x221.0\x22?><ListQueuesResponse xmlns=\x22http://queue.amazonaws.com/doc/2012-11-05/\x22><ListQueuesResult><QueueUrl>https://sqs.sa-east-1.amazonaws.com/854330369555/queue</QueueUrl></ListQueuesResult><ResponseMetadata><RequestId>bc7a4d3d-a580-553c-aa18-038f7214d69d</RequestId></ResponseMetadata></ListQueuesResponse>"
         http_version: 
-      recorded_at: "Mon, 02 Nov 2015 18:54:58 GMT"
+      recorded_at: "Tue, 03 Nov 2015 15:42:04 GMT"
     - request: 
         method: post
-        uri: "https://sqs.us-west-1.amazonaws.com/854330369555/71b3ac187342696888a9"
+        uri: "https://sqs.sa-east-1.amazonaws.com/854330369555/queue"
         body: 
           encoding: UTF-8
-          string: "Action=GetQueueAttributes&AttributeName.1=All&QueueUrl=https%3A%2F%2Fsqs.us-west-1.amazonaws.com%2F854330369555%2F71b3ac187342696888a9&Version=2012-11-05"
+          string: "Action=GetQueueAttributes&AttributeName.1=All&QueueUrl=https%3A%2F%2Fsqs.sa-east-1.amazonaws.com%2F854330369555%2Fqueue&Version=2012-11-05"
         headers: 
           Content-Type: 
             - "application/x-www-form-urlencoded; charset=utf-8"
@@ -59,101 +59,11 @@
           User-Agent: 
             - "aws-sdk-ruby2/2.0.5 ruby/1.9.3 x86_64-darwin13.4.0"
           X-Amz-Date: 
-            - "20151102T185458Z"
+            - "20151103T154204Z"
           X-Amz-Content-Sha256: 
-            - "104390c3abbbec8f25f0bf9598054cf0d088acf7162166f36d13650b4e03927c"
+            - "4172538b909231f47b6e0f3310c0da4c5b146c4d1549d6fa8ee58644a94f9f06"
           Authorization: 
-            - "AWS4-HMAC-SHA256 Credential=redacted/20151102/us-west-1/sqs/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=c896eb3ea26ba18559d9dd2d6c8958f307c93266dd82128a259668d6be37f287"
-          Content-Length: 
-            - "153"
-          Accept: 
-            - "*/*"
-      response: 
-        status: 
-          code: 200
-          message: OK
-        headers: 
-          Server: 
-            - Server
-          Date: 
-            - "Mon, 02 Nov 2015 18:53:00 GMT"
-          Content-Type: 
-            - text/xml
-          Content-Length: 
-            - "1173"
-          Connection: 
-            - keep-alive
-          X-Amzn-Requestid: 
-            - ebfd4c23-b231-5317-8191-0292017d64b8
-        body: 
-          encoding: US-ASCII
-          string: "<?xml version=\x221.0\x22?><GetQueueAttributesResponse xmlns=\x22http://queue.amazonaws.com/doc/2012-11-05/\x22><GetQueueAttributesResult><Attribute><Name>QueueArn</Name><Value>arn:aws:sqs:us-west-1:854330369555:71b3ac187342696888a9</Value></Attribute><Attribute><Name>ApproximateNumberOfMessages</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesNotVisible</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesDelayed</Name><Value>0</Value></Attribute><Attribute><Name>CreatedTimestamp</Name><Value>1446489955</Value></Attribute><Attribute><Name>LastModifiedTimestamp</Name><Value>1446489955</Value></Attribute><Attribute><Name>VisibilityTimeout</Name><Value>30</Value></Attribute><Attribute><Name>MaximumMessageSize</Name><Value>262144</Value></Attribute><Attribute><Name>MessageRetentionPeriod</Name><Value>120</Value></Attribute><Attribute><Name>DelaySeconds</Name><Value>100</Value></Attribute><Attribute><Name>ReceiveMessageWaitTimeSeconds</Name><Value>0</Value></Attribute></GetQueueAttributesResult><ResponseMetadata><RequestId>ebfd4c23-b231-5317-8191-0292017d64b8</RequestId></ResponseMetadata></GetQueueAttributesResponse>"
-        http_version: 
-      recorded_at: "Mon, 02 Nov 2015 18:54:59 GMT"
-    - request: 
-        method: post
-        uri: "https://sqs.us-west-1.amazonaws.com/854330369555/fc9501e5636022c597f7"
-        body: 
-          encoding: UTF-8
-          string: "Action=GetQueueAttributes&AttributeName.1=All&QueueUrl=https%3A%2F%2Fsqs.us-west-1.amazonaws.com%2F854330369555%2Ffc9501e5636022c597f7&Version=2012-11-05"
-        headers: 
-          Content-Type: 
-            - "application/x-www-form-urlencoded; charset=utf-8"
-          Accept-Encoding: 
-            - ""
-          User-Agent: 
-            - "aws-sdk-ruby2/2.0.5 ruby/1.9.3 x86_64-darwin13.4.0"
-          X-Amz-Date: 
-            - "20151102T185459Z"
-          X-Amz-Content-Sha256: 
-            - "82a518cbdd75de72e95f29ef74f466b308bf2247813520945154370f98904086"
-          Authorization: 
-            - "AWS4-HMAC-SHA256 Credential=redacted/20151102/us-west-1/sqs/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=e3b44d8c8b569a018841a8834485aa78cc9e7728a6cdc46ce615f6876c39e1cf"
-          Content-Length: 
-            - "153"
-          Accept: 
-            - "*/*"
-      response: 
-        status: 
-          code: 200
-          message: OK
-        headers: 
-          Server: 
-            - Server
-          Date: 
-            - "Mon, 02 Nov 2015 18:53:02 GMT"
-          Content-Type: 
-            - text/xml
-          Content-Length: 
-            - "1173"
-          Connection: 
-            - keep-alive
-          X-Amzn-Requestid: 
-            - "5af2a60f-9513-526d-bbb2-e8be265d3da6"
-        body: 
-          encoding: US-ASCII
-          string: "<?xml version=\x221.0\x22?><GetQueueAttributesResponse xmlns=\x22http://queue.amazonaws.com/doc/2012-11-05/\x22><GetQueueAttributesResult><Attribute><Name>QueueArn</Name><Value>arn:aws:sqs:us-west-1:854330369555:fc9501e5636022c597f7</Value></Attribute><Attribute><Name>ApproximateNumberOfMessages</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesNotVisible</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesDelayed</Name><Value>0</Value></Attribute><Attribute><Name>CreatedTimestamp</Name><Value>1446490059</Value></Attribute><Attribute><Name>LastModifiedTimestamp</Name><Value>1446490059</Value></Attribute><Attribute><Name>VisibilityTimeout</Name><Value>30</Value></Attribute><Attribute><Name>MaximumMessageSize</Name><Value>262144</Value></Attribute><Attribute><Name>MessageRetentionPeriod</Name><Value>120</Value></Attribute><Attribute><Name>DelaySeconds</Name><Value>100</Value></Attribute><Attribute><Name>ReceiveMessageWaitTimeSeconds</Name><Value>0</Value></Attribute></GetQueueAttributesResult><ResponseMetadata><RequestId>5af2a60f-9513-526d-bbb2-e8be265d3da6</RequestId></ResponseMetadata></GetQueueAttributesResponse>"
-        http_version: 
-      recorded_at: "Mon, 02 Nov 2015 18:55:00 GMT"
-    - request: 
-        method: post
-        uri: "https://sqs.us-west-1.amazonaws.com/854330369555/queue"
-        body: 
-          encoding: UTF-8
-          string: "Action=GetQueueAttributes&AttributeName.1=All&QueueUrl=https%3A%2F%2Fsqs.us-west-1.amazonaws.com%2F854330369555%2Fqueue&Version=2012-11-05"
-        headers: 
-          Content-Type: 
-            - "application/x-www-form-urlencoded; charset=utf-8"
-          Accept-Encoding: 
-            - ""
-          User-Agent: 
-            - "aws-sdk-ruby2/2.0.5 ruby/1.9.3 x86_64-darwin13.4.0"
-          X-Amz-Date: 
-            - "20151102T185500Z"
-          X-Amz-Content-Sha256: 
-            - db1e111d346eeac4860326380f0d4b58130b9fb08f40f0769b2e305704acc49f
-          Authorization: 
-            - "AWS4-HMAC-SHA256 Credential=redacted/20151102/us-west-1/sqs/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=16b6b0cca5a209aa62290ad08cf180b51837178c349dbe2dc0a2278d1915b951"
+            - "AWS4-HMAC-SHA256 Credential=redacted/20151103/sa-east-1/sqs/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=2105f7f6e969fb4ea3fcd089081a1a68321a4bd8527cf7926e13bcc6694e8dc3"
           Content-Length: 
             - "138"
           Accept: 
@@ -166,7 +76,7 @@
           Server: 
             - Server
           Date: 
-            - "Mon, 02 Nov 2015 18:53:03 GMT"
+            - "Tue, 03 Nov 2015 15:40:06 GMT"
           Content-Type: 
             - text/xml
           Content-Length: 
@@ -174,18 +84,18 @@
           Connection: 
             - keep-alive
           X-Amzn-Requestid: 
-            - "9bf9d5ae-a2ca-5862-88a3-9b1f118529d0"
+            - ca1336ed-4dcd-5c78-9d4a-785f9a5bb53e
         body: 
           encoding: US-ASCII
-          string: "<?xml version=\x221.0\x22?><GetQueueAttributesResponse xmlns=\x22http://queue.amazonaws.com/doc/2012-11-05/\x22><GetQueueAttributesResult><Attribute><Name>QueueArn</Name><Value>arn:aws:sqs:us-west-1:854330369555:queue</Value></Attribute><Attribute><Name>ApproximateNumberOfMessages</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesNotVisible</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesDelayed</Name><Value>0</Value></Attribute><Attribute><Name>CreatedTimestamp</Name><Value>1446473434</Value></Attribute><Attribute><Name>LastModifiedTimestamp</Name><Value>1446473434</Value></Attribute><Attribute><Name>VisibilityTimeout</Name><Value>30</Value></Attribute><Attribute><Name>MaximumMessageSize</Name><Value>262144</Value></Attribute><Attribute><Name>MessageRetentionPeriod</Name><Value>345600</Value></Attribute><Attribute><Name>DelaySeconds</Name><Value>0</Value></Attribute><Attribute><Name>ReceiveMessageWaitTimeSeconds</Name><Value>0</Value></Attribute></GetQueueAttributesResult><ResponseMetadata><RequestId>9bf9d5ae-a2ca-5862-88a3-9b1f118529d0</RequestId></ResponseMetadata></GetQueueAttributesResponse>"
+          string: "<?xml version=\x221.0\x22?><GetQueueAttributesResponse xmlns=\x22http://queue.amazonaws.com/doc/2012-11-05/\x22><GetQueueAttributesResult><Attribute><Name>QueueArn</Name><Value>arn:aws:sqs:sa-east-1:854330369555:queue</Value></Attribute><Attribute><Name>ApproximateNumberOfMessages</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesNotVisible</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesDelayed</Name><Value>0</Value></Attribute><Attribute><Name>CreatedTimestamp</Name><Value>1446564993</Value></Attribute><Attribute><Name>LastModifiedTimestamp</Name><Value>1446564993</Value></Attribute><Attribute><Name>VisibilityTimeout</Name><Value>30</Value></Attribute><Attribute><Name>MaximumMessageSize</Name><Value>262144</Value></Attribute><Attribute><Name>MessageRetentionPeriod</Name><Value>345600</Value></Attribute><Attribute><Name>DelaySeconds</Name><Value>0</Value></Attribute><Attribute><Name>ReceiveMessageWaitTimeSeconds</Name><Value>0</Value></Attribute></GetQueueAttributesResult><ResponseMetadata><RequestId>ca1336ed-4dcd-5c78-9d4a-785f9a5bb53e</RequestId></ResponseMetadata></GetQueueAttributesResponse>"
         http_version: 
-      recorded_at: "Mon, 02 Nov 2015 18:55:01 GMT"
+      recorded_at: "Tue, 03 Nov 2015 15:42:05 GMT"
     - request: 
         method: post
-        uri: "https://sqs.us-west-1.amazonaws.com/"
+        uri: "https://sqs.sa-east-1.amazonaws.com/"
         body: 
           encoding: UTF-8
-          string: "Action=GetQueueUrl&QueueName=71b3ac187342696888a9&Version=2012-11-05"
+          string: "Action=GetQueueUrl&QueueName=queue&Version=2012-11-05"
         headers: 
           Content-Type: 
             - "application/x-www-form-urlencoded; charset=utf-8"
@@ -194,13 +104,13 @@
           User-Agent: 
             - "aws-sdk-ruby2/2.0.5 ruby/1.9.3 x86_64-darwin13.4.0"
           X-Amz-Date: 
-            - "20151102T185501Z"
+            - "20151103T154205Z"
           X-Amz-Content-Sha256: 
-            - "05b46e23bfea3f99af037c5b2f2a872030b0038205d41ecf3a369e9f8be60d44"
+            - "86bbe326e14164a5e1b618f183501995b3580522d441709828f5bfc209e41ddd"
           Authorization: 
-            - "AWS4-HMAC-SHA256 Credential=redacted/20151102/us-west-1/sqs/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=48f67eefeec2ad4219219e9edd6a121fd3b494b99c15ecc34c8dbc42653d6e64"
+            - "AWS4-HMAC-SHA256 Credential=redacted/20151103/sa-east-1/sqs/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=b65a26cbaf2e3bd82aefbcbaafa9c92736e73d1c4c3b1364dda56d20db9e1156"
           Content-Length: 
-            - "68"
+            - "53"
           Accept: 
             - "*/*"
       response: 
@@ -211,18 +121,18 @@
           Server: 
             - Server
           Date: 
-            - "Mon, 02 Nov 2015 18:53:04 GMT"
+            - "Tue, 03 Nov 2015 15:40:07 GMT"
           Content-Type: 
             - text/xml
           Content-Length: 
-            - "340"
+            - "325"
           Connection: 
             - keep-alive
           X-Amzn-Requestid: 
-            - "743fc4bc-bf0c-5ddd-ae73-8a0d0c5c5e0c"
+            - "35c0c27b-ef60-51ab-8e42-8cc938f762ca"
         body: 
           encoding: US-ASCII
-          string: "<?xml version=\x221.0\x22?><GetQueueUrlResponse xmlns=\x22http://queue.amazonaws.com/doc/2012-11-05/\x22><GetQueueUrlResult><QueueUrl>https://sqs.us-west-1.amazonaws.com/854330369555/71b3ac187342696888a9</QueueUrl></GetQueueUrlResult><ResponseMetadata><RequestId>743fc4bc-bf0c-5ddd-ae73-8a0d0c5c5e0c</RequestId></ResponseMetadata></GetQueueUrlResponse>"
+          string: "<?xml version=\x221.0\x22?><GetQueueUrlResponse xmlns=\x22http://queue.amazonaws.com/doc/2012-11-05/\x22><GetQueueUrlResult><QueueUrl>https://sqs.sa-east-1.amazonaws.com/854330369555/queue</QueueUrl></GetQueueUrlResult><ResponseMetadata><RequestId>35c0c27b-ef60-51ab-8e42-8cc938f762ca</RequestId></ResponseMetadata></GetQueueUrlResponse>"
         http_version: 
-      recorded_at: "Mon, 02 Nov 2015 18:55:02 GMT"
+      recorded_at: "Tue, 03 Nov 2015 15:42:07 GMT"
   recorded_with: "VCR 2.9.3"

--- a/fixtures/vcr_cassettes/named-queue.yml
+++ b/fixtures/vcr_cassettes/named-queue.yml
@@ -1,0 +1,183 @@
+--- 
+  http_interactions: 
+    - request: 
+        method: post
+        uri: "https://sqs.us-west-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "Action=ListQueues&Version=2012-11-05"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.5 ruby/1.9.3 x86_64-darwin13.4.0"
+          X-Amz-Date: 
+            - "20151102T185451Z"
+          X-Amz-Content-Sha256: 
+            - "48a38266faf90970d6c7fea9b15e6ba366e5f6397c2970fc893f8a7b5e207bd0"
+          Authorization: 
+            - "AWS4-HMAC-SHA256 Credential=redacted/20151102/us-west-1/sqs/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=68a4ea4453b2f43dcd94d4c105af5d5a0eb76c119362150c256cc1c5fec7aa29"
+          Content-Length: 
+            - "36"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Server: 
+            - Server
+          Date: 
+            - "Mon, 02 Nov 2015 18:52:54 GMT"
+          Content-Type: 
+            - text/xml
+          Content-Length: 
+            - "501"
+          Connection: 
+            - keep-alive
+          X-Amzn-Requestid: 
+            - "5e19fcdd-5a91-579d-8e50-b26ce9d7ea49"
+        body: 
+          encoding: US-ASCII
+          string: "<?xml version=\x221.0\x22?><ListQueuesResponse xmlns=\x22http://queue.amazonaws.com/doc/2012-11-05/\x22><ListQueuesResult><QueueUrl>https://sqs.us-west-1.amazonaws.com/854330369555/71b3ac187342696888a9</QueueUrl><QueueUrl>https://sqs.us-west-1.amazonaws.com/854330369555/fc9501e5636022c597f7</QueueUrl><QueueUrl>https://sqs.us-west-1.amazonaws.com/854330369555/queue</QueueUrl></ListQueuesResult><ResponseMetadata><RequestId>5e19fcdd-5a91-579d-8e50-b26ce9d7ea49</RequestId></ResponseMetadata></ListQueuesResponse>"
+        http_version: 
+      recorded_at: "Mon, 02 Nov 2015 18:54:52 GMT"
+    - request: 
+        method: post
+        uri: "https://sqs.us-west-1.amazonaws.com/854330369555/71b3ac187342696888a9"
+        body: 
+          encoding: UTF-8
+          string: "Action=GetQueueAttributes&AttributeName.1=All&QueueUrl=https%3A%2F%2Fsqs.us-west-1.amazonaws.com%2F854330369555%2F71b3ac187342696888a9&Version=2012-11-05"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.5 ruby/1.9.3 x86_64-darwin13.4.0"
+          X-Amz-Date: 
+            - "20151102T185452Z"
+          X-Amz-Content-Sha256: 
+            - "104390c3abbbec8f25f0bf9598054cf0d088acf7162166f36d13650b4e03927c"
+          Authorization: 
+            - "AWS4-HMAC-SHA256 Credential=redacted/20151102/us-west-1/sqs/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=2f9b55b11ed6284d6b3876002aa9db9d01b6dce9738c772cde3fe83952f73057"
+          Content-Length: 
+            - "153"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Server: 
+            - Server
+          Date: 
+            - "Mon, 02 Nov 2015 18:52:55 GMT"
+          Content-Type: 
+            - text/xml
+          Content-Length: 
+            - "1173"
+          Connection: 
+            - keep-alive
+          X-Amzn-Requestid: 
+            - "5d309842-585c-588f-a578-d6f3eb1bd73c"
+        body: 
+          encoding: US-ASCII
+          string: "<?xml version=\x221.0\x22?><GetQueueAttributesResponse xmlns=\x22http://queue.amazonaws.com/doc/2012-11-05/\x22><GetQueueAttributesResult><Attribute><Name>QueueArn</Name><Value>arn:aws:sqs:us-west-1:854330369555:71b3ac187342696888a9</Value></Attribute><Attribute><Name>ApproximateNumberOfMessages</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesNotVisible</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesDelayed</Name><Value>0</Value></Attribute><Attribute><Name>CreatedTimestamp</Name><Value>1446489955</Value></Attribute><Attribute><Name>LastModifiedTimestamp</Name><Value>1446489955</Value></Attribute><Attribute><Name>VisibilityTimeout</Name><Value>30</Value></Attribute><Attribute><Name>MaximumMessageSize</Name><Value>262144</Value></Attribute><Attribute><Name>MessageRetentionPeriod</Name><Value>120</Value></Attribute><Attribute><Name>DelaySeconds</Name><Value>100</Value></Attribute><Attribute><Name>ReceiveMessageWaitTimeSeconds</Name><Value>0</Value></Attribute></GetQueueAttributesResult><ResponseMetadata><RequestId>5d309842-585c-588f-a578-d6f3eb1bd73c</RequestId></ResponseMetadata></GetQueueAttributesResponse>"
+        http_version: 
+      recorded_at: "Mon, 02 Nov 2015 18:54:53 GMT"
+    - request: 
+        method: post
+        uri: "https://sqs.us-west-1.amazonaws.com/854330369555/fc9501e5636022c597f7"
+        body: 
+          encoding: UTF-8
+          string: "Action=GetQueueAttributes&AttributeName.1=All&QueueUrl=https%3A%2F%2Fsqs.us-west-1.amazonaws.com%2F854330369555%2Ffc9501e5636022c597f7&Version=2012-11-05"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.5 ruby/1.9.3 x86_64-darwin13.4.0"
+          X-Amz-Date: 
+            - "20151102T185453Z"
+          X-Amz-Content-Sha256: 
+            - "82a518cbdd75de72e95f29ef74f466b308bf2247813520945154370f98904086"
+          Authorization: 
+            - "AWS4-HMAC-SHA256 Credential=redacted/20151102/us-west-1/sqs/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=4303dd6fe0c29ddb3d8250ce79642c06da559b5bd9e9ebec5f6b931636f9c266"
+          Content-Length: 
+            - "153"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Server: 
+            - Server
+          Date: 
+            - "Mon, 02 Nov 2015 18:52:56 GMT"
+          Content-Type: 
+            - text/xml
+          Content-Length: 
+            - "1173"
+          Connection: 
+            - keep-alive
+          X-Amzn-Requestid: 
+            - df2e3f31-d3e9-58bd-9a72-718060a14511
+        body: 
+          encoding: US-ASCII
+          string: "<?xml version=\x221.0\x22?><GetQueueAttributesResponse xmlns=\x22http://queue.amazonaws.com/doc/2012-11-05/\x22><GetQueueAttributesResult><Attribute><Name>QueueArn</Name><Value>arn:aws:sqs:us-west-1:854330369555:fc9501e5636022c597f7</Value></Attribute><Attribute><Name>ApproximateNumberOfMessages</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesNotVisible</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesDelayed</Name><Value>0</Value></Attribute><Attribute><Name>CreatedTimestamp</Name><Value>1446490059</Value></Attribute><Attribute><Name>LastModifiedTimestamp</Name><Value>1446490059</Value></Attribute><Attribute><Name>VisibilityTimeout</Name><Value>30</Value></Attribute><Attribute><Name>MaximumMessageSize</Name><Value>262144</Value></Attribute><Attribute><Name>MessageRetentionPeriod</Name><Value>120</Value></Attribute><Attribute><Name>DelaySeconds</Name><Value>100</Value></Attribute><Attribute><Name>ReceiveMessageWaitTimeSeconds</Name><Value>0</Value></Attribute></GetQueueAttributesResult><ResponseMetadata><RequestId>df2e3f31-d3e9-58bd-9a72-718060a14511</RequestId></ResponseMetadata></GetQueueAttributesResponse>"
+        http_version: 
+      recorded_at: "Mon, 02 Nov 2015 18:54:54 GMT"
+    - request: 
+        method: post
+        uri: "https://sqs.us-west-1.amazonaws.com/854330369555/queue"
+        body: 
+          encoding: UTF-8
+          string: "Action=GetQueueAttributes&AttributeName.1=All&QueueUrl=https%3A%2F%2Fsqs.us-west-1.amazonaws.com%2F854330369555%2Fqueue&Version=2012-11-05"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.5 ruby/1.9.3 x86_64-darwin13.4.0"
+          X-Amz-Date: 
+            - "20151102T185454Z"
+          X-Amz-Content-Sha256: 
+            - db1e111d346eeac4860326380f0d4b58130b9fb08f40f0769b2e305704acc49f
+          Authorization: 
+            - "AWS4-HMAC-SHA256 Credential=redacted/20151102/us-west-1/sqs/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=1dfb13b06d6f88e210ef964c887576d69c143319cb0b05b118566053024ec369"
+          Content-Length: 
+            - "138"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Server: 
+            - Server
+          Date: 
+            - "Mon, 02 Nov 2015 18:52:57 GMT"
+          Content-Type: 
+            - text/xml
+          Content-Length: 
+            - "1159"
+          Connection: 
+            - keep-alive
+          X-Amzn-Requestid: 
+            - "3737163b-89c8-5ea5-9ae0-588a3a81ef17"
+        body: 
+          encoding: US-ASCII
+          string: "<?xml version=\x221.0\x22?><GetQueueAttributesResponse xmlns=\x22http://queue.amazonaws.com/doc/2012-11-05/\x22><GetQueueAttributesResult><Attribute><Name>QueueArn</Name><Value>arn:aws:sqs:us-west-1:854330369555:queue</Value></Attribute><Attribute><Name>ApproximateNumberOfMessages</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesNotVisible</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesDelayed</Name><Value>0</Value></Attribute><Attribute><Name>CreatedTimestamp</Name><Value>1446473434</Value></Attribute><Attribute><Name>LastModifiedTimestamp</Name><Value>1446473434</Value></Attribute><Attribute><Name>VisibilityTimeout</Name><Value>30</Value></Attribute><Attribute><Name>MaximumMessageSize</Name><Value>262144</Value></Attribute><Attribute><Name>MessageRetentionPeriod</Name><Value>345600</Value></Attribute><Attribute><Name>DelaySeconds</Name><Value>0</Value></Attribute><Attribute><Name>ReceiveMessageWaitTimeSeconds</Name><Value>0</Value></Attribute></GetQueueAttributesResult><ResponseMetadata><RequestId>3737163b-89c8-5ea5-9ae0-588a3a81ef17</RequestId></ResponseMetadata></GetQueueAttributesResponse>"
+        http_version: 
+      recorded_at: "Mon, 02 Nov 2015 18:54:56 GMT"
+  recorded_with: "VCR 2.9.3"

--- a/fixtures/vcr_cassettes/named-queue.yml
+++ b/fixtures/vcr_cassettes/named-queue.yml
@@ -2,7 +2,7 @@
   http_interactions: 
     - request: 
         method: post
-        uri: "https://sqs.us-west-1.amazonaws.com/"
+        uri: "https://sqs.sa-east-1.amazonaws.com/"
         body: 
           encoding: UTF-8
           string: "Action=ListQueues&Version=2012-11-05"
@@ -14,11 +14,11 @@
           User-Agent: 
             - "aws-sdk-ruby2/2.0.5 ruby/1.9.3 x86_64-darwin13.4.0"
           X-Amz-Date: 
-            - "20151102T185451Z"
+            - "20151103T154158Z"
           X-Amz-Content-Sha256: 
             - "48a38266faf90970d6c7fea9b15e6ba366e5f6397c2970fc893f8a7b5e207bd0"
           Authorization: 
-            - "AWS4-HMAC-SHA256 Credential=redacted/20151102/us-west-1/sqs/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=68a4ea4453b2f43dcd94d4c105af5d5a0eb76c119362150c256cc1c5fec7aa29"
+            - "AWS4-HMAC-SHA256 Credential=redacted/20151103/sa-east-1/sqs/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=c05fe599d0c3b44bb57005aa3f7630c9ddddcc992d243818bbcb78be3902b742"
           Content-Length: 
             - "36"
           Accept: 
@@ -31,26 +31,26 @@
           Server: 
             - Server
           Date: 
-            - "Mon, 02 Nov 2015 18:52:54 GMT"
+            - "Tue, 03 Nov 2015 15:40:00 GMT"
           Content-Type: 
             - text/xml
           Content-Length: 
-            - "501"
+            - "321"
           Connection: 
             - keep-alive
           X-Amzn-Requestid: 
-            - "5e19fcdd-5a91-579d-8e50-b26ce9d7ea49"
+            - e3bea7b3-9274-5d4e-9c0e-e90145e492cd
         body: 
           encoding: US-ASCII
-          string: "<?xml version=\x221.0\x22?><ListQueuesResponse xmlns=\x22http://queue.amazonaws.com/doc/2012-11-05/\x22><ListQueuesResult><QueueUrl>https://sqs.us-west-1.amazonaws.com/854330369555/71b3ac187342696888a9</QueueUrl><QueueUrl>https://sqs.us-west-1.amazonaws.com/854330369555/fc9501e5636022c597f7</QueueUrl><QueueUrl>https://sqs.us-west-1.amazonaws.com/854330369555/queue</QueueUrl></ListQueuesResult><ResponseMetadata><RequestId>5e19fcdd-5a91-579d-8e50-b26ce9d7ea49</RequestId></ResponseMetadata></ListQueuesResponse>"
+          string: "<?xml version=\x221.0\x22?><ListQueuesResponse xmlns=\x22http://queue.amazonaws.com/doc/2012-11-05/\x22><ListQueuesResult><QueueUrl>https://sqs.sa-east-1.amazonaws.com/854330369555/queue</QueueUrl></ListQueuesResult><ResponseMetadata><RequestId>e3bea7b3-9274-5d4e-9c0e-e90145e492cd</RequestId></ResponseMetadata></ListQueuesResponse>"
         http_version: 
-      recorded_at: "Mon, 02 Nov 2015 18:54:52 GMT"
+      recorded_at: "Tue, 03 Nov 2015 15:42:00 GMT"
     - request: 
         method: post
-        uri: "https://sqs.us-west-1.amazonaws.com/854330369555/71b3ac187342696888a9"
+        uri: "https://sqs.sa-east-1.amazonaws.com/854330369555/queue"
         body: 
           encoding: UTF-8
-          string: "Action=GetQueueAttributes&AttributeName.1=All&QueueUrl=https%3A%2F%2Fsqs.us-west-1.amazonaws.com%2F854330369555%2F71b3ac187342696888a9&Version=2012-11-05"
+          string: "Action=GetQueueAttributes&AttributeName.1=All&QueueUrl=https%3A%2F%2Fsqs.sa-east-1.amazonaws.com%2F854330369555%2Fqueue&Version=2012-11-05"
         headers: 
           Content-Type: 
             - "application/x-www-form-urlencoded; charset=utf-8"
@@ -59,101 +59,11 @@
           User-Agent: 
             - "aws-sdk-ruby2/2.0.5 ruby/1.9.3 x86_64-darwin13.4.0"
           X-Amz-Date: 
-            - "20151102T185452Z"
+            - "20151103T154200Z"
           X-Amz-Content-Sha256: 
-            - "104390c3abbbec8f25f0bf9598054cf0d088acf7162166f36d13650b4e03927c"
+            - "4172538b909231f47b6e0f3310c0da4c5b146c4d1549d6fa8ee58644a94f9f06"
           Authorization: 
-            - "AWS4-HMAC-SHA256 Credential=redacted/20151102/us-west-1/sqs/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=2f9b55b11ed6284d6b3876002aa9db9d01b6dce9738c772cde3fe83952f73057"
-          Content-Length: 
-            - "153"
-          Accept: 
-            - "*/*"
-      response: 
-        status: 
-          code: 200
-          message: OK
-        headers: 
-          Server: 
-            - Server
-          Date: 
-            - "Mon, 02 Nov 2015 18:52:55 GMT"
-          Content-Type: 
-            - text/xml
-          Content-Length: 
-            - "1173"
-          Connection: 
-            - keep-alive
-          X-Amzn-Requestid: 
-            - "5d309842-585c-588f-a578-d6f3eb1bd73c"
-        body: 
-          encoding: US-ASCII
-          string: "<?xml version=\x221.0\x22?><GetQueueAttributesResponse xmlns=\x22http://queue.amazonaws.com/doc/2012-11-05/\x22><GetQueueAttributesResult><Attribute><Name>QueueArn</Name><Value>arn:aws:sqs:us-west-1:854330369555:71b3ac187342696888a9</Value></Attribute><Attribute><Name>ApproximateNumberOfMessages</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesNotVisible</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesDelayed</Name><Value>0</Value></Attribute><Attribute><Name>CreatedTimestamp</Name><Value>1446489955</Value></Attribute><Attribute><Name>LastModifiedTimestamp</Name><Value>1446489955</Value></Attribute><Attribute><Name>VisibilityTimeout</Name><Value>30</Value></Attribute><Attribute><Name>MaximumMessageSize</Name><Value>262144</Value></Attribute><Attribute><Name>MessageRetentionPeriod</Name><Value>120</Value></Attribute><Attribute><Name>DelaySeconds</Name><Value>100</Value></Attribute><Attribute><Name>ReceiveMessageWaitTimeSeconds</Name><Value>0</Value></Attribute></GetQueueAttributesResult><ResponseMetadata><RequestId>5d309842-585c-588f-a578-d6f3eb1bd73c</RequestId></ResponseMetadata></GetQueueAttributesResponse>"
-        http_version: 
-      recorded_at: "Mon, 02 Nov 2015 18:54:53 GMT"
-    - request: 
-        method: post
-        uri: "https://sqs.us-west-1.amazonaws.com/854330369555/fc9501e5636022c597f7"
-        body: 
-          encoding: UTF-8
-          string: "Action=GetQueueAttributes&AttributeName.1=All&QueueUrl=https%3A%2F%2Fsqs.us-west-1.amazonaws.com%2F854330369555%2Ffc9501e5636022c597f7&Version=2012-11-05"
-        headers: 
-          Content-Type: 
-            - "application/x-www-form-urlencoded; charset=utf-8"
-          Accept-Encoding: 
-            - ""
-          User-Agent: 
-            - "aws-sdk-ruby2/2.0.5 ruby/1.9.3 x86_64-darwin13.4.0"
-          X-Amz-Date: 
-            - "20151102T185453Z"
-          X-Amz-Content-Sha256: 
-            - "82a518cbdd75de72e95f29ef74f466b308bf2247813520945154370f98904086"
-          Authorization: 
-            - "AWS4-HMAC-SHA256 Credential=redacted/20151102/us-west-1/sqs/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=4303dd6fe0c29ddb3d8250ce79642c06da559b5bd9e9ebec5f6b931636f9c266"
-          Content-Length: 
-            - "153"
-          Accept: 
-            - "*/*"
-      response: 
-        status: 
-          code: 200
-          message: OK
-        headers: 
-          Server: 
-            - Server
-          Date: 
-            - "Mon, 02 Nov 2015 18:52:56 GMT"
-          Content-Type: 
-            - text/xml
-          Content-Length: 
-            - "1173"
-          Connection: 
-            - keep-alive
-          X-Amzn-Requestid: 
-            - df2e3f31-d3e9-58bd-9a72-718060a14511
-        body: 
-          encoding: US-ASCII
-          string: "<?xml version=\x221.0\x22?><GetQueueAttributesResponse xmlns=\x22http://queue.amazonaws.com/doc/2012-11-05/\x22><GetQueueAttributesResult><Attribute><Name>QueueArn</Name><Value>arn:aws:sqs:us-west-1:854330369555:fc9501e5636022c597f7</Value></Attribute><Attribute><Name>ApproximateNumberOfMessages</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesNotVisible</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesDelayed</Name><Value>0</Value></Attribute><Attribute><Name>CreatedTimestamp</Name><Value>1446490059</Value></Attribute><Attribute><Name>LastModifiedTimestamp</Name><Value>1446490059</Value></Attribute><Attribute><Name>VisibilityTimeout</Name><Value>30</Value></Attribute><Attribute><Name>MaximumMessageSize</Name><Value>262144</Value></Attribute><Attribute><Name>MessageRetentionPeriod</Name><Value>120</Value></Attribute><Attribute><Name>DelaySeconds</Name><Value>100</Value></Attribute><Attribute><Name>ReceiveMessageWaitTimeSeconds</Name><Value>0</Value></Attribute></GetQueueAttributesResult><ResponseMetadata><RequestId>df2e3f31-d3e9-58bd-9a72-718060a14511</RequestId></ResponseMetadata></GetQueueAttributesResponse>"
-        http_version: 
-      recorded_at: "Mon, 02 Nov 2015 18:54:54 GMT"
-    - request: 
-        method: post
-        uri: "https://sqs.us-west-1.amazonaws.com/854330369555/queue"
-        body: 
-          encoding: UTF-8
-          string: "Action=GetQueueAttributes&AttributeName.1=All&QueueUrl=https%3A%2F%2Fsqs.us-west-1.amazonaws.com%2F854330369555%2Fqueue&Version=2012-11-05"
-        headers: 
-          Content-Type: 
-            - "application/x-www-form-urlencoded; charset=utf-8"
-          Accept-Encoding: 
-            - ""
-          User-Agent: 
-            - "aws-sdk-ruby2/2.0.5 ruby/1.9.3 x86_64-darwin13.4.0"
-          X-Amz-Date: 
-            - "20151102T185454Z"
-          X-Amz-Content-Sha256: 
-            - db1e111d346eeac4860326380f0d4b58130b9fb08f40f0769b2e305704acc49f
-          Authorization: 
-            - "AWS4-HMAC-SHA256 Credential=redacted/20151102/us-west-1/sqs/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=1dfb13b06d6f88e210ef964c887576d69c143319cb0b05b118566053024ec369"
+            - "AWS4-HMAC-SHA256 Credential=redacted/20151103/sa-east-1/sqs/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=61f1a603b49c6892ca5912fc1349ef82134580a2d6d5494881fe1cdbe3678a7d"
           Content-Length: 
             - "138"
           Accept: 
@@ -166,7 +76,7 @@
           Server: 
             - Server
           Date: 
-            - "Mon, 02 Nov 2015 18:52:57 GMT"
+            - "Tue, 03 Nov 2015 15:40:01 GMT"
           Content-Type: 
             - text/xml
           Content-Length: 
@@ -174,10 +84,10 @@
           Connection: 
             - keep-alive
           X-Amzn-Requestid: 
-            - "3737163b-89c8-5ea5-9ae0-588a3a81ef17"
+            - "7ea38620-82ed-51a8-97f5-c892557c6a15"
         body: 
           encoding: US-ASCII
-          string: "<?xml version=\x221.0\x22?><GetQueueAttributesResponse xmlns=\x22http://queue.amazonaws.com/doc/2012-11-05/\x22><GetQueueAttributesResult><Attribute><Name>QueueArn</Name><Value>arn:aws:sqs:us-west-1:854330369555:queue</Value></Attribute><Attribute><Name>ApproximateNumberOfMessages</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesNotVisible</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesDelayed</Name><Value>0</Value></Attribute><Attribute><Name>CreatedTimestamp</Name><Value>1446473434</Value></Attribute><Attribute><Name>LastModifiedTimestamp</Name><Value>1446473434</Value></Attribute><Attribute><Name>VisibilityTimeout</Name><Value>30</Value></Attribute><Attribute><Name>MaximumMessageSize</Name><Value>262144</Value></Attribute><Attribute><Name>MessageRetentionPeriod</Name><Value>345600</Value></Attribute><Attribute><Name>DelaySeconds</Name><Value>0</Value></Attribute><Attribute><Name>ReceiveMessageWaitTimeSeconds</Name><Value>0</Value></Attribute></GetQueueAttributesResult><ResponseMetadata><RequestId>3737163b-89c8-5ea5-9ae0-588a3a81ef17</RequestId></ResponseMetadata></GetQueueAttributesResponse>"
+          string: "<?xml version=\x221.0\x22?><GetQueueAttributesResponse xmlns=\x22http://queue.amazonaws.com/doc/2012-11-05/\x22><GetQueueAttributesResult><Attribute><Name>QueueArn</Name><Value>arn:aws:sqs:sa-east-1:854330369555:queue</Value></Attribute><Attribute><Name>ApproximateNumberOfMessages</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesNotVisible</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesDelayed</Name><Value>0</Value></Attribute><Attribute><Name>CreatedTimestamp</Name><Value>1446564993</Value></Attribute><Attribute><Name>LastModifiedTimestamp</Name><Value>1446564993</Value></Attribute><Attribute><Name>VisibilityTimeout</Name><Value>30</Value></Attribute><Attribute><Name>MaximumMessageSize</Name><Value>262144</Value></Attribute><Attribute><Name>MessageRetentionPeriod</Name><Value>345600</Value></Attribute><Attribute><Name>DelaySeconds</Name><Value>0</Value></Attribute><Attribute><Name>ReceiveMessageWaitTimeSeconds</Name><Value>0</Value></Attribute></GetQueueAttributesResult><ResponseMetadata><RequestId>7ea38620-82ed-51a8-97f5-c892557c6a15</RequestId></ResponseMetadata></GetQueueAttributesResponse>"
         http_version: 
-      recorded_at: "Mon, 02 Nov 2015 18:54:56 GMT"
+      recorded_at: "Tue, 03 Nov 2015 15:42:01 GMT"
   recorded_with: "VCR 2.9.3"

--- a/fixtures/vcr_cassettes/sqs-setup.yml
+++ b/fixtures/vcr_cassettes/sqs-setup.yml
@@ -2,7 +2,7 @@
   http_interactions: 
     - request: 
         method: post
-        uri: "https://sqs.us-west-1.amazonaws.com/"
+        uri: "https://sqs.sa-east-1.amazonaws.com/"
         body: 
           encoding: UTF-8
           string: "Action=ListQueues&Version=2012-11-05"
@@ -14,11 +14,11 @@
           User-Agent: 
             - "aws-sdk-ruby2/2.0.5 ruby/1.9.3 x86_64-darwin13.4.0"
           X-Amz-Date: 
-            - "20151102T185441Z"
+            - "20151103T154152Z"
           X-Amz-Content-Sha256: 
             - "48a38266faf90970d6c7fea9b15e6ba366e5f6397c2970fc893f8a7b5e207bd0"
           Authorization: 
-            - "AWS4-HMAC-SHA256 Credential=redacted/20151102/us-west-1/sqs/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=576a34da61f4572936fd99857c75907f284e08749a4261c7b34d20e99a4db0a6"
+            - "AWS4-HMAC-SHA256 Credential=redacted/20151103/sa-east-1/sqs/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=578a1a42bad25bba50d365356505b11d6c71f20c2d2caa481233797b6bf548cf"
           Content-Length: 
             - "36"
           Accept: 
@@ -31,26 +31,26 @@
           Server: 
             - Server
           Date: 
-            - "Mon, 02 Nov 2015 18:52:44 GMT"
+            - "Tue, 03 Nov 2015 15:39:55 GMT"
           Content-Type: 
             - text/xml
           Content-Length: 
-            - "501"
+            - "321"
           Connection: 
             - keep-alive
           X-Amzn-Requestid: 
-            - edd88531-1aae-53c4-abee-cb80a9920869
+            - "0559c6fd-b0c7-54e3-a471-884f674c9183"
         body: 
           encoding: US-ASCII
-          string: "<?xml version=\x221.0\x22?><ListQueuesResponse xmlns=\x22http://queue.amazonaws.com/doc/2012-11-05/\x22><ListQueuesResult><QueueUrl>https://sqs.us-west-1.amazonaws.com/854330369555/71b3ac187342696888a9</QueueUrl><QueueUrl>https://sqs.us-west-1.amazonaws.com/854330369555/fc9501e5636022c597f7</QueueUrl><QueueUrl>https://sqs.us-west-1.amazonaws.com/854330369555/queue</QueueUrl></ListQueuesResult><ResponseMetadata><RequestId>edd88531-1aae-53c4-abee-cb80a9920869</RequestId></ResponseMetadata></ListQueuesResponse>"
+          string: "<?xml version=\x221.0\x22?><ListQueuesResponse xmlns=\x22http://queue.amazonaws.com/doc/2012-11-05/\x22><ListQueuesResult><QueueUrl>https://sqs.sa-east-1.amazonaws.com/854330369555/queue</QueueUrl></ListQueuesResult><ResponseMetadata><RequestId>0559c6fd-b0c7-54e3-a471-884f674c9183</RequestId></ResponseMetadata></ListQueuesResponse>"
         http_version: 
-      recorded_at: "Mon, 02 Nov 2015 18:54:43 GMT"
+      recorded_at: "Tue, 03 Nov 2015 15:41:54 GMT"
     - request: 
         method: post
-        uri: "https://sqs.us-west-1.amazonaws.com/854330369555/71b3ac187342696888a9"
+        uri: "https://sqs.sa-east-1.amazonaws.com/854330369555/queue"
         body: 
           encoding: UTF-8
-          string: "Action=GetQueueAttributes&AttributeName.1=All&QueueUrl=https%3A%2F%2Fsqs.us-west-1.amazonaws.com%2F854330369555%2F71b3ac187342696888a9&Version=2012-11-05"
+          string: "Action=GetQueueAttributes&AttributeName.1=All&QueueUrl=https%3A%2F%2Fsqs.sa-east-1.amazonaws.com%2F854330369555%2Fqueue&Version=2012-11-05"
         headers: 
           Content-Type: 
             - "application/x-www-form-urlencoded; charset=utf-8"
@@ -59,101 +59,11 @@
           User-Agent: 
             - "aws-sdk-ruby2/2.0.5 ruby/1.9.3 x86_64-darwin13.4.0"
           X-Amz-Date: 
-            - "20151102T185443Z"
+            - "20151103T154154Z"
           X-Amz-Content-Sha256: 
-            - "104390c3abbbec8f25f0bf9598054cf0d088acf7162166f36d13650b4e03927c"
+            - "4172538b909231f47b6e0f3310c0da4c5b146c4d1549d6fa8ee58644a94f9f06"
           Authorization: 
-            - "AWS4-HMAC-SHA256 Credential=redacted/20151102/us-west-1/sqs/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=6e309574eaa897173fc8c6dca7ecf31d26f2b76a41b9f334a9b6be4ee0999b54"
-          Content-Length: 
-            - "153"
-          Accept: 
-            - "*/*"
-      response: 
-        status: 
-          code: 200
-          message: OK
-        headers: 
-          Server: 
-            - Server
-          Date: 
-            - "Mon, 02 Nov 2015 18:52:46 GMT"
-          Content-Type: 
-            - text/xml
-          Content-Length: 
-            - "1173"
-          Connection: 
-            - keep-alive
-          X-Amzn-Requestid: 
-            - "8a2ee5d6-eb6b-5754-89a4-ab675855d4c5"
-        body: 
-          encoding: US-ASCII
-          string: "<?xml version=\x221.0\x22?><GetQueueAttributesResponse xmlns=\x22http://queue.amazonaws.com/doc/2012-11-05/\x22><GetQueueAttributesResult><Attribute><Name>QueueArn</Name><Value>arn:aws:sqs:us-west-1:854330369555:71b3ac187342696888a9</Value></Attribute><Attribute><Name>ApproximateNumberOfMessages</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesNotVisible</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesDelayed</Name><Value>0</Value></Attribute><Attribute><Name>CreatedTimestamp</Name><Value>1446489955</Value></Attribute><Attribute><Name>LastModifiedTimestamp</Name><Value>1446489955</Value></Attribute><Attribute><Name>VisibilityTimeout</Name><Value>30</Value></Attribute><Attribute><Name>MaximumMessageSize</Name><Value>262144</Value></Attribute><Attribute><Name>MessageRetentionPeriod</Name><Value>120</Value></Attribute><Attribute><Name>DelaySeconds</Name><Value>100</Value></Attribute><Attribute><Name>ReceiveMessageWaitTimeSeconds</Name><Value>0</Value></Attribute></GetQueueAttributesResult><ResponseMetadata><RequestId>8a2ee5d6-eb6b-5754-89a4-ab675855d4c5</RequestId></ResponseMetadata></GetQueueAttributesResponse>"
-        http_version: 
-      recorded_at: "Mon, 02 Nov 2015 18:54:44 GMT"
-    - request: 
-        method: post
-        uri: "https://sqs.us-west-1.amazonaws.com/854330369555/fc9501e5636022c597f7"
-        body: 
-          encoding: UTF-8
-          string: "Action=GetQueueAttributes&AttributeName.1=All&QueueUrl=https%3A%2F%2Fsqs.us-west-1.amazonaws.com%2F854330369555%2Ffc9501e5636022c597f7&Version=2012-11-05"
-        headers: 
-          Content-Type: 
-            - "application/x-www-form-urlencoded; charset=utf-8"
-          Accept-Encoding: 
-            - ""
-          User-Agent: 
-            - "aws-sdk-ruby2/2.0.5 ruby/1.9.3 x86_64-darwin13.4.0"
-          X-Amz-Date: 
-            - "20151102T185444Z"
-          X-Amz-Content-Sha256: 
-            - "82a518cbdd75de72e95f29ef74f466b308bf2247813520945154370f98904086"
-          Authorization: 
-            - "AWS4-HMAC-SHA256 Credential=redacted/20151102/us-west-1/sqs/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=e2c4bd9e8250a6c9f921acb08277f3197532e5e2f53bc1d6219abe1822ddfc0d"
-          Content-Length: 
-            - "153"
-          Accept: 
-            - "*/*"
-      response: 
-        status: 
-          code: 200
-          message: OK
-        headers: 
-          Server: 
-            - Server
-          Date: 
-            - "Mon, 02 Nov 2015 18:52:47 GMT"
-          Content-Type: 
-            - text/xml
-          Content-Length: 
-            - "1173"
-          Connection: 
-            - keep-alive
-          X-Amzn-Requestid: 
-            - c8e21b55-4d2c-5e4a-8d27-55e4fe137f98
-        body: 
-          encoding: US-ASCII
-          string: "<?xml version=\x221.0\x22?><GetQueueAttributesResponse xmlns=\x22http://queue.amazonaws.com/doc/2012-11-05/\x22><GetQueueAttributesResult><Attribute><Name>QueueArn</Name><Value>arn:aws:sqs:us-west-1:854330369555:fc9501e5636022c597f7</Value></Attribute><Attribute><Name>ApproximateNumberOfMessages</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesNotVisible</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesDelayed</Name><Value>0</Value></Attribute><Attribute><Name>CreatedTimestamp</Name><Value>1446490059</Value></Attribute><Attribute><Name>LastModifiedTimestamp</Name><Value>1446490059</Value></Attribute><Attribute><Name>VisibilityTimeout</Name><Value>30</Value></Attribute><Attribute><Name>MaximumMessageSize</Name><Value>262144</Value></Attribute><Attribute><Name>MessageRetentionPeriod</Name><Value>120</Value></Attribute><Attribute><Name>DelaySeconds</Name><Value>100</Value></Attribute><Attribute><Name>ReceiveMessageWaitTimeSeconds</Name><Value>0</Value></Attribute></GetQueueAttributesResult><ResponseMetadata><RequestId>c8e21b55-4d2c-5e4a-8d27-55e4fe137f98</RequestId></ResponseMetadata></GetQueueAttributesResponse>"
-        http_version: 
-      recorded_at: "Mon, 02 Nov 2015 18:54:45 GMT"
-    - request: 
-        method: post
-        uri: "https://sqs.us-west-1.amazonaws.com/854330369555/queue"
-        body: 
-          encoding: UTF-8
-          string: "Action=GetQueueAttributes&AttributeName.1=All&QueueUrl=https%3A%2F%2Fsqs.us-west-1.amazonaws.com%2F854330369555%2Fqueue&Version=2012-11-05"
-        headers: 
-          Content-Type: 
-            - "application/x-www-form-urlencoded; charset=utf-8"
-          Accept-Encoding: 
-            - ""
-          User-Agent: 
-            - "aws-sdk-ruby2/2.0.5 ruby/1.9.3 x86_64-darwin13.4.0"
-          X-Amz-Date: 
-            - "20151102T185445Z"
-          X-Amz-Content-Sha256: 
-            - db1e111d346eeac4860326380f0d4b58130b9fb08f40f0769b2e305704acc49f
-          Authorization: 
-            - "AWS4-HMAC-SHA256 Credential=redacted/20151102/us-west-1/sqs/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=92f4a94f1a72e76ef37cedc090c4073ef550b45b36c79b8d561c4b80a0f827ca"
+            - "AWS4-HMAC-SHA256 Credential=redacted/20151103/sa-east-1/sqs/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=a41feb6d2a88884078c76b32343232dc39416a900781478ac560ac8b35505ff6"
           Content-Length: 
             - "138"
           Accept: 
@@ -166,7 +76,7 @@
           Server: 
             - Server
           Date: 
-            - "Mon, 02 Nov 2015 18:52:48 GMT"
+            - "Tue, 03 Nov 2015 15:39:56 GMT"
           Content-Type: 
             - text/xml
           Content-Length: 
@@ -174,15 +84,15 @@
           Connection: 
             - keep-alive
           X-Amzn-Requestid: 
-            - "8d62c2cb-12de-54c7-a03b-8c7aa19e8913"
+            - "8c09ac6a-ef89-535d-a4dd-e2d83805d402"
         body: 
           encoding: US-ASCII
-          string: "<?xml version=\x221.0\x22?><GetQueueAttributesResponse xmlns=\x22http://queue.amazonaws.com/doc/2012-11-05/\x22><GetQueueAttributesResult><Attribute><Name>QueueArn</Name><Value>arn:aws:sqs:us-west-1:854330369555:queue</Value></Attribute><Attribute><Name>ApproximateNumberOfMessages</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesNotVisible</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesDelayed</Name><Value>0</Value></Attribute><Attribute><Name>CreatedTimestamp</Name><Value>1446473434</Value></Attribute><Attribute><Name>LastModifiedTimestamp</Name><Value>1446473434</Value></Attribute><Attribute><Name>VisibilityTimeout</Name><Value>30</Value></Attribute><Attribute><Name>MaximumMessageSize</Name><Value>262144</Value></Attribute><Attribute><Name>MessageRetentionPeriod</Name><Value>345600</Value></Attribute><Attribute><Name>DelaySeconds</Name><Value>0</Value></Attribute><Attribute><Name>ReceiveMessageWaitTimeSeconds</Name><Value>0</Value></Attribute></GetQueueAttributesResult><ResponseMetadata><RequestId>8d62c2cb-12de-54c7-a03b-8c7aa19e8913</RequestId></ResponseMetadata></GetQueueAttributesResponse>"
+          string: "<?xml version=\x221.0\x22?><GetQueueAttributesResponse xmlns=\x22http://queue.amazonaws.com/doc/2012-11-05/\x22><GetQueueAttributesResult><Attribute><Name>QueueArn</Name><Value>arn:aws:sqs:sa-east-1:854330369555:queue</Value></Attribute><Attribute><Name>ApproximateNumberOfMessages</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesNotVisible</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesDelayed</Name><Value>0</Value></Attribute><Attribute><Name>CreatedTimestamp</Name><Value>1446564993</Value></Attribute><Attribute><Name>LastModifiedTimestamp</Name><Value>1446564993</Value></Attribute><Attribute><Name>VisibilityTimeout</Name><Value>30</Value></Attribute><Attribute><Name>MaximumMessageSize</Name><Value>262144</Value></Attribute><Attribute><Name>MessageRetentionPeriod</Name><Value>345600</Value></Attribute><Attribute><Name>DelaySeconds</Name><Value>0</Value></Attribute><Attribute><Name>ReceiveMessageWaitTimeSeconds</Name><Value>0</Value></Attribute></GetQueueAttributesResult><ResponseMetadata><RequestId>8c09ac6a-ef89-535d-a4dd-e2d83805d402</RequestId></ResponseMetadata></GetQueueAttributesResponse>"
         http_version: 
-      recorded_at: "Mon, 02 Nov 2015 18:54:47 GMT"
+      recorded_at: "Tue, 03 Nov 2015 15:41:56 GMT"
     - request: 
         method: post
-        uri: "https://sqs.us-west-1.amazonaws.com/"
+        uri: "https://sqs.sa-east-1.amazonaws.com/"
         body: 
           encoding: UTF-8
           string: "Action=ListQueues&Version=2012-11-05"
@@ -194,11 +104,11 @@
           User-Agent: 
             - "aws-sdk-ruby2/2.0.5 ruby/1.9.3 x86_64-darwin13.4.0"
           X-Amz-Date: 
-            - "20151102T185447Z"
+            - "20151103T154156Z"
           X-Amz-Content-Sha256: 
             - "48a38266faf90970d6c7fea9b15e6ba366e5f6397c2970fc893f8a7b5e207bd0"
           Authorization: 
-            - "AWS4-HMAC-SHA256 Credential=redacted/20151102/us-west-1/sqs/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=e588919a027bc919273418c2f6c3dba06efec2ff3e83cd536425478010fe5d81"
+            - "AWS4-HMAC-SHA256 Credential=redacted/20151103/sa-east-1/sqs/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=0e3ac20ac61e20045c4ba73ef70ec92c50eab5365109416975ce1ca93a238a1f"
           Content-Length: 
             - "36"
           Accept: 
@@ -211,26 +121,26 @@
           Server: 
             - Server
           Date: 
-            - "Mon, 02 Nov 2015 18:52:49 GMT"
+            - "Tue, 03 Nov 2015 15:39:58 GMT"
           Content-Type: 
             - text/xml
           Content-Length: 
-            - "501"
+            - "321"
           Connection: 
             - keep-alive
           X-Amzn-Requestid: 
-            - "151f9e44-deb4-5686-bf6f-d0f56df5cf68"
+            - "8dd206b6-6bc3-58e5-8ed3-4804bc4d97a6"
         body: 
           encoding: US-ASCII
-          string: "<?xml version=\x221.0\x22?><ListQueuesResponse xmlns=\x22http://queue.amazonaws.com/doc/2012-11-05/\x22><ListQueuesResult><QueueUrl>https://sqs.us-west-1.amazonaws.com/854330369555/71b3ac187342696888a9</QueueUrl><QueueUrl>https://sqs.us-west-1.amazonaws.com/854330369555/fc9501e5636022c597f7</QueueUrl><QueueUrl>https://sqs.us-west-1.amazonaws.com/854330369555/queue</QueueUrl></ListQueuesResult><ResponseMetadata><RequestId>151f9e44-deb4-5686-bf6f-d0f56df5cf68</RequestId></ResponseMetadata></ListQueuesResponse>"
+          string: "<?xml version=\x221.0\x22?><ListQueuesResponse xmlns=\x22http://queue.amazonaws.com/doc/2012-11-05/\x22><ListQueuesResult><QueueUrl>https://sqs.sa-east-1.amazonaws.com/854330369555/queue</QueueUrl></ListQueuesResult><ResponseMetadata><RequestId>8dd206b6-6bc3-58e5-8ed3-4804bc4d97a6</RequestId></ResponseMetadata></ListQueuesResponse>"
         http_version: 
-      recorded_at: "Mon, 02 Nov 2015 18:54:48 GMT"
+      recorded_at: "Tue, 03 Nov 2015 15:41:57 GMT"
     - request: 
         method: post
-        uri: "https://sqs.us-west-1.amazonaws.com/854330369555/71b3ac187342696888a9"
+        uri: "https://sqs.sa-east-1.amazonaws.com/854330369555/queue"
         body: 
           encoding: UTF-8
-          string: "Action=GetQueueAttributes&AttributeName.1=All&QueueUrl=https%3A%2F%2Fsqs.us-west-1.amazonaws.com%2F854330369555%2F71b3ac187342696888a9&Version=2012-11-05"
+          string: "Action=GetQueueAttributes&AttributeName.1=All&QueueUrl=https%3A%2F%2Fsqs.sa-east-1.amazonaws.com%2F854330369555%2Fqueue&Version=2012-11-05"
         headers: 
           Content-Type: 
             - "application/x-www-form-urlencoded; charset=utf-8"
@@ -239,101 +149,11 @@
           User-Agent: 
             - "aws-sdk-ruby2/2.0.5 ruby/1.9.3 x86_64-darwin13.4.0"
           X-Amz-Date: 
-            - "20151102T185448Z"
+            - "20151103T154157Z"
           X-Amz-Content-Sha256: 
-            - "104390c3abbbec8f25f0bf9598054cf0d088acf7162166f36d13650b4e03927c"
+            - "4172538b909231f47b6e0f3310c0da4c5b146c4d1549d6fa8ee58644a94f9f06"
           Authorization: 
-            - "AWS4-HMAC-SHA256 Credential=redacted/20151102/us-west-1/sqs/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=069a087749e82466b468cd4b249e40aaf92d1f3709733b93b272874516fb46f6"
-          Content-Length: 
-            - "153"
-          Accept: 
-            - "*/*"
-      response: 
-        status: 
-          code: 200
-          message: OK
-        headers: 
-          Server: 
-            - Server
-          Date: 
-            - "Mon, 02 Nov 2015 18:52:50 GMT"
-          Content-Type: 
-            - text/xml
-          Content-Length: 
-            - "1173"
-          Connection: 
-            - keep-alive
-          X-Amzn-Requestid: 
-            - a8bc35ad-0e25-54af-aac0-7b1cbd671b1c
-        body: 
-          encoding: US-ASCII
-          string: "<?xml version=\x221.0\x22?><GetQueueAttributesResponse xmlns=\x22http://queue.amazonaws.com/doc/2012-11-05/\x22><GetQueueAttributesResult><Attribute><Name>QueueArn</Name><Value>arn:aws:sqs:us-west-1:854330369555:71b3ac187342696888a9</Value></Attribute><Attribute><Name>ApproximateNumberOfMessages</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesNotVisible</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesDelayed</Name><Value>0</Value></Attribute><Attribute><Name>CreatedTimestamp</Name><Value>1446489955</Value></Attribute><Attribute><Name>LastModifiedTimestamp</Name><Value>1446489955</Value></Attribute><Attribute><Name>VisibilityTimeout</Name><Value>30</Value></Attribute><Attribute><Name>MaximumMessageSize</Name><Value>262144</Value></Attribute><Attribute><Name>MessageRetentionPeriod</Name><Value>120</Value></Attribute><Attribute><Name>DelaySeconds</Name><Value>100</Value></Attribute><Attribute><Name>ReceiveMessageWaitTimeSeconds</Name><Value>0</Value></Attribute></GetQueueAttributesResult><ResponseMetadata><RequestId>a8bc35ad-0e25-54af-aac0-7b1cbd671b1c</RequestId></ResponseMetadata></GetQueueAttributesResponse>"
-        http_version: 
-      recorded_at: "Mon, 02 Nov 2015 18:54:49 GMT"
-    - request: 
-        method: post
-        uri: "https://sqs.us-west-1.amazonaws.com/854330369555/fc9501e5636022c597f7"
-        body: 
-          encoding: UTF-8
-          string: "Action=GetQueueAttributes&AttributeName.1=All&QueueUrl=https%3A%2F%2Fsqs.us-west-1.amazonaws.com%2F854330369555%2Ffc9501e5636022c597f7&Version=2012-11-05"
-        headers: 
-          Content-Type: 
-            - "application/x-www-form-urlencoded; charset=utf-8"
-          Accept-Encoding: 
-            - ""
-          User-Agent: 
-            - "aws-sdk-ruby2/2.0.5 ruby/1.9.3 x86_64-darwin13.4.0"
-          X-Amz-Date: 
-            - "20151102T185449Z"
-          X-Amz-Content-Sha256: 
-            - "82a518cbdd75de72e95f29ef74f466b308bf2247813520945154370f98904086"
-          Authorization: 
-            - "AWS4-HMAC-SHA256 Credential=redacted/20151102/us-west-1/sqs/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=8ed4ed8ec0a8434f3b86c46c232f87491a303c2863ea5ac93458ec5ee88b8ef0"
-          Content-Length: 
-            - "153"
-          Accept: 
-            - "*/*"
-      response: 
-        status: 
-          code: 200
-          message: OK
-        headers: 
-          Server: 
-            - Server
-          Date: 
-            - "Mon, 02 Nov 2015 18:52:51 GMT"
-          Content-Type: 
-            - text/xml
-          Content-Length: 
-            - "1173"
-          Connection: 
-            - keep-alive
-          X-Amzn-Requestid: 
-            - a9a350da-69b9-5870-9ac9-1e6bdafaffbf
-        body: 
-          encoding: US-ASCII
-          string: "<?xml version=\x221.0\x22?><GetQueueAttributesResponse xmlns=\x22http://queue.amazonaws.com/doc/2012-11-05/\x22><GetQueueAttributesResult><Attribute><Name>QueueArn</Name><Value>arn:aws:sqs:us-west-1:854330369555:fc9501e5636022c597f7</Value></Attribute><Attribute><Name>ApproximateNumberOfMessages</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesNotVisible</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesDelayed</Name><Value>0</Value></Attribute><Attribute><Name>CreatedTimestamp</Name><Value>1446490059</Value></Attribute><Attribute><Name>LastModifiedTimestamp</Name><Value>1446490059</Value></Attribute><Attribute><Name>VisibilityTimeout</Name><Value>30</Value></Attribute><Attribute><Name>MaximumMessageSize</Name><Value>262144</Value></Attribute><Attribute><Name>MessageRetentionPeriod</Name><Value>120</Value></Attribute><Attribute><Name>DelaySeconds</Name><Value>100</Value></Attribute><Attribute><Name>ReceiveMessageWaitTimeSeconds</Name><Value>0</Value></Attribute></GetQueueAttributesResult><ResponseMetadata><RequestId>a9a350da-69b9-5870-9ac9-1e6bdafaffbf</RequestId></ResponseMetadata></GetQueueAttributesResponse>"
-        http_version: 
-      recorded_at: "Mon, 02 Nov 2015 18:54:50 GMT"
-    - request: 
-        method: post
-        uri: "https://sqs.us-west-1.amazonaws.com/854330369555/queue"
-        body: 
-          encoding: UTF-8
-          string: "Action=GetQueueAttributes&AttributeName.1=All&QueueUrl=https%3A%2F%2Fsqs.us-west-1.amazonaws.com%2F854330369555%2Fqueue&Version=2012-11-05"
-        headers: 
-          Content-Type: 
-            - "application/x-www-form-urlencoded; charset=utf-8"
-          Accept-Encoding: 
-            - ""
-          User-Agent: 
-            - "aws-sdk-ruby2/2.0.5 ruby/1.9.3 x86_64-darwin13.4.0"
-          X-Amz-Date: 
-            - "20151102T185450Z"
-          X-Amz-Content-Sha256: 
-            - db1e111d346eeac4860326380f0d4b58130b9fb08f40f0769b2e305704acc49f
-          Authorization: 
-            - "AWS4-HMAC-SHA256 Credential=redacted/20151102/us-west-1/sqs/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=ca0fde3c6a476be4f31d5540d430cd9432540255d4e68c41c3332af9d7f54fe9"
+            - "AWS4-HMAC-SHA256 Credential=redacted/20151103/sa-east-1/sqs/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=5636013fe1a1e50a452aea14c2fa9dd4cb68096ae693da00c5c5cf61b64a8a29"
           Content-Length: 
             - "138"
           Accept: 
@@ -346,7 +166,7 @@
           Server: 
             - Server
           Date: 
-            - "Mon, 02 Nov 2015 18:52:52 GMT"
+            - "Tue, 03 Nov 2015 15:39:59 GMT"
           Content-Type: 
             - text/xml
           Content-Length: 
@@ -354,10 +174,10 @@
           Connection: 
             - keep-alive
           X-Amzn-Requestid: 
-            - b6655afc-cb32-5223-bffd-144d78769996
+            - "08970201-5a96-526c-a165-4cb38d194f48"
         body: 
           encoding: US-ASCII
-          string: "<?xml version=\x221.0\x22?><GetQueueAttributesResponse xmlns=\x22http://queue.amazonaws.com/doc/2012-11-05/\x22><GetQueueAttributesResult><Attribute><Name>QueueArn</Name><Value>arn:aws:sqs:us-west-1:854330369555:queue</Value></Attribute><Attribute><Name>ApproximateNumberOfMessages</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesNotVisible</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesDelayed</Name><Value>0</Value></Attribute><Attribute><Name>CreatedTimestamp</Name><Value>1446473434</Value></Attribute><Attribute><Name>LastModifiedTimestamp</Name><Value>1446473434</Value></Attribute><Attribute><Name>VisibilityTimeout</Name><Value>30</Value></Attribute><Attribute><Name>MaximumMessageSize</Name><Value>262144</Value></Attribute><Attribute><Name>MessageRetentionPeriod</Name><Value>345600</Value></Attribute><Attribute><Name>DelaySeconds</Name><Value>0</Value></Attribute><Attribute><Name>ReceiveMessageWaitTimeSeconds</Name><Value>0</Value></Attribute></GetQueueAttributesResult><ResponseMetadata><RequestId>b6655afc-cb32-5223-bffd-144d78769996</RequestId></ResponseMetadata></GetQueueAttributesResponse>"
+          string: "<?xml version=\x221.0\x22?><GetQueueAttributesResponse xmlns=\x22http://queue.amazonaws.com/doc/2012-11-05/\x22><GetQueueAttributesResult><Attribute><Name>QueueArn</Name><Value>arn:aws:sqs:sa-east-1:854330369555:queue</Value></Attribute><Attribute><Name>ApproximateNumberOfMessages</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesNotVisible</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesDelayed</Name><Value>0</Value></Attribute><Attribute><Name>CreatedTimestamp</Name><Value>1446564993</Value></Attribute><Attribute><Name>LastModifiedTimestamp</Name><Value>1446564993</Value></Attribute><Attribute><Name>VisibilityTimeout</Name><Value>30</Value></Attribute><Attribute><Name>MaximumMessageSize</Name><Value>262144</Value></Attribute><Attribute><Name>MessageRetentionPeriod</Name><Value>345600</Value></Attribute><Attribute><Name>DelaySeconds</Name><Value>0</Value></Attribute><Attribute><Name>ReceiveMessageWaitTimeSeconds</Name><Value>0</Value></Attribute></GetQueueAttributesResult><ResponseMetadata><RequestId>08970201-5a96-526c-a165-4cb38d194f48</RequestId></ResponseMetadata></GetQueueAttributesResponse>"
         http_version: 
-      recorded_at: "Mon, 02 Nov 2015 18:54:51 GMT"
+      recorded_at: "Tue, 03 Nov 2015 15:41:58 GMT"
   recorded_with: "VCR 2.9.3"

--- a/fixtures/vcr_cassettes/sqs-setup.yml
+++ b/fixtures/vcr_cassettes/sqs-setup.yml
@@ -1,0 +1,363 @@
+--- 
+  http_interactions: 
+    - request: 
+        method: post
+        uri: "https://sqs.us-west-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "Action=ListQueues&Version=2012-11-05"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.5 ruby/1.9.3 x86_64-darwin13.4.0"
+          X-Amz-Date: 
+            - "20151102T185441Z"
+          X-Amz-Content-Sha256: 
+            - "48a38266faf90970d6c7fea9b15e6ba366e5f6397c2970fc893f8a7b5e207bd0"
+          Authorization: 
+            - "AWS4-HMAC-SHA256 Credential=redacted/20151102/us-west-1/sqs/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=576a34da61f4572936fd99857c75907f284e08749a4261c7b34d20e99a4db0a6"
+          Content-Length: 
+            - "36"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Server: 
+            - Server
+          Date: 
+            - "Mon, 02 Nov 2015 18:52:44 GMT"
+          Content-Type: 
+            - text/xml
+          Content-Length: 
+            - "501"
+          Connection: 
+            - keep-alive
+          X-Amzn-Requestid: 
+            - edd88531-1aae-53c4-abee-cb80a9920869
+        body: 
+          encoding: US-ASCII
+          string: "<?xml version=\x221.0\x22?><ListQueuesResponse xmlns=\x22http://queue.amazonaws.com/doc/2012-11-05/\x22><ListQueuesResult><QueueUrl>https://sqs.us-west-1.amazonaws.com/854330369555/71b3ac187342696888a9</QueueUrl><QueueUrl>https://sqs.us-west-1.amazonaws.com/854330369555/fc9501e5636022c597f7</QueueUrl><QueueUrl>https://sqs.us-west-1.amazonaws.com/854330369555/queue</QueueUrl></ListQueuesResult><ResponseMetadata><RequestId>edd88531-1aae-53c4-abee-cb80a9920869</RequestId></ResponseMetadata></ListQueuesResponse>"
+        http_version: 
+      recorded_at: "Mon, 02 Nov 2015 18:54:43 GMT"
+    - request: 
+        method: post
+        uri: "https://sqs.us-west-1.amazonaws.com/854330369555/71b3ac187342696888a9"
+        body: 
+          encoding: UTF-8
+          string: "Action=GetQueueAttributes&AttributeName.1=All&QueueUrl=https%3A%2F%2Fsqs.us-west-1.amazonaws.com%2F854330369555%2F71b3ac187342696888a9&Version=2012-11-05"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.5 ruby/1.9.3 x86_64-darwin13.4.0"
+          X-Amz-Date: 
+            - "20151102T185443Z"
+          X-Amz-Content-Sha256: 
+            - "104390c3abbbec8f25f0bf9598054cf0d088acf7162166f36d13650b4e03927c"
+          Authorization: 
+            - "AWS4-HMAC-SHA256 Credential=redacted/20151102/us-west-1/sqs/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=6e309574eaa897173fc8c6dca7ecf31d26f2b76a41b9f334a9b6be4ee0999b54"
+          Content-Length: 
+            - "153"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Server: 
+            - Server
+          Date: 
+            - "Mon, 02 Nov 2015 18:52:46 GMT"
+          Content-Type: 
+            - text/xml
+          Content-Length: 
+            - "1173"
+          Connection: 
+            - keep-alive
+          X-Amzn-Requestid: 
+            - "8a2ee5d6-eb6b-5754-89a4-ab675855d4c5"
+        body: 
+          encoding: US-ASCII
+          string: "<?xml version=\x221.0\x22?><GetQueueAttributesResponse xmlns=\x22http://queue.amazonaws.com/doc/2012-11-05/\x22><GetQueueAttributesResult><Attribute><Name>QueueArn</Name><Value>arn:aws:sqs:us-west-1:854330369555:71b3ac187342696888a9</Value></Attribute><Attribute><Name>ApproximateNumberOfMessages</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesNotVisible</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesDelayed</Name><Value>0</Value></Attribute><Attribute><Name>CreatedTimestamp</Name><Value>1446489955</Value></Attribute><Attribute><Name>LastModifiedTimestamp</Name><Value>1446489955</Value></Attribute><Attribute><Name>VisibilityTimeout</Name><Value>30</Value></Attribute><Attribute><Name>MaximumMessageSize</Name><Value>262144</Value></Attribute><Attribute><Name>MessageRetentionPeriod</Name><Value>120</Value></Attribute><Attribute><Name>DelaySeconds</Name><Value>100</Value></Attribute><Attribute><Name>ReceiveMessageWaitTimeSeconds</Name><Value>0</Value></Attribute></GetQueueAttributesResult><ResponseMetadata><RequestId>8a2ee5d6-eb6b-5754-89a4-ab675855d4c5</RequestId></ResponseMetadata></GetQueueAttributesResponse>"
+        http_version: 
+      recorded_at: "Mon, 02 Nov 2015 18:54:44 GMT"
+    - request: 
+        method: post
+        uri: "https://sqs.us-west-1.amazonaws.com/854330369555/fc9501e5636022c597f7"
+        body: 
+          encoding: UTF-8
+          string: "Action=GetQueueAttributes&AttributeName.1=All&QueueUrl=https%3A%2F%2Fsqs.us-west-1.amazonaws.com%2F854330369555%2Ffc9501e5636022c597f7&Version=2012-11-05"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.5 ruby/1.9.3 x86_64-darwin13.4.0"
+          X-Amz-Date: 
+            - "20151102T185444Z"
+          X-Amz-Content-Sha256: 
+            - "82a518cbdd75de72e95f29ef74f466b308bf2247813520945154370f98904086"
+          Authorization: 
+            - "AWS4-HMAC-SHA256 Credential=redacted/20151102/us-west-1/sqs/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=e2c4bd9e8250a6c9f921acb08277f3197532e5e2f53bc1d6219abe1822ddfc0d"
+          Content-Length: 
+            - "153"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Server: 
+            - Server
+          Date: 
+            - "Mon, 02 Nov 2015 18:52:47 GMT"
+          Content-Type: 
+            - text/xml
+          Content-Length: 
+            - "1173"
+          Connection: 
+            - keep-alive
+          X-Amzn-Requestid: 
+            - c8e21b55-4d2c-5e4a-8d27-55e4fe137f98
+        body: 
+          encoding: US-ASCII
+          string: "<?xml version=\x221.0\x22?><GetQueueAttributesResponse xmlns=\x22http://queue.amazonaws.com/doc/2012-11-05/\x22><GetQueueAttributesResult><Attribute><Name>QueueArn</Name><Value>arn:aws:sqs:us-west-1:854330369555:fc9501e5636022c597f7</Value></Attribute><Attribute><Name>ApproximateNumberOfMessages</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesNotVisible</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesDelayed</Name><Value>0</Value></Attribute><Attribute><Name>CreatedTimestamp</Name><Value>1446490059</Value></Attribute><Attribute><Name>LastModifiedTimestamp</Name><Value>1446490059</Value></Attribute><Attribute><Name>VisibilityTimeout</Name><Value>30</Value></Attribute><Attribute><Name>MaximumMessageSize</Name><Value>262144</Value></Attribute><Attribute><Name>MessageRetentionPeriod</Name><Value>120</Value></Attribute><Attribute><Name>DelaySeconds</Name><Value>100</Value></Attribute><Attribute><Name>ReceiveMessageWaitTimeSeconds</Name><Value>0</Value></Attribute></GetQueueAttributesResult><ResponseMetadata><RequestId>c8e21b55-4d2c-5e4a-8d27-55e4fe137f98</RequestId></ResponseMetadata></GetQueueAttributesResponse>"
+        http_version: 
+      recorded_at: "Mon, 02 Nov 2015 18:54:45 GMT"
+    - request: 
+        method: post
+        uri: "https://sqs.us-west-1.amazonaws.com/854330369555/queue"
+        body: 
+          encoding: UTF-8
+          string: "Action=GetQueueAttributes&AttributeName.1=All&QueueUrl=https%3A%2F%2Fsqs.us-west-1.amazonaws.com%2F854330369555%2Fqueue&Version=2012-11-05"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.5 ruby/1.9.3 x86_64-darwin13.4.0"
+          X-Amz-Date: 
+            - "20151102T185445Z"
+          X-Amz-Content-Sha256: 
+            - db1e111d346eeac4860326380f0d4b58130b9fb08f40f0769b2e305704acc49f
+          Authorization: 
+            - "AWS4-HMAC-SHA256 Credential=redacted/20151102/us-west-1/sqs/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=92f4a94f1a72e76ef37cedc090c4073ef550b45b36c79b8d561c4b80a0f827ca"
+          Content-Length: 
+            - "138"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Server: 
+            - Server
+          Date: 
+            - "Mon, 02 Nov 2015 18:52:48 GMT"
+          Content-Type: 
+            - text/xml
+          Content-Length: 
+            - "1159"
+          Connection: 
+            - keep-alive
+          X-Amzn-Requestid: 
+            - "8d62c2cb-12de-54c7-a03b-8c7aa19e8913"
+        body: 
+          encoding: US-ASCII
+          string: "<?xml version=\x221.0\x22?><GetQueueAttributesResponse xmlns=\x22http://queue.amazonaws.com/doc/2012-11-05/\x22><GetQueueAttributesResult><Attribute><Name>QueueArn</Name><Value>arn:aws:sqs:us-west-1:854330369555:queue</Value></Attribute><Attribute><Name>ApproximateNumberOfMessages</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesNotVisible</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesDelayed</Name><Value>0</Value></Attribute><Attribute><Name>CreatedTimestamp</Name><Value>1446473434</Value></Attribute><Attribute><Name>LastModifiedTimestamp</Name><Value>1446473434</Value></Attribute><Attribute><Name>VisibilityTimeout</Name><Value>30</Value></Attribute><Attribute><Name>MaximumMessageSize</Name><Value>262144</Value></Attribute><Attribute><Name>MessageRetentionPeriod</Name><Value>345600</Value></Attribute><Attribute><Name>DelaySeconds</Name><Value>0</Value></Attribute><Attribute><Name>ReceiveMessageWaitTimeSeconds</Name><Value>0</Value></Attribute></GetQueueAttributesResult><ResponseMetadata><RequestId>8d62c2cb-12de-54c7-a03b-8c7aa19e8913</RequestId></ResponseMetadata></GetQueueAttributesResponse>"
+        http_version: 
+      recorded_at: "Mon, 02 Nov 2015 18:54:47 GMT"
+    - request: 
+        method: post
+        uri: "https://sqs.us-west-1.amazonaws.com/"
+        body: 
+          encoding: UTF-8
+          string: "Action=ListQueues&Version=2012-11-05"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.5 ruby/1.9.3 x86_64-darwin13.4.0"
+          X-Amz-Date: 
+            - "20151102T185447Z"
+          X-Amz-Content-Sha256: 
+            - "48a38266faf90970d6c7fea9b15e6ba366e5f6397c2970fc893f8a7b5e207bd0"
+          Authorization: 
+            - "AWS4-HMAC-SHA256 Credential=redacted/20151102/us-west-1/sqs/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=e588919a027bc919273418c2f6c3dba06efec2ff3e83cd536425478010fe5d81"
+          Content-Length: 
+            - "36"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Server: 
+            - Server
+          Date: 
+            - "Mon, 02 Nov 2015 18:52:49 GMT"
+          Content-Type: 
+            - text/xml
+          Content-Length: 
+            - "501"
+          Connection: 
+            - keep-alive
+          X-Amzn-Requestid: 
+            - "151f9e44-deb4-5686-bf6f-d0f56df5cf68"
+        body: 
+          encoding: US-ASCII
+          string: "<?xml version=\x221.0\x22?><ListQueuesResponse xmlns=\x22http://queue.amazonaws.com/doc/2012-11-05/\x22><ListQueuesResult><QueueUrl>https://sqs.us-west-1.amazonaws.com/854330369555/71b3ac187342696888a9</QueueUrl><QueueUrl>https://sqs.us-west-1.amazonaws.com/854330369555/fc9501e5636022c597f7</QueueUrl><QueueUrl>https://sqs.us-west-1.amazonaws.com/854330369555/queue</QueueUrl></ListQueuesResult><ResponseMetadata><RequestId>151f9e44-deb4-5686-bf6f-d0f56df5cf68</RequestId></ResponseMetadata></ListQueuesResponse>"
+        http_version: 
+      recorded_at: "Mon, 02 Nov 2015 18:54:48 GMT"
+    - request: 
+        method: post
+        uri: "https://sqs.us-west-1.amazonaws.com/854330369555/71b3ac187342696888a9"
+        body: 
+          encoding: UTF-8
+          string: "Action=GetQueueAttributes&AttributeName.1=All&QueueUrl=https%3A%2F%2Fsqs.us-west-1.amazonaws.com%2F854330369555%2F71b3ac187342696888a9&Version=2012-11-05"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.5 ruby/1.9.3 x86_64-darwin13.4.0"
+          X-Amz-Date: 
+            - "20151102T185448Z"
+          X-Amz-Content-Sha256: 
+            - "104390c3abbbec8f25f0bf9598054cf0d088acf7162166f36d13650b4e03927c"
+          Authorization: 
+            - "AWS4-HMAC-SHA256 Credential=redacted/20151102/us-west-1/sqs/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=069a087749e82466b468cd4b249e40aaf92d1f3709733b93b272874516fb46f6"
+          Content-Length: 
+            - "153"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Server: 
+            - Server
+          Date: 
+            - "Mon, 02 Nov 2015 18:52:50 GMT"
+          Content-Type: 
+            - text/xml
+          Content-Length: 
+            - "1173"
+          Connection: 
+            - keep-alive
+          X-Amzn-Requestid: 
+            - a8bc35ad-0e25-54af-aac0-7b1cbd671b1c
+        body: 
+          encoding: US-ASCII
+          string: "<?xml version=\x221.0\x22?><GetQueueAttributesResponse xmlns=\x22http://queue.amazonaws.com/doc/2012-11-05/\x22><GetQueueAttributesResult><Attribute><Name>QueueArn</Name><Value>arn:aws:sqs:us-west-1:854330369555:71b3ac187342696888a9</Value></Attribute><Attribute><Name>ApproximateNumberOfMessages</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesNotVisible</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesDelayed</Name><Value>0</Value></Attribute><Attribute><Name>CreatedTimestamp</Name><Value>1446489955</Value></Attribute><Attribute><Name>LastModifiedTimestamp</Name><Value>1446489955</Value></Attribute><Attribute><Name>VisibilityTimeout</Name><Value>30</Value></Attribute><Attribute><Name>MaximumMessageSize</Name><Value>262144</Value></Attribute><Attribute><Name>MessageRetentionPeriod</Name><Value>120</Value></Attribute><Attribute><Name>DelaySeconds</Name><Value>100</Value></Attribute><Attribute><Name>ReceiveMessageWaitTimeSeconds</Name><Value>0</Value></Attribute></GetQueueAttributesResult><ResponseMetadata><RequestId>a8bc35ad-0e25-54af-aac0-7b1cbd671b1c</RequestId></ResponseMetadata></GetQueueAttributesResponse>"
+        http_version: 
+      recorded_at: "Mon, 02 Nov 2015 18:54:49 GMT"
+    - request: 
+        method: post
+        uri: "https://sqs.us-west-1.amazonaws.com/854330369555/fc9501e5636022c597f7"
+        body: 
+          encoding: UTF-8
+          string: "Action=GetQueueAttributes&AttributeName.1=All&QueueUrl=https%3A%2F%2Fsqs.us-west-1.amazonaws.com%2F854330369555%2Ffc9501e5636022c597f7&Version=2012-11-05"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.5 ruby/1.9.3 x86_64-darwin13.4.0"
+          X-Amz-Date: 
+            - "20151102T185449Z"
+          X-Amz-Content-Sha256: 
+            - "82a518cbdd75de72e95f29ef74f466b308bf2247813520945154370f98904086"
+          Authorization: 
+            - "AWS4-HMAC-SHA256 Credential=redacted/20151102/us-west-1/sqs/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=8ed4ed8ec0a8434f3b86c46c232f87491a303c2863ea5ac93458ec5ee88b8ef0"
+          Content-Length: 
+            - "153"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Server: 
+            - Server
+          Date: 
+            - "Mon, 02 Nov 2015 18:52:51 GMT"
+          Content-Type: 
+            - text/xml
+          Content-Length: 
+            - "1173"
+          Connection: 
+            - keep-alive
+          X-Amzn-Requestid: 
+            - a9a350da-69b9-5870-9ac9-1e6bdafaffbf
+        body: 
+          encoding: US-ASCII
+          string: "<?xml version=\x221.0\x22?><GetQueueAttributesResponse xmlns=\x22http://queue.amazonaws.com/doc/2012-11-05/\x22><GetQueueAttributesResult><Attribute><Name>QueueArn</Name><Value>arn:aws:sqs:us-west-1:854330369555:fc9501e5636022c597f7</Value></Attribute><Attribute><Name>ApproximateNumberOfMessages</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesNotVisible</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesDelayed</Name><Value>0</Value></Attribute><Attribute><Name>CreatedTimestamp</Name><Value>1446490059</Value></Attribute><Attribute><Name>LastModifiedTimestamp</Name><Value>1446490059</Value></Attribute><Attribute><Name>VisibilityTimeout</Name><Value>30</Value></Attribute><Attribute><Name>MaximumMessageSize</Name><Value>262144</Value></Attribute><Attribute><Name>MessageRetentionPeriod</Name><Value>120</Value></Attribute><Attribute><Name>DelaySeconds</Name><Value>100</Value></Attribute><Attribute><Name>ReceiveMessageWaitTimeSeconds</Name><Value>0</Value></Attribute></GetQueueAttributesResult><ResponseMetadata><RequestId>a9a350da-69b9-5870-9ac9-1e6bdafaffbf</RequestId></ResponseMetadata></GetQueueAttributesResponse>"
+        http_version: 
+      recorded_at: "Mon, 02 Nov 2015 18:54:50 GMT"
+    - request: 
+        method: post
+        uri: "https://sqs.us-west-1.amazonaws.com/854330369555/queue"
+        body: 
+          encoding: UTF-8
+          string: "Action=GetQueueAttributes&AttributeName.1=All&QueueUrl=https%3A%2F%2Fsqs.us-west-1.amazonaws.com%2F854330369555%2Fqueue&Version=2012-11-05"
+        headers: 
+          Content-Type: 
+            - "application/x-www-form-urlencoded; charset=utf-8"
+          Accept-Encoding: 
+            - ""
+          User-Agent: 
+            - "aws-sdk-ruby2/2.0.5 ruby/1.9.3 x86_64-darwin13.4.0"
+          X-Amz-Date: 
+            - "20151102T185450Z"
+          X-Amz-Content-Sha256: 
+            - db1e111d346eeac4860326380f0d4b58130b9fb08f40f0769b2e305704acc49f
+          Authorization: 
+            - "AWS4-HMAC-SHA256 Credential=redacted/20151102/us-west-1/sqs/aws4_request, SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date, Signature=ca0fde3c6a476be4f31d5540d430cd9432540255d4e68c41c3332af9d7f54fe9"
+          Content-Length: 
+            - "138"
+          Accept: 
+            - "*/*"
+      response: 
+        status: 
+          code: 200
+          message: OK
+        headers: 
+          Server: 
+            - Server
+          Date: 
+            - "Mon, 02 Nov 2015 18:52:52 GMT"
+          Content-Type: 
+            - text/xml
+          Content-Length: 
+            - "1159"
+          Connection: 
+            - keep-alive
+          X-Amzn-Requestid: 
+            - b6655afc-cb32-5223-bffd-144d78769996
+        body: 
+          encoding: US-ASCII
+          string: "<?xml version=\x221.0\x22?><GetQueueAttributesResponse xmlns=\x22http://queue.amazonaws.com/doc/2012-11-05/\x22><GetQueueAttributesResult><Attribute><Name>QueueArn</Name><Value>arn:aws:sqs:us-west-1:854330369555:queue</Value></Attribute><Attribute><Name>ApproximateNumberOfMessages</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesNotVisible</Name><Value>0</Value></Attribute><Attribute><Name>ApproximateNumberOfMessagesDelayed</Name><Value>0</Value></Attribute><Attribute><Name>CreatedTimestamp</Name><Value>1446473434</Value></Attribute><Attribute><Name>LastModifiedTimestamp</Name><Value>1446473434</Value></Attribute><Attribute><Name>VisibilityTimeout</Name><Value>30</Value></Attribute><Attribute><Name>MaximumMessageSize</Name><Value>262144</Value></Attribute><Attribute><Name>MessageRetentionPeriod</Name><Value>345600</Value></Attribute><Attribute><Name>DelaySeconds</Name><Value>0</Value></Attribute><Attribute><Name>ReceiveMessageWaitTimeSeconds</Name><Value>0</Value></Attribute></GetQueueAttributesResult><ResponseMetadata><RequestId>b6655afc-cb32-5223-bffd-144d78769996</RequestId></ResponseMetadata></GetQueueAttributesResponse>"
+        http_version: 
+      recorded_at: "Mon, 02 Nov 2015 18:54:51 GMT"
+  recorded_with: "VCR 2.9.3"

--- a/lib/puppet/provider/sqs_queue/v2.rb
+++ b/lib/puppet/provider/sqs_queue/v2.rb
@@ -1,0 +1,123 @@
+require_relative '../../../puppet_x/puppetlabs/aws.rb'
+
+Puppet::Type.type(:sqs_queue).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) do
+  confine feature: :aws
+
+  mk_resource_methods
+
+  def self.instances
+    queue_array = []
+    regions.collect do |region|
+      sqs = sqs_client(region)
+      sqs.list_queues().data.queue_urls.each() do |queue_url|
+        attrs = sqs.get_queue_attributes(:queue_url => queue_url, :attribute_names => ['All'])
+        queue_array << new(queue_to_hash(queue_url.split('/')[-1], region, queue_url, attrs.data[:attributes]))
+      end
+    end
+    queue_array
+  end
+
+  def self.prefetch(resources)
+    instances.each do |prov|
+      if resource = resources[prov.name] # rubocop:disable Lint/AssignmentInCondition
+        resource.provider = prov if resource[:region] == prov.region
+        resource[:url] = prov.url
+      end
+    end
+  end
+
+  def create
+    sqs = sqs_client(target_region)
+
+    attributes = get_queue_api_attributes(@resource)
+    url = sqs.create_queue(
+      {
+          queue_name: name,
+          attributes: attributes
+      }
+    )
+    @property_hash[:ensure] = :present
+    @property_hash[:url] = url.data[:queue_url]
+  end
+
+  def destroy
+    sqs = sqs_client(target_region)
+    Puppet.notice("Destroying queue #{resource[:url]}")
+    response = sqs.delete_queue(
+      {
+          queue_url: @resource[:url]
+      }
+    )
+
+    @property_hash[:ensure] = :absent
+    if response.error
+      fail("Failed to delete queue: #{response.error}") if response.error
+    end
+    response.error
+  end
+
+  def exists?
+    Puppet.info("Checking if queue is present")
+    @property_hash[:ensure] == :present
+  end
+
+
+  def initialize(value = {})
+    super(value)
+    @property_flush = {}
+  end
+
+  def delay_seconds=(value)
+    @property_flush[:delay_seconds] = value
+  end
+
+  def message_retention_period=(value)
+    @property_flush[:message_retention_period] = value
+  end
+
+  def maximum_message_size=(value)
+    @property_flush[:maximum_message_size] = value
+  end
+
+  def get_name
+    return @property_hash[:name]
+  end
+
+
+  def get_queue_api_attributes (attrs)
+    transformations = {:delay_seconds => :DelaySeconds, :message_retention_period => :MessageRetentionPeriod,
+                       :maximum_message_size => :MaximumMessageSize}
+    new_hash = {}
+    transformations.map do |k, v|
+      new_hash[v] = attrs[k]
+    end
+    new_hash
+  end
+
+
+  def flush
+    unless (@property_hash[:ensure] == :absent || @property_hash[:ensure] == :purged)
+
+      attributes = get_queue_api_attributes(@resource)
+      sqs_client(target_region).set_queue_attributes(
+        {
+            queue_url: @property_hash[:url],
+            attributes: attributes
+        }
+      )
+      @property_hash = resource.to_hash
+    end
+  end
+
+  def self.queue_to_hash (queue_name, region, queue_url, attrs)
+    queue_hash = {
+        name: queue_name,
+        region: region,
+        ensure: :present,
+        url: queue_url,
+        delay_seconds: attrs['DelaySeconds'],
+        message_retention_period: attrs['MessageRetentionPeriod'],
+        maximum_message_size: attrs['MaximumMessageSize'],
+    }
+  end
+end

--- a/lib/puppet/type/sqs_queue.rb
+++ b/lib/puppet/type/sqs_queue.rb
@@ -1,0 +1,53 @@
+Puppet::Type.newtype(:sqs_queue) do
+  @doc = "Type representing a SQS Queue"
+  ensurable
+
+  newparam(:name, namevar: true) do
+    desc 'The name of the SQS queue'
+    validate do |value|
+      fail 'Queue name must be a string' unless value.is_a?(String)
+      fail 'Queue name cannot be blank' if value.nil? || value.empty?
+      fail 'The name of a SQS queue must contain only alphanumeric characters,dashes or underscores' unless value =~ /[\w-]+/
+    end
+  end
+
+  newparam(:url) do
+    desc 'The URL of an existing queue - read only parameter'
+  end
+
+  newproperty(:delay_seconds) do
+    desc 'The time in seconds that the delivery of all messages in the queue will be delayed'
+    defaultto "0"
+    validate do |value|
+      fail "delay_seconds must be an integer between 0 and 900" if value.to_i < 0 || value.to_i > 900
+    end
+    munge(&:to_s)
+  end
+
+  newproperty(:message_retention_period) do
+    desc 'The number of seconds Amazon SQS retains a message.'
+    defaultto "345600"
+    validate do |value|
+      fail "message_retention_period must be an integer between 60 and 1209600" if value.to_i < 60 || value.to_i > 1209600
+    end
+
+    munge(&:to_s)
+  end
+
+  newproperty(:maximum_message_size) do
+    desc 'The limit of how many bytes a message can contain before Amazon SQS rejects it.'
+    defaultto "262144"
+    validate do |value|
+      fail "maximum_message_size must be an integer between 1024 and 262144" if value.to_i < 1024 || value.to_i > 262144
+    end
+     munge(&:to_s)
+  end
+  newproperty(:region) do
+    desc 'The name of the region in which the SQS queue is located'
+    validate do |value|
+      fail 'region should be a String' unless value.is_a?(String)
+      fail 'You must provide a non-blank region name for SQS Queues' if value.nil? || value.empty?
+      fail 'The name of a region should contain only alphanumeric characters or dashes' unless value =~ /^([a-zA-Z]+-+)+\d$/
+    end
+  end
+end

--- a/lib/puppet_x/puppetlabs/aws.rb
+++ b/lib/puppet_x/puppetlabs/aws.rb
@@ -192,6 +192,15 @@ This could be because some other process is modifying AWS at the same time."""
         ::Aws::RDS::Client.new({region: region})
       end
 
+      def sqs_client(region = default_region)
+        self.class.sqs_client(region)
+      end
+
+      def self.sqs_client(region = default_region)
+        ::Aws::SQS::Client.new({region: region})
+      end
+
+
       def tags_for_resource
         tags = resource[:tags] ? resource[:tags].map { |k,v| {key: k, value: v} } : []
         tags << {key: 'Name', value: name}
@@ -295,6 +304,13 @@ This could be because some other process is modifying AWS at the same time."""
           end
         end
         @dhcp_options[options_id]
+      end
+
+
+      def queue_url_from_name (queue_name )
+        sqs = sqs_client(target_region)
+        response = sqs.get_queue_url ({queue_name: name})
+        response.data.queue_url
       end
 
       def self.gateway_name_from_id(region, gateway_id)

--- a/spec/acceptance/fixtures/sqs_queue.pp.tmpl
+++ b/spec/acceptance/fixtures/sqs_queue.pp.tmpl
@@ -1,0 +1,7 @@
+sqs_queue { '{{name}}':
+  ensure      => '{{ensure}}' ,
+  region      => '{{region}}',
+  delay_seconds => {{delay_seconds}},
+  message_retention_period => {{message_retention_period}},
+  maximum_message_size => {{maximum_message_size}},
+}

--- a/spec/acceptance/sqs_spec.rb
+++ b/spec/acceptance/sqs_spec.rb
@@ -1,0 +1,117 @@
+require 'spec_helper_acceptance'
+require 'securerandom'
+
+describe "sqs_queue" do
+  before(:all) do
+    @default_region = 'us-west-1'
+    @template = 'sqs_queue.pp.tmpl'
+    @aws = AwsHelper.new(@default_region)
+  end
+  describe "should create new sqs queue" do
+    before (:all) do
+      @config = {
+          :name => SecureRandom.hex(10),
+          :ensure => 'present',
+          :region => 'us-west-1',
+          :delay_seconds => 100,
+          :message_retention_period => 120,
+          :maximum_message_size => 2048,
+      }
+      PuppetManifest.new(@template, @config).apply
+
+      # Hack: queues aren't instantly visible
+      # this means the ensure => absent step can get skipped
+      sleep(60)
+    end
+
+    after (:all) do
+      new_config = @config.update({
+                                      :ensure => 'absent',
+                                      :region => 'us-west-1'
+                                  })
+      PuppetManifest.new(@template, new_config).apply
+    end
+
+    it "creates a queue and which has a url" do
+      url = @aws.get_sqs_queue_url(@config[:name])
+      expect(url).to include("amazonaws.com/")
+    end
+
+    it "has expected retention_period" do
+      url = @aws.get_sqs_queue_url(@config[:name])
+      attrs = @aws.get_sqs_queue_attributes(url)
+      expect(attrs["MessageRetentionPeriod"]).to eq(@config[:message_retention_period].to_s)
+    end
+
+    it "has expected delay seconds" do
+      url = @aws.get_sqs_queue_url(@config[:name])
+      attrs = @aws.get_sqs_queue_attributes(url)
+      expect(attrs["DelaySeconds"]).to eq(@config[:delay_seconds].to_s)
+    end
+
+    it "has expected maximum message size" do
+      url = @aws.get_sqs_queue_url(@config[:name])
+      attrs = @aws.get_sqs_queue_attributes(url)
+      expect(attrs["MaximumMessageSize"]).to eq(@config[:maximum_message_size].to_s)
+    end
+
+    context "using resource" do
+      before(:all) do
+        ENV['AWS_REGION'] = @default_region
+        options = {:name => @config[:name]}
+        @result = TestExecutor.puppet_resource('sqs_queue', options, '--modulepath ../')
+      end
+
+      it 'should show the queue as present' do
+        regex = /ensure\s*=>\s*'present'/
+        expect(@result.stdout).to match(regex)
+      end
+
+      it 'should show delay seconds' do
+        regex = /delay_seconds\s*=>\s*'100'/
+        expect(@result.stdout).to match(regex)
+      end
+
+      it 'should show message_retention_period ' do
+        regex = /message_retention_period\s*=>\s*'120'/
+        expect(@result.stdout).to match(regex)
+      end
+      it 'should show maximum_message_size' do
+        regex = /maximum_message_size\s*=>\s*'2048'/
+        expect(@result.stdout).to match(regex)
+      end
+    end
+
+
+    context "change params" do
+      before (:all) do
+        new_config = @config.update({
+                                        :delay_seconds => 200,
+                                        :message_retention_period => 140,
+                                        :maximum_message_size => 4048,
+                                    })
+        PuppetManifest.new(@template, new_config).apply
+        sleep(60)
+      end
+
+      it "updates expected_queue_size" do
+        url = @aws.get_sqs_queue_url(@config[:name])
+        attrs = @aws.get_sqs_queue_attributes(url)
+        expect(attrs["MaximumMessageSize"]).to eq(@config[:maximum_message_size].to_s)
+      end
+
+      it "updates expected message_retention_period" do
+        url = @aws.get_sqs_queue_url(@config[:name])
+        attrs = @aws.get_sqs_queue_attributes(url)
+        expect(attrs["MessageRetentionPeriod"]).to eq(@config[:message_retention_period].to_s)
+      end
+
+      it "update delay seconds " do
+        url = @aws.get_sqs_queue_url(@config[:name])
+        attrs = @aws.get_sqs_queue_attributes(url)
+        expect(attrs["DelaySeconds"]).to eq(@config[:delay_seconds].to_s)
+      end
+    end
+  end
+end
+

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -100,7 +100,25 @@ class AwsHelper
     @cloudwatch_client = ::Aws::CloudWatch::Client.new({region: region})
     @route53_client = ::Aws::Route53::Client.new({region: region})
     @rds_client = ::Aws::RDS::Client.new({region: region})
+    @sqs_client = ::Aws::SQS::Client.new({region: region})
   end
+
+
+  def get_sqs_queue_url(name)
+    response = @sqs_client.get_queue_url(
+      queue_name: name
+    )
+    response.data.queue_url
+  end
+
+  def get_sqs_queue_attributes(url)
+    response = @sqs_client.get_queue_attributes(
+      queue_url: url,
+      attribute_names: ['All']
+    )
+    response.data.attributes
+  end
+
 
   def get_rds_instance(name)
     response = @rds_client.describe_db_instances(

--- a/spec/unit/provider/sqs_queue/v2_spec.rb
+++ b/spec/unit/provider/sqs_queue/v2_spec.rb
@@ -1,0 +1,96 @@
+require 'spec_helper'
+require_relative '../../../../lib/puppet_x/puppetlabs/aws.rb'
+
+provider_class = Puppet::Type.type(:sqs_queue).provider(:v2)
+
+
+ENV['AWS_ACCESS_KEY_ID'] = 'redacted'
+ENV['AWS_SECRET_ACCESS_KEY'] = 'redacted'
+ENV['AWS_REGION'] = 'us-west-1'
+
+describe provider_class do
+  context 'with params' do
+    let(:resource) do 
+      Puppet::Type.type(:sqs_queue).new(
+        name: 'queue',
+        region: 'us-east-1',
+        delay_seconds: 10,
+        message_retention_period: 699
+      ) 
+    end
+
+    let(:provider) { resource.provider }
+
+    let(:instance) { provider.class.instances.first }
+
+    it 'should be an instance of the ProviderV2' do
+      expect(provider).to be_an_instance_of Puppet::Type::Sqs_queue::ProviderV2
+    end
+
+    describe 'self.prefetch' do
+      it 'exists' do
+        VCR.use_cassette('sqs-setup') do
+          provider.class.instances
+          provider.class.prefetch({})
+        end
+      end
+    end
+
+    describe 'no given queue name' do
+      it 'exists' do
+        VCR.use_cassette('unnamed-queue') do
+          expect(provider.exists?).to be_falsey
+        end
+      end
+    end
+
+    describe 'given queue name' do
+      it 'exists' do
+        VCR.use_cassette('named-queue') do
+          expect(instance.exists?).to be_truthy
+        end
+      end
+    end
+  end
+
+  context "creating and destroying" do
+    let(:resource) do 
+      Puppet::Type.type(:sqs_queue).new(
+        name: 'queue2',
+        region: 'us-east-1',
+        delay_seconds: 10,
+      ) 
+    end
+    let(:provider) { resource.provider }
+    let(:instance) { provider.class.instances.first }
+    describe 'create and destroy queue' do
+      queue_url = ''
+      def get_queue_url (name)
+        VCR.use_cassette('get_queue') do
+          instance.queue_url_from_name(name)
+        end
+      end
+      it 'creates' do
+        VCR.use_cassette('create-named-queue') do
+          expect(provider.create).to be_truthy
+        end
+      end
+
+      it "gets the queue url" do
+        queue_url = get_queue_url('queue')
+      end
+     let(:resource) do 
+       Puppet::Type.type(:sqs_queue).new(
+         name: 'queue',
+         region: 'us-east-1',
+         url:  queue_url
+       ) 
+     end
+      it "destroys the queue" do
+        VCR.use_cassette('destroy-queue') do
+          expect(provider.destroy).to be_nil
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/provider/sqs_queue/v2_spec.rb
+++ b/spec/unit/provider/sqs_queue/v2_spec.rb
@@ -6,14 +6,14 @@ provider_class = Puppet::Type.type(:sqs_queue).provider(:v2)
 
 ENV['AWS_ACCESS_KEY_ID'] = 'redacted'
 ENV['AWS_SECRET_ACCESS_KEY'] = 'redacted'
-ENV['AWS_REGION'] = 'us-west-1'
+ENV['AWS_REGION'] = 'sa-east-1'
 
 describe provider_class do
   context 'with params' do
     let(:resource) do 
       Puppet::Type.type(:sqs_queue).new(
         name: 'queue',
-        region: 'us-east-1',
+        region: 'sa-east-1',
         delay_seconds: 10,
         message_retention_period: 699
       ) 
@@ -57,7 +57,7 @@ describe provider_class do
     let(:resource) do 
       Puppet::Type.type(:sqs_queue).new(
         name: 'queue2',
-        region: 'us-east-1',
+        region: 'sa-east-1',
         delay_seconds: 10,
       ) 
     end
@@ -82,7 +82,7 @@ describe provider_class do
      let(:resource) do 
        Puppet::Type.type(:sqs_queue).new(
          name: 'queue',
-         region: 'us-east-1',
+         region: 'sa-east-1',
          url:  queue_url
        ) 
      end

--- a/spec/unit/type/sqs_queue_spec.rb
+++ b/spec/unit/type/sqs_queue_spec.rb
@@ -1,0 +1,108 @@
+require 'spec_helper'
+
+type_class = Puppet::Type.type(:sqs_queue)
+
+describe type_class do
+  context "expected values" do
+    let :params do
+      [
+          :name,
+      ]
+    end
+
+    let :properties do
+      [
+          :ensure,
+          :region,
+          :delay_seconds,
+          :maximum_message_size,
+          :message_retention_period,
+      ]
+    end
+
+
+    it 'should have expected properties' do
+      properties.each do |property|
+        expect(type_class.properties.map(&:name)).to be_include(property)
+      end
+    end
+
+    it 'should create a valid instance' do
+      type_class.new({name: 'name', region: 'us-east-1'})
+    end
+
+
+    it 'should set delay seconds should get set with a valid value' do
+      queue = type_class.new({name: 'queue', region: 'us-east-1', delay_seconds: 450})
+      expect(queue[:delay_seconds]).to eq("450")
+    end
+
+    it 'delay seconds should default to 0' do
+      queue = type_class.new({name: 'queue', region: 'us-east-1'})
+      expect(queue[:delay_seconds]).to eq("0")
+    end
+
+    it 'should set message_retention_period should get set with a valid value' do
+      queue = type_class.new({name: 'queue', region: 'us-east-1', message_retention_period: 360})
+      expect(queue[:message_retention_period]).to eq("360")
+    end
+
+    it 'should set message_retention_period to default to 345600' do
+      queue = type_class.new({name: 'queue', region: 'us-east-1'})
+      expect(queue[:message_retention_period]).to eq("345600")
+    end
+
+    it 'should set maximum_message_size should get set with a valid value' do
+      queue = type_class.new({name: 'queue', region: 'us-east-1', maximum_message_size: 2048})
+      expect(queue[:maximum_message_size]).to eq("2048")
+    end
+
+    it 'should set maximum_message_size to default to 262144' do
+      queue = type_class.new({name: 'queue', region: 'us-east-1'})
+      expect(queue[:maximum_message_size]).to eq("262144")
+    end
+
+
+    it 'should have expected parameters' do
+      params.each do |param|
+        expect(type_class.parameters).to be_include(param)
+      end
+    end
+  end
+  context 'erroring values' do
+    it 'should error with incorrect range value for delay seconds' do
+      expect do
+        type_class.new({name: 'queue', region: 'us-east-1', delay_seconds: 1024})
+      end.to raise_error(Puppet::Error, /delay_seconds must be an integer between 0 and 900/)
+    end
+
+     it 'should require something that looks like a region' do
+      expect do
+        type_class.new ({name: 'somename', :region => 'us_east_1'})
+      end.to raise_error(Puppet::Error, /The name of a region should contain only alphanumeric characters or dashes/)
+      expect do
+        type_class.new ({name: 'somename', :region => '123'})
+      end.to raise_error(Puppet::Error, /The name of a region should contain only alphanumeric characters or dashes/)
+      expect do
+        type_class.new ({name: 'somename', :region => 'europe'})
+      end.to raise_error(Puppet::Error, /The name of a region should contain only alphanumeric characters or dashes/)
+     end
+
+     it 'should require a non-blank region' do
+      expect do
+        type_class.new ({name: 'somename', region: ''})
+      end.to raise_error(Puppet::Error, /You must provide a non-blank region name for SQS Queues/)
+    end
+    it 'should require a name' do
+      expect do
+        type_class.new({})
+      end.to raise_error(Puppet::Error, 'Title or name must be provided')
+    end
+
+    it 'should require a non-blank name' do
+      expect do
+        type_class.new({name: ''})
+      end.to raise_error(Puppet::Error, /Queue name cannot be blank/)
+    end
+  end
+end


### PR DESCRIPTION
Introducing ability to create, update and destroy SQS queues based on the name of the queue. The only supported queue attributes are:
 - delay_seconds
 - maximum_message_size
 - message_retention_period

Previously there was no support for managing SQS queues.

Unit tests included for both type/provider and also e2e acceptance test is included.

I'm not much of a Ruby developer and haven't written a custom type before so it would be great to get some feedback!



