### PR TITLE
Add support and doc for configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,15 @@ setting for all traffic like so:
 export PUPPET_AWS_PROXY=http://localhost:8888
 ~~~
 
+#### Using a configuration file
+
+The AWS region and HTTP proxy can be provided in a file called 
+`puppetlabs_aws_configuration.ini` in the Puppet confdir 
+(`$settings::confdir`) using this format:
+
+    [default]
+      region = us-east-1
+      http_proxy = http://proxy.example.com:80
 
 ##Getting Started with aws
 

--- a/lib/puppet_x/puppetlabs/aws.rb
+++ b/lib/puppet_x/puppetlabs/aws.rb
@@ -84,7 +84,7 @@ This could be because some other process is modifying AWS at the same time."""
       def self.global_configuration
         Puppet.initialize_settings unless Puppet[:confdir]
         path = File.join(Puppet[:confdir], 'puppetlabs_aws_configuration.ini')
-        File.exists?(path) ? parse_ini(File.new(path)) : nil
+        File.exists?(path) ? ini_parse(File.new(path)) : nil
       end
 
       def self.region_from_global_configuration


### PR DESCRIPTION
In reviewing the 1.3.0 release, the groundwork for supporting the configuration file was in place, but not documented.  I tested it based on a review of the code and have a working configuration with the included code update as documented in the README update.