### PR TITLE
(MAINT) Fix issue where an exception triggers another exception

### DIFF
--- a/lib/puppet/provider/route53_record.rb
+++ b/lib/puppet/provider/route53_record.rb
@@ -19,10 +19,9 @@ class Puppet::Provider::Route53Record < PuppetX::Puppetlabs::Aws
         end
       end
     end
-      
       records
     rescue Timeout::Error, StandardError => e
-      raise PuppetX::Puppetlabs::FetchingAWSDataError.new(region, self.resource_type.name.to_s, e.message)
+      raise PuppetX::Puppetlabs::FetchingAWSDataError.new("Route 53", self.resource_type.name.to_s, e.message)
     end
   end
 


### PR DESCRIPTION
This is a copy-paste bug. Route53 is a global service (it's DNS), unlike
all the other services which are scoped to region. This is rarely seen,
but a user managing a large number of records hit it a few times. This
should mean when the exception occurs a useful error message is produced
rather than getting Error: Failed to apply catalog: undefined local
variable or method `region' for.