### PR TITLE
(FM-3772) Resolve issue when using running for ensure on ec2_instance

### DIFF
--- a/lib/puppet/type/ec2_instance.rb
+++ b/lib/puppet/type/ec2_instance.rb
@@ -22,9 +22,11 @@ Puppet::Type.newtype(:ec2_instance) do
       current == desired ? current : "changed #{current} to #{desired}"
     end
     def insync?(is)
-      is = :present if is == :running
-      is = :stopped if is == :stopping
-      is.to_s == should.to_s
+      is.to_s == should.to_s or
+        (is.to_s == 'running' and should.to_s == 'present') or
+        (is.to_s == 'stopped' and should.to_s == 'present') or
+        (is.to_s == 'stopping' and should.to_s == 'stopped') or
+        (is.to_s == 'stopping' and should.to_s == 'present')
     end
   end
 

--- a/spec/unit/type/ec2_instance_spec.rb
+++ b/spec/unit/type/ec2_instance_spec.rb
@@ -55,6 +55,31 @@ describe type_class do
     type_class.new(:name => 'sample', :ensure => :running)
   end
 
+  it 'should acknowledge stopped instance to be present' do
+    machine = type_class.new(:name => 'sample', :ensure => :present)
+    expect(machine.property(:ensure).insync?(:stopped)).to be true
+  end
+
+  it 'should acknowledge stopping instance to be present' do
+    machine = type_class.new(:name => 'sample', :ensure => :present)
+    expect(machine.property(:ensure).insync?(:stopping)).to be true
+  end
+
+  it 'should acknowledge running instance to be present' do
+    machine = type_class.new(:name => 'sample', :ensure => :present)
+    expect(machine.property(:ensure).insync?(:running)).to be true
+  end
+
+  it 'should acknowledge stopping instance to be stopped' do
+    machine = type_class.new(:name => 'sample', :ensure => :stopped)
+    expect(machine.property(:ensure).insync?(:stopping)).to be true
+  end
+
+  it 'should acknowledge running instance to be running' do
+    machine = type_class.new(:name => 'sample', :ensure => :running)
+    expect(machine.property(:ensure).insync?(:running)).to be true
+  end
+
   it 'should default monitoring to false' do
     srv = type_class.new(:name => 'sample')
     expect(srv[:monitoring]).to eq(:false)


### PR DESCRIPTION
The logic around the use of running for ensure was incorrect. Although
instances would correctly report they were running, if you used
'running' rather than 'present' in your manifests it would mistakenly
issue change notifications.

This commit fixes the logic and adds (previously failing) tests to
verify the change.