### PR TITLE
Support for managing EC2 Volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -601,8 +601,14 @@ back- end instances.  Accepts a hash with the following keys:
 ##### `load_balancers`
 *Optional* A list of load balancer names that should be attached to this autoscaling group.
 
+##### `target_groups`
+*Optional* A list of ELBv2 Target Group names that should be attached to this autoscaling group.
+
 ##### `subnets`
 *Optional* The subnets to associate with the autoscaling group.
+
+##### `termination_policies`
+*Optional* A list of termination policies to use when scaling in instances. For valid termination policies, see [Controlling Which Instances Auto Scaling Terminates During Scale In](http://docs.aws.amazon.com/autoscaling/latest/userguide/as-instance-termination.html).
 
 #####`tags`
 *Optional* The tags to assign to the autoscaling group. Accepts a 'key => value' hash of tags. The tags are not propagated to launched instances.

--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ You can use the aws module to audit AWS resources, launch autoscaling groups in 
 
 * `ec2_instance`: Sets up an EC2 instance.
 * `ec2_securitygroup`: Sets up an EC2 security group.
+* `ec2_volume`: Sets up an EC2 EBS volume.
 * `elb_loadbalancer`: Sets up an ELB load balancer.
 * `cloudwatch_alarm`: Sets up a Cloudwatch Alarm.
 * `ec2_autoscalinggroup`: Sets up an EC2 auto scaling group.
@@ -527,6 +528,35 @@ back- end instances.  Accepts a hash with the following keys:
 
 #####`scheme`
 *Optional* Whether the load balancer is internal or public facing. This parameter is set at creation only; it is not affected by updates. Valid values are 'internal', 'internet-facing'. Default value is 'internet-facing' and makes the load balancer publicly available.
+
+#### Type: ec2_volume
+
+##### `name`
+*Required* The name of the volume
+
+##### `region`
+*Required* The region in which to create the volume. For valid values, see [AWS Regions](http://docs.aws.amazon.com/general/latest/gr/rande.html#ec2_region).
+
+##### `size`
+*Conditional* The size of the EBS volume in GB. if restoring from snapshot this parameter is not required.
+
+##### `iops`
+*Optional* Only valid for Provisioned IOPS SSD volumes. The number of I/O operations per second (IOPS) to provision for the volume, with a maximum ratio of 50 IOPS/GiB.
+
+##### `availability_zone`
+*Required* The availability zones in which to create the volume. Accepts an array of availability zone codes. For valid availability zone codes, see [AWS Regions and Availability Zones](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html).
+
+##### `volume_type`
+*Required* The volume type. This can be gp2 for General Purpose SSD, io1 for Provisioned IOPS SSD, st1 for Throughput Optimized HDD, sc1 for Cold HDD, or standard for Magnetic volumes.
+
+##### `encrypted`
+*Optional* Specifies whether the volume should be encrypted. Encrypted Amazon EBS volumes may only be attached to instances that support Amazon EBS encryption. Volumes that are created from encrypted snapshots are automatically encrypted. There is no way to create an encrypted volume from an unencrypted snapshot or vice versa.
+
+##### `kms_key_id`
+*Optional* The full ARN of the AWS Key Management Service (AWS KMS) customer master key (CMK) to use when creating the encrypted volume. This parameter is only required if you want to use a non-default CMK; if this parameter is not specified, the default CMK for EBS is used.
+
+##### `snapshot_id`
+*Optional* The snapshot from which to create the volume.
 
 #### Type: cloudwatch_alarm
 

--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ You can use the aws module to audit AWS resources, launch autoscaling groups in 
 * `ecs_service`: Manage an Ec2 Container Service service.
 * `ecs_task_definition`: Manage an Ec2 Container Service task definition.
 * `iam_group`: Manage IAM groups and their membership.
+* `iam_instance_profile`: Manage IAM instance profiles.
 * `iam_policy`: Manage an IAM 'managed' policy.
 * `iam_policy_attachment`: Manage an IAM 'managed' policy attachments.
 * `iam_role`: Manage an IAM role.
@@ -1036,6 +1037,24 @@ iam_group { 'root':
 
 #####`members`
 *Required* An array of user names to include in the group.  Users not specified in this array will be removed.
+
+#### Type: iam_instance_profile
+
+```Puppet
+iam_instance_profile { 'my_iam_role':
+  ensure  => present,
+  roles => [ 'my_iam_role' ],
+}
+```
+
+#####`ensure`
+Specifies the basic state of the resource. Valid values are 'present', 'absent'.
+
+#####`name`
+*Required* The name of the IAM instance profile.
+
+#####`roles`
+*Optional* The IAM role(s) to associate this instance profile with.  Accepts an array for multiple roles.
 
 #### Type: iam_policy
 

--- a/README.md
+++ b/README.md
@@ -1239,6 +1239,9 @@ is deleted. Defaults to false.
 The name of an associated DB parameter group. Should be a string. This
 parameter is set at creation only; it is not affected by updates.
 
+#####`restore_snapshot
+Specify the snapshot name to optionally trigger creating the RDS DB from a snapshot.
+
 #####`final_db_snapshot_identifier`
 The name of the snapshot created when the instance is terminated. Note
 that skip_final_snapshot must be set to false.

--- a/README.md
+++ b/README.md
@@ -333,6 +333,7 @@ You can use the aws module to audit AWS resources, launch autoscaling groups in 
 * `iam_group`: Manage IAM groups and their membership.
 * `iam_policy`: Manage an IAM 'managed' policy.
 * `iam_policy_attachment`: Manage an IAM 'managed' policy attachments.
+* `iam_role`: Manage an IAM role.
 * `iam_user`: Manage IAM users.
 * `rds_db_parameter_group`: Allows read access to DB Parameter Groups.
 * `rds_db_securitygroup`: Sets up an RDS DB Security Group.
@@ -1095,6 +1096,56 @@ iam_policy_attachment { 'root':
 
 #####`roles`
 *Optional* An array of role names to attach to the policy.  **Role names not mentioned in this array will be detached from the policy.**
+
+#### Type: iam_role
+The `iam_role` type manages IAM roles.  
+
+```
+iam_role { 'devtesting':
+  ensure => present,
+  policy_document => '[
+      {
+        "Effect": "Allow",
+        "Principal": {
+          "Service": "ec2.amazonaws.com"
+        },
+        "Action": "sts:AssumeRole"
+      }
+    ]',
+}
+```
+
+All parameters are read-only once created.
+
+#####`ensure`
+Specifies the basic state of the resource. Valid values are 'present', 'absent'
+
+#####`name`
+The name of the IAM role
+
+#####`path`
+Role path (optional)
+
+#####`policy_document`
+A string containing the IAM policy in JSON format which controls which entities may assume this role, e.g. the default:
+ 
+```
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+```
+
+#####`arn`
+The Amazon Resource Name for this IAM role.
 
 #### Type: iam_user
 The `iam_user` type manages user accounts in IAM.  Only the user's name is

--- a/fixtures/vcr_cassettes/create-instance-profile.yml
+++ b/fixtures/vcr_cassettes/create-instance-profile.yml
@@ -1,0 +1,141 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://iam.amazonaws.com/
+    body:
+      encoding: UTF-8
+      string: Action=ListInstanceProfiles&Version=2010-05-08
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby2/2.3.3 ruby/2.1.7 x86_64-darwin14.0
+      X-Amz-Date:
+      - 20160802T182439Z
+      X-Amz-Content-Sha256:
+      - 44d83e3a0f5f6915cab0b95802111050b054a3353097341089af8a6c2ee48399
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=redacted/20160802/us-east-1/iam/aws4_request,
+        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, Signature=222a01c263b05370d9bac5ddcd7ef1b5072e241be12b2726f5ca3e970ee2b5d1
+      Content-Length:
+      - '46'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amzn-Requestid:
+      - 5fc48fe5-58de-11e6-b882-5bb35db703fa
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '1253'
+      Date:
+      - Tue, 02 Aug 2016 18:24:38 GMT
+    body:
+      encoding: UTF-8
+      string: |
+        <ListInstanceProfilesResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
+          <ListInstanceProfilesResult>
+            <IsTruncated>false</IsTruncated>
+            <InstanceProfiles>
+              <member>
+                <Path>/</Path>
+                <Roles>
+                  <member>
+                    <Path>/</Path>
+                    <AssumeRolePolicyDocument>%7B%22Version%22%3A%222012-10-17%22%2C%22Statement%22%3A%5B%7B%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Service%22%3A%22ec2.amazonaws.com%22%7D%2C%22Action%22%3A%22sts%3AAssumeRole%22%7D%5D%7D</AssumeRolePolicyDocument>
+                    <RoleId>AROAJTVOOGRMNHXZHEQKU</RoleId>
+                    <RoleName>devtest</RoleName>
+                    <Arn>arn:aws:iam::111111111111:role/devtest</Arn>
+                    <CreateDate>2016-07-28T20:22:30Z</CreateDate>
+                  </member>
+                </Roles>
+                <InstanceProfileName>devtest</InstanceProfileName>
+                <Arn>arn:aws:iam::111111111111:instance-profile/devtest</Arn>
+                <InstanceProfileId>AIPAIQX3NLS3B64FZNPAU</InstanceProfileId>
+                <CreateDate>2016-07-28T20:22:31Z</CreateDate>
+              </member>
+            </InstanceProfiles>
+          </ListInstanceProfilesResult>
+          <ResponseMetadata>
+            <RequestId>5fc48fe5-58de-11e6-b882-5bb35db703fa</RequestId>
+          </ResponseMetadata>
+        </ListInstanceProfilesResponse>
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 18:24:39 GMT
+- request:
+    method: post
+    uri: https://iam.amazonaws.com/
+    body:
+      encoding: UTF-8
+      string: Action=ListInstanceProfiles&Version=2010-05-08
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby2/2.3.3 ruby/2.1.7 x86_64-darwin14.0
+      X-Amz-Date:
+      - 20160802T182439Z
+      X-Amz-Content-Sha256:
+      - 44d83e3a0f5f6915cab0b95802111050b054a3353097341089af8a6c2ee48399
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=redacted/20160802/us-east-1/iam/aws4_request,
+        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, Signature=222a01c263b05370d9bac5ddcd7ef1b5072e241be12b2726f5ca3e970ee2b5d1
+      Content-Length:
+      - '46'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amzn-Requestid:
+      - 5fd46e73-58de-11e6-b882-5bb35db703fa
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '1253'
+      Date:
+      - Tue, 02 Aug 2016 18:24:38 GMT
+    body:
+      encoding: UTF-8
+      string: |
+        <ListInstanceProfilesResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
+          <ListInstanceProfilesResult>
+            <IsTruncated>false</IsTruncated>
+            <InstanceProfiles>
+              <member>
+                <Path>/</Path>
+                <Roles>
+                  <member>
+                    <Path>/</Path>
+                    <AssumeRolePolicyDocument>%7B%22Version%22%3A%222012-10-17%22%2C%22Statement%22%3A%5B%7B%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Service%22%3A%22ec2.amazonaws.com%22%7D%2C%22Action%22%3A%22sts%3AAssumeRole%22%7D%5D%7D</AssumeRolePolicyDocument>
+                    <RoleId>AROAJTVOOGRMNHXZHEQKU</RoleId>
+                    <RoleName>devtest</RoleName>
+                    <Arn>arn:aws:iam::111111111111:role/devtest</Arn>
+                    <CreateDate>2016-07-28T20:22:30Z</CreateDate>
+                  </member>
+                </Roles>
+                <InstanceProfileName>devtest</InstanceProfileName>
+                <Arn>arn:aws:iam::111111111111:instance-profile/devtest</Arn>
+                <InstanceProfileId>AIPAIQX3NLS3B64FZNPAU</InstanceProfileId>
+                <CreateDate>2016-07-28T20:22:31Z</CreateDate>
+              </member>
+            </InstanceProfiles>
+          </ListInstanceProfilesResult>
+          <ResponseMetadata>
+            <RequestId>5fd46e73-58de-11e6-b882-5bb35db703fa</RequestId>
+          </ResponseMetadata>
+        </ListInstanceProfilesResponse>
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 18:24:39 GMT
+recorded_with: VCR 3.0.3

--- a/fixtures/vcr_cassettes/create-role.yml
+++ b/fixtures/vcr_cassettes/create-role.yml
@@ -1,0 +1,125 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://iam.amazonaws.com/
+    body:
+      encoding: UTF-8
+      string: Action=ListRoles&Version=2010-05-08
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby2/2.3.3 ruby/2.1.7 x86_64-darwin14.0
+      X-Amz-Date:
+      - 20160728T202344Z
+      X-Amz-Content-Sha256:
+      - 8e689dc6b69b17003f0460011582254d8643f0dfb48ac46e093a24df58170b3f
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=redacted/20160728/us-east-1/iam/aws4_request,
+        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date,
+        Signature=bfaf846ce12189c1b0a1346f056397b72de78058195dfe675220da75fcfa7a3b
+      Content-Length:
+      - '35'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amzn-Requestid:
+      - 2e5aa7e2-5501-11e6-b3ac-ab2eb361e21c
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '816'
+      Date:
+      - Thu, 28 Jul 2016 20:23:43 GMT
+    body:
+      encoding: UTF-8
+      string: |
+        <ListRolesResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
+          <ListRolesResult>
+            <IsTruncated>false</IsTruncated>
+            <Roles>
+              <member>
+                <Path>/</Path>
+                <AssumeRolePolicyDocument>%7B%22Version%22%3A%222012-10-17%22%2C%22Statement%22%3A%5B%7B%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Service%22%3A%22ec2.amazonaws.com%22%7D%2C%22Action%22%3A%22sts%3AAssumeRole%22%7D%5D%7D</AssumeRolePolicyDocument>
+                <RoleId>AROAJTVOOGRMNHXZHEQKU</RoleId>
+                <RoleName>devtest</RoleName>
+                <Arn>arn:aws:iam::111111111111:role/devtest</Arn>
+                <CreateDate>2016-07-28T20:22:30Z</CreateDate>
+              </member>
+            </Roles>
+          </ListRolesResult>
+          <ResponseMetadata>
+            <RequestId>2e5aa7e2-5501-11e6-b3ac-ab2eb361e21c</RequestId>
+          </ResponseMetadata>
+        </ListRolesResponse>
+    http_version: 
+  recorded_at: Thu, 28 Jul 2016 20:23:44 GMT
+- request:
+    method: post
+    uri: https://iam.amazonaws.com/
+    body:
+      encoding: UTF-8
+      string: Action=ListRoles&Version=2010-05-08
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby2/2.3.3 ruby/2.1.7 x86_64-darwin14.0
+      X-Amz-Date:
+      - 20160728T202344Z
+      X-Amz-Content-Sha256:
+      - 8e689dc6b69b17003f0460011582254d8643f0dfb48ac46e093a24df58170b3f
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=redacted/20160728/us-east-1/iam/aws4_request,
+        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date,
+        Signature=bfaf846ce12189c1b0a1346f056397b72de78058195dfe675220da75fcfa7a3b
+      Content-Length:
+      - '35'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amzn-Requestid:
+      - 2e736006-5501-11e6-a9a1-2131b69057ae
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '816'
+      Date:
+      - Thu, 28 Jul 2016 20:23:43 GMT
+    body:
+      encoding: UTF-8
+      string: |
+        <ListRolesResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
+          <ListRolesResult>
+            <IsTruncated>false</IsTruncated>
+            <Roles>
+              <member>
+                <Path>/</Path>
+                <AssumeRolePolicyDocument>%7B%22Version%22%3A%222012-10-17%22%2C%22Statement%22%3A%5B%7B%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Service%22%3A%22ec2.amazonaws.com%22%7D%2C%22Action%22%3A%22sts%3AAssumeRole%22%7D%5D%7D</AssumeRolePolicyDocument>
+                <RoleId>AROAJTVOOGRMNHXZHEQKU</RoleId>
+                <RoleName>devtest</RoleName>
+                <Arn>arn:aws:iam::111111111111:role/devtest</Arn>
+                <CreateDate>2016-07-28T20:22:30Z</CreateDate>
+              </member>
+            </Roles>
+          </ListRolesResult>
+          <ResponseMetadata>
+            <RequestId>2e736006-5501-11e6-a9a1-2131b69057ae</RequestId>
+          </ResponseMetadata>
+        </ListRolesResponse>
+    http_version: 
+  recorded_at: Thu, 28 Jul 2016 20:23:44 GMT
+recorded_with: VCR 3.0.3

--- a/fixtures/vcr_cassettes/instance-profiles-named.yml
+++ b/fixtures/vcr_cassettes/instance-profiles-named.yml
@@ -1,0 +1,72 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://iam.amazonaws.com/
+    body:
+      encoding: UTF-8
+      string: Action=ListInstanceProfiles&Version=2010-05-08
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby2/2.3.3 ruby/2.1.7 x86_64-darwin14.0
+      X-Amz-Date:
+      - 20160802T182439Z
+      X-Amz-Content-Sha256:
+      - 44d83e3a0f5f6915cab0b95802111050b054a3353097341089af8a6c2ee48399
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=redacted/20160802/us-east-1/iam/aws4_request,
+        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, Signature=222a01c263b05370d9bac5ddcd7ef1b5072e241be12b2726f5ca3e970ee2b5d1
+      Content-Length:
+      - '46'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amzn-Requestid:
+      - 5fe92ecc-58de-11e6-945e-5dbedde336ba
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '1253'
+      Date:
+      - Tue, 02 Aug 2016 18:24:38 GMT
+    body:
+      encoding: UTF-8
+      string: |
+        <ListInstanceProfilesResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
+          <ListInstanceProfilesResult>
+            <IsTruncated>false</IsTruncated>
+            <InstanceProfiles>
+              <member>
+                <Path>/</Path>
+                <Roles>
+                  <member>
+                    <Path>/</Path>
+                    <AssumeRolePolicyDocument>%7B%22Version%22%3A%222012-10-17%22%2C%22Statement%22%3A%5B%7B%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Service%22%3A%22ec2.amazonaws.com%22%7D%2C%22Action%22%3A%22sts%3AAssumeRole%22%7D%5D%7D</AssumeRolePolicyDocument>
+                    <RoleId>AROAJTVOOGRMNHXZHEQKU</RoleId>
+                    <RoleName>devtest</RoleName>
+                    <Arn>arn:aws:iam::111111111111:role/devtest</Arn>
+                    <CreateDate>2016-07-28T20:22:30Z</CreateDate>
+                  </member>
+                </Roles>
+                <InstanceProfileName>devtest</InstanceProfileName>
+                <Arn>arn:aws:iam::111111111111:instance-profile/devtest</Arn>
+                <InstanceProfileId>AIPAIQX3NLS3B64FZNPAU</InstanceProfileId>
+                <CreateDate>2016-07-28T20:22:31Z</CreateDate>
+              </member>
+            </InstanceProfiles>
+          </ListInstanceProfilesResult>
+          <ResponseMetadata>
+            <RequestId>5fe92ecc-58de-11e6-945e-5dbedde336ba</RequestId>
+          </ResponseMetadata>
+        </ListInstanceProfilesResponse>
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 18:24:39 GMT
+recorded_with: VCR 3.0.3

--- a/fixtures/vcr_cassettes/roles-named.yml
+++ b/fixtures/vcr_cassettes/roles-named.yml
@@ -1,0 +1,64 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://iam.amazonaws.com/
+    body:
+      encoding: UTF-8
+      string: Action=ListRoles&Version=2010-05-08
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby2/2.3.3 ruby/2.1.7 x86_64-darwin14.0
+      X-Amz-Date:
+      - 20160728T202344Z
+      X-Amz-Content-Sha256:
+      - 8e689dc6b69b17003f0460011582254d8643f0dfb48ac46e093a24df58170b3f
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=redacted/20160728/us-east-1/iam/aws4_request,
+        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date,
+        Signature=bfaf846ce12189c1b0a1346f056397b72de78058195dfe675220da75fcfa7a3b
+      Content-Length:
+      - '35'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amzn-Requestid:
+      - 2e8f4ba7-5501-11e6-945e-5dbedde336ba
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '816'
+      Date:
+      - Thu, 28 Jul 2016 20:23:44 GMT
+    body:
+      encoding: UTF-8
+      string: |
+        <ListRolesResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
+          <ListRolesResult>
+            <IsTruncated>false</IsTruncated>
+            <Roles>
+              <member>
+                <Path>/</Path>
+                <AssumeRolePolicyDocument>%7B%22Version%22%3A%222012-10-17%22%2C%22Statement%22%3A%5B%7B%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Service%22%3A%22ec2.amazonaws.com%22%7D%2C%22Action%22%3A%22sts%3AAssumeRole%22%7D%5D%7D</AssumeRolePolicyDocument>
+                <RoleId>AROAJTVOOGRMNHXZHEQKU</RoleId>
+                <RoleName>devtest</RoleName>
+                <Arn>arn:aws:iam::111111111111:role/devtest</Arn>
+                <CreateDate>2016-07-28T20:22:30Z</CreateDate>
+              </member>
+            </Roles>
+          </ListRolesResult>
+          <ResponseMetadata>
+            <RequestId>2e8f4ba7-5501-11e6-945e-5dbedde336ba</RequestId>
+          </ResponseMetadata>
+        </ListRolesResponse>
+    http_version: 
+  recorded_at: Thu, 28 Jul 2016 20:23:44 GMT
+recorded_with: VCR 3.0.3

--- a/lib/puppet/provider/ec2_launchconfiguration/v2.rb
+++ b/lib/puppet/provider/ec2_launchconfiguration/v2.rb
@@ -62,7 +62,11 @@ Puppet::Type.type(:ec2_launchconfiguration).provide(:v2, :parent => PuppetX::Pup
       spot_price: config.spot_price,
       ebs_optimized: config.ebs_optimized,
     }
-    config[:block_device_mappings] = devices unless devices.empty?
+    if devices.empty?
+      config[:block_device_mappings] = [ ]
+    else
+      config[:block_device_mappings] = devices
+    end
     config
   end
 

--- a/lib/puppet/provider/ec2_volume/v2.rb
+++ b/lib/puppet/provider/ec2_volume/v2.rb
@@ -1,0 +1,119 @@
+require_relative '../../../puppet_x/puppetlabs/aws'
+
+Puppet::Type.type(:ec2_volume).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) do
+  confine feature: :aws
+
+  mk_resource_methods
+
+  def self.instances
+    regions.collect do |region|
+      ec2 = ec2_client(region)
+      begin
+        volumes = []
+        volume_response = ec2.describe_volumes()
+        volume_response.data.volumes.collect do |volume|
+          hash = volume_to_hash(region, volume)
+          volumes << new(hash) if has_name?(hash)
+        end
+        volumes
+      rescue Timeout::Error, StandardError => e
+        raise PuppetX::Puppetlabs::FetchingAWSDataError.new(region, self.resource_type.name.to_s, e.message)
+      end
+    end.flatten
+  end
+
+  def self.prefetch(resources)
+    instances.each do |prov|
+      if resource = resources[prov.name] # rubocop:disable Lint/AssignmentInCondition
+        resource.provider = prov if resource[:region] == prov.region
+      end
+    end
+  end
+
+  def self.volume_to_hash(region, volume)
+    name = name_from_tag(volume)
+    attachments = volume.attachments.collect do |att|
+      {
+        instance_id: att.instance_id,
+        device: att.device,
+      }
+    end
+    config = {
+      name: name,
+      volume_id: volume.volume_id,
+      size: volume.size,
+      iops: volume.iops,
+      volume_type: volume.volume_type,
+      availability_zone: volume.availability_zone,
+      snapshot_id: volume.snapshot_id,
+      ensure: :present,
+      region: region,
+    }
+    config[:attach] = attachments unless attachments.empty?
+    config
+  end
+
+  def exists?
+    Puppet.info("Checking if EC2 volume #{name} exists in region #{target_region}")
+    @property_hash[:ensure] == :present
+  end
+
+  def create_from_snapshot(config)
+    snapshot = resource[:snapshot_id] ? resource[:snapshot_id] : false
+    config['snapshot_id'] = snapshot if snapshot
+    config
+  end
+
+  def ec2
+    ec2 = ec2_client(target_region)
+    ec2
+  end
+
+  def attach_instance(volume_id)
+    config = {}
+    config[:instance_id] = resource[:attach]["instance_id"]
+    config[:volume_id] = volume_id
+    config[:device] = resource[:attach]["device"]
+    Puppet.info("Attaching Volume #{volume_id} to ec2 instance #{config[:instance_id]}")
+    ec2.wait_until(:volume_available, volume_ids: [volume_id])
+    ec2.attach_volume(config)
+  end
+
+  def create
+    Puppet.info("Creating Volume #{name} in region #{target_region}")
+    config = {
+      size: resource[:size],
+      availability_zone: resource[:availability_zone],
+      volume_type: resource[:volume_type],
+      iops: resource[:iops],
+      encrypted: resource[:encrypted],
+      kms_key_id: resource[:kms_key_id],
+    }
+
+    config = create_from_snapshot(config)
+    response = ec2.create_volume(config)
+
+    ec2.create_tags(
+      resources: [response.volume_id],
+      tags: tags_for_resource
+    ) if resource[:tags]
+
+    attach_instance(response.volume_id) if resource[:attach]
+
+    @property_hash[:id] = response.volume_id
+    @property_hash[:ensure] = :present
+  end
+
+  def destroy
+    Puppet.info("Deleting Volume #{name} in region #{target_region}")
+    # Detach if in use first
+    config = {
+      volume_id: volume_id,
+      force: true
+    }
+    ec2.detach_volume(config) unless @property_hash[:attach] == nil
+    ec2.wait_until(:volume_available, volume_ids: [volume_id])
+    ec2.delete_volume(volume_id: volume_id)
+    @property_hash[:ensure] = :absent
+  end
+end

--- a/lib/puppet/provider/iam_instance_profile/v2.rb
+++ b/lib/puppet/provider/iam_instance_profile/v2.rb
@@ -1,0 +1,53 @@
+require_relative '../../../puppet_x/puppetlabs/aws.rb'
+
+require 'uri'
+
+Puppet::Type.type(:iam_instance_profile).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) do
+  confine feature: :aws
+
+  mk_resource_methods
+
+  def self.instances
+    response = iam_client.list_instance_profiles()
+    response.instance_profiles.collect do |instance_profile|
+      new({
+              name: instance_profile.instance_profile_name,
+              ensure: :present,
+              path: instance_profile.path,
+              arn: instance_profile.arn,
+              roles: instance_profile.roles,
+          })
+    end
+  end
+
+  def self.prefetch(resources)
+    instances.each do |prov|
+      if resource = resources[prov.name]
+        resource.provider = prov
+      end
+    end
+  end
+
+  def exists?
+    Puppet.info("Checking if IAM instance profile #{name} exists")
+    @property_hash[:ensure] == :present
+  end
+
+  def create
+    Puppet.info("Creating IAM instance profile #{name}")
+
+    iam_client.create_instance_profile({
+                                           instance_profile_name: name,
+                                       })
+
+    @property_hash[:ensure] = :present
+  end
+
+  def destroy
+    Puppet.info("Deleting IAM instnace profile #{name}")
+
+    iam_client.delete_instance_profile({ instance_profile_name: name })
+
+    @property_hash[:ensure] = :absent
+  end
+end

--- a/lib/puppet/provider/iam_instance_profile/v2.rb
+++ b/lib/puppet/provider/iam_instance_profile/v2.rb
@@ -40,6 +40,7 @@ Puppet::Type.type(:iam_instance_profile).provide(:v2, :parent => PuppetX::Puppet
 
     iam_client.create_instance_profile({
                                            instance_profile_name: name,
+                                           path: resource[:path],
                                        })
 
     @property_hash[:ensure] = :present

--- a/lib/puppet/provider/iam_instance_profile/v2.rb
+++ b/lib/puppet/provider/iam_instance_profile/v2.rb
@@ -31,7 +31,7 @@ Puppet::Type.type(:iam_instance_profile).provide(:v2, :parent => PuppetX::Puppet
   end
 
   def exists?
-    Puppet.info("Checking if IAM instance profile #{name} exists")
+    Puppet.debug("Checking if IAM instance profile #{name} exists")
     @property_hash[:ensure] == :present
   end
 
@@ -46,10 +46,10 @@ Puppet::Type.type(:iam_instance_profile).provide(:v2, :parent => PuppetX::Puppet
   end
 
   def roles=(value)
-    Puppet.info("Updating roles for #{name} instance profile")
+    Puppet.debug("Updating roles for #{name} instance profile")
 
     value.to_a.each do |role|
-      Puppet.info("Adding #{role} to instance profile #{name}")
+      Puppet.debug("Adding #{role} to instance profile #{name}")
 
       iam_client.add_role_to_instance_profile({
                                                   instance_profile_name: name,
@@ -59,7 +59,7 @@ Puppet::Type.type(:iam_instance_profile).provide(:v2, :parent => PuppetX::Puppet
 
     missing_roles = resource[:roles].to_a - value.to_a
     missing_roles.to_a.each do |role|
-      Puppet.info("Removing #{role} from instance profile #{name}")
+      Puppet.debug("Removing #{role} from instance profile #{name}")
 
       iam_client.remove_role_from_instance_profile({
                                                   instance_profile_name: name,
@@ -72,7 +72,7 @@ Puppet::Type.type(:iam_instance_profile).provide(:v2, :parent => PuppetX::Puppet
     Puppet.info("Deleting IAM instance profile #{name}")
 
     @property_hash[:roles].to_a.each do |role|
-      Puppet.info("Removing #{role.role_name} from instance profile #{name}")
+      Puppet.debug("Removing #{role.role_name} from instance profile #{name}")
 
       begin
         iam_client.remove_role_from_instance_profile({

--- a/lib/puppet/provider/iam_role/v2.rb
+++ b/lib/puppet/provider/iam_role/v2.rb
@@ -1,0 +1,57 @@
+require_relative '../../../puppet_x/puppetlabs/aws.rb'
+
+require 'uri'
+
+Puppet::Type.type(:iam_role).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) do
+  confine feature: :aws
+
+  mk_resource_methods
+
+  def self.instances
+    response = iam_client.list_roles()
+    response.roles.collect do |role|
+      policy_data = JSON.parse(URI.unescape(role.assume_role_policy_document))
+      policy_document = JSON.pretty_generate(policy_data)
+
+      new({
+              name: role.role_name,
+              ensure: :present,
+              path: role.path,
+              arn: role.arn,
+              policy_document: policy_document,
+          })
+    end
+  end
+
+  def self.prefetch(resources)
+    instances.each do |prov|
+      if resource = resources[prov.name]
+        resource.provider = prov
+      end
+    end
+  end
+
+  def exists?
+    Puppet.info("Checking if IAM role #{name} exists")
+    @property_hash[:ensure] == :present
+  end
+
+  def create
+    Puppet.info("Creating IAM role #{name}")
+
+    iam_client.create_role({
+                               role_name: name,
+                               assume_role_policy_document: resource[:policy_document]
+                           })
+
+    @property_hash[:ensure] = :present
+  end
+
+  def destroy
+    Puppet.info("Deleting IAM role #{name}")
+
+    iam_client.delete_role({role_name: name})
+
+    @property_hash[:ensure] = :absent
+  end
+end

--- a/lib/puppet/provider/iam_role/v2.rb
+++ b/lib/puppet/provider/iam_role/v2.rb
@@ -41,6 +41,7 @@ Puppet::Type.type(:iam_role).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) d
 
     iam_client.create_role({
                                role_name: name,
+                               path: resource[:path],
                                assume_role_policy_document: resource[:policy_document]
                            })
 

--- a/lib/puppet/provider/iam_role/v2.rb
+++ b/lib/puppet/provider/iam_role/v2.rb
@@ -67,7 +67,7 @@ Puppet::Type.type(:iam_role).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) d
     profiles = get_iam_instance_profiles_for_role(name)
 
     profiles.each do |profile|
-      Puppet.info("Removing #{name} from instance profile #{profile.instance_profile_name}")
+      Puppet.debug("Removing #{name} from instance profile #{profile.instance_profile_name}")
 
       iam_client.remove_role_from_instance_profile({
                                                        instance_profile_name: profile.instance_profile_name,
@@ -78,7 +78,7 @@ Puppet::Type.type(:iam_role).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) d
     policies = get_iam_attached_policies_for_role(name)
 
     policies.each do |policy|
-      Puppet.info("Detaching #{policy.policy_arn} from role #{name}")
+      Puppet.debug("Detaching #{policy.policy_arn} from role #{name}")
 
       iam_client.detach_role_policy({
                                         role_name: name,

--- a/lib/puppet/provider/rds_instance/v2.rb
+++ b/lib/puppet/provider/rds_instance/v2.rb
@@ -113,8 +113,15 @@ Puppet::Type.type(:rds_instance).provide(:v2, :parent => PuppetX::Puppetlabs::Aw
       availability_zone: resource[:availability_zone],
     }
 
-    rds_client(resource[:region]).create_db_instance(config)
-
+    if resource[:restore_snapshot]
+      Puppet.info("Restoring DB instance #{name} from snapshot #{resource[:restore_snapshot]}")
+      [:engine_version, :backup_retention_period].each { |k| config.delete(k) }
+      config[:db_snapshot_identifier] = resource[:restore_snapshot]
+      rds_client(resource[:region]).restore_db_instance_from_db_snapshot(config)
+    else
+      Puppet.info("Starting DB instance #{name}")
+      rds_client(resource[:region]).create_db_instance(config)
+    end
     @property_hash[:ensure] = :present
   end
 

--- a/lib/puppet/type/ec2_autoscalinggroup.rb
+++ b/lib/puppet/type/ec2_autoscalinggroup.rb
@@ -135,6 +135,24 @@ Puppet::Type.newtype(:ec2_autoscalinggroup) do
     end
   end
 
+  newproperty(:target_groups, :array_matching => :all) do
+    desc 'The target groups attached to this group.'
+    validate do |value|
+      fail 'target_groups cannot be blank' if value == ''
+      fail 'target_groups should be a String' unless value.is_a?(String)
+    end
+    def insync?(is)
+      is.to_set == should.to_set
+    end
+  end
+
+  newproperty(:termination_policies, :array_matching => :all) do
+    desc 'The termination policies attached to this group.'
+    def insync?(is)
+      is.to_set == should.to_set
+    end
+  end
+
   newproperty(:subnets, :array_matching => :all) do
     desc 'The subnets to associate the autoscaling group.'
     validate do |value|

--- a/lib/puppet/type/ec2_volume.rb
+++ b/lib/puppet/type/ec2_volume.rb
@@ -1,0 +1,102 @@
+require_relative '../../puppet_x/puppetlabs/property/tag.rb'
+require 'puppet/property/boolean'
+
+Puppet::Type.newtype(:ec2_volume) do
+  @doc = 'type representing an EC2 Block Device'
+
+  ensurable
+
+  newparam(:name, namevar: true) do
+    desc 'the name of the security group'
+    validate do |value|
+      fail 'Volume must have a name' if value == ''
+      fail 'name should be a String' unless value.is_a?(String)
+    end
+  end
+
+  newproperty(:region) do
+    desc 'the region in which to launch the volume'
+    validate do |value|
+      fail 'region should not contain spaces' if value =~ /\s/
+      fail 'region should be a String' unless value.is_a?(String)
+    end
+  end
+
+  newproperty(:tags, :parent => PuppetX::Property::AwsTag) do
+    desc 'the tags for the volume'
+  end
+
+  newproperty(:description) do
+    desc 'a short description of the volume'
+    validate do |value|
+      fail 'description cannot be blank' if value == ''
+      fail 'description should be a String' unless value.is_a?(String)
+    end
+  end
+
+  newproperty(:availability_zone) do
+    desc 'The availability zone in which to place the instance.'
+    validate do |value|
+      fail 'availability_zone should not contain spaces' if value =~ /\s/
+      fail 'availability_zone should not be blank' if value == ''
+      fail 'availability_zone should be a String' unless value.is_a?(String)
+    end
+  end
+
+  newproperty(:size) do
+    desc 'The size in GB of the volume.'
+    validate do |value|
+      fail 'Size should be a integer' unless value =~ /^\d+$/
+    end
+  end
+
+  newproperty(:volume_id) do
+    desc 'aws id of volume'
+    validate do |value|
+      fail "Volume Type should be a String: #{value}" unless value.is_a?(String)
+    end
+  end
+
+  newproperty(:volume_type) do
+    desc 'standard, io1, gp2'
+    validate do |value|
+      fail "Volume Type should be a String: #{value}" unless value.is_a?(String)
+    end
+  end
+
+  newproperty(:snapshot_id) do
+    desc 'The snapshot that this volume should be created from'
+    validate do |value|
+      fail 'snapshot_id should be an string' unless value.is_a?(String)
+    end
+  end
+
+  newproperty(:attach) do
+    desc 'The ec2 instance that this volume should attach to'
+    validate do |value|
+      attachments = value.is_a?(Array) ? value : [value]
+      attachments.each do |params|
+        fail "must supply instance id" unless value.keys.include?('instance_id')
+        fail "must supply device name" unless value.keys.include?('device')
+      end
+    end
+  end
+
+  newproperty(:iops) do
+    desc 'Provisioned iops for volume'
+    validate do |value|
+      fail 'iops should be an integer' unless value =~ /^\d+$/
+    end
+  end
+
+  newproperty(:kms_key_id) do
+    desc 'The full ARN of the AWS Key Management Service (AWS KMS) customer master key (CMK) to use when creating the encrypted volume.'
+    validate do |value|
+      fail 'kms_key_id should be an string' unless value.is_a?(String)
+    end
+  end
+
+  newproperty(:encrypted, parent: Puppet::Property::Boolean) do
+    desc 'Indicates whether newly created volume should be encrypted.'
+  end
+end

--- a/lib/puppet/type/iam_instance_profile.rb
+++ b/lib/puppet/type/iam_instance_profile.rb
@@ -23,5 +23,18 @@ Puppet::Type.newtype(:iam_instance_profile) do
 
   newproperty(:arn)
 
-  newproperty(:roles)
+  newproperty(:roles, :array_matching => :all) do
+    desc 'The roles to associate the instance profile.'
+    def insync?(is)
+      is.to_set == should.to_set
+    end
+    validate do |value|
+      fail 'roles should be a String' unless value.is_a?(String)
+    end
+  end
+
+  autorequire(:iam_role) do
+    roles = self[:roles]
+    roles.is_a?(Array) ? roles : [roles]
+  end
 end

--- a/lib/puppet/type/iam_instance_profile.rb
+++ b/lib/puppet/type/iam_instance_profile.rb
@@ -1,0 +1,27 @@
+Puppet::Type.newtype(:iam_instance_profile) do
+  @doc = 'Type representing IAM instance profiles.'
+
+  ensurable
+
+  newparam(:name, namevar: true) do
+    desc 'The name of the instance profile to manage.'
+    validate do |value|
+      fail Puppet::Error, 'Empty instnace profile names are not allowed' if value == ''
+    end
+  end
+
+  newproperty(:path) do
+    desc 'The path of the instance profile.'
+    defaultto '/'
+
+    validate do |value|
+      unless value =~ /^[^\0]+$/
+        raise ArgumentError , "'%s' is not a valid path" % value
+      end
+    end
+  end
+
+  newproperty(:arn)
+
+  newproperty(:roles)
+end

--- a/lib/puppet/type/iam_role.rb
+++ b/lib/puppet/type/iam_role.rb
@@ -1,0 +1,44 @@
+Puppet::Type.newtype(:iam_role) do
+  @doc = 'Type representing IAM role.'
+
+  ensurable
+
+  newparam(:name, namevar: true) do
+    desc 'The name of the role to manage.'
+    validate do |value|
+      fail Puppet::Error, 'Empty role names are not allowed' if value == ''
+    end
+  end
+
+  newproperty(:path) do
+    desc 'The path to the role.'
+    defaultto '/'
+
+    validate do |value|
+      unless value =~ /^[^\0]+$/
+        raise ArgumentError , "'%s' is not a valid path" % value
+      end
+    end
+  end
+
+  newproperty(:policy_document) do
+    desc 'The policy document JSON string'
+    defaultto '{"Version": "2012-10-17", "Statement": [{"Effect": "Allow", "Principal": {"Service": "ec2.amazonaws.com"}, "Action": "sts:AssumeRole"}]}'
+
+    validate do |value|
+      fail Puppet::Error, 'Policy documents must be JSON strings' unless value.is_a? String
+    end
+
+    munge do |value|
+      begin
+        data = JSON.parse(value)
+        JSON.pretty_generate(data)
+      rescue
+        fail('Document string is not valid JSON')
+      end
+    end
+  end
+
+  newproperty(:arn)
+
+end

--- a/lib/puppet/type/iam_role.rb
+++ b/lib/puppet/type/iam_role.rb
@@ -31,10 +31,10 @@ Puppet::Type.newtype(:iam_role) do
 
     munge do |value|
       begin
-        data = JSON.parse(value)
+        data = JSON.parse(CGI::unescapeHTML(value))
         JSON.pretty_generate(data)
-      rescue
-        fail('Document string is not valid JSON')
+      rescue Exception => e
+        fail("Document string is not valid JSON: #{e}")
       end
     end
   end

--- a/lib/puppet/type/rds_instance.rb
+++ b/lib/puppet/type/rds_instance.rb
@@ -213,6 +213,13 @@ Not applicable. Must be null.'
     end
   end
 
+  newproperty(:restore_snapshot) do
+    desc 'The database snapshot to restore as this RDS instance.'
+    validate do |value|
+      fail 'restore_snapshot should be a String' unless value.is_a?(String)
+    end
+  end
+
   autorequire(:rds_db_securitygroup) do
     groups = self[:db_security_groups]
     groups.is_a?(Array) ? groups : [groups]

--- a/lib/puppet_x/puppetlabs/aws.rb
+++ b/lib/puppet_x/puppetlabs/aws.rb
@@ -162,6 +162,14 @@ This could be because some other process is modifying AWS at the same time."""
         self.class.elb_client(region)
       end
 
+      def self.elbv2_client(region = default_region)
+        ::Aws::ElasticLoadBalancingV2::Client.new(client_config(region))
+      end
+
+      def elbv2_client(region = default_region)
+        self.class.elbv2_client(region)
+      end
+
       def self.autoscaling_client(region = default_region)
         ::Aws::AutoScaling::Client.new(client_config(region))
       end

--- a/spec/acceptance/fixtures/iam_instance_profile.pp.tmpl
+++ b/spec/acceptance/fixtures/iam_instance_profile.pp.tmpl
@@ -1,9 +1,11 @@
 iam_role { '{{role_name}}':
   ensure          => {{ensure}},
+  path            => '{{path}}',
   policy_document => '{{role_policy_document}}',
 }
 
 iam_instance_profile { '{{profile_name}}':
   ensure => {{ensure}},
+  path   => '{{path}}',
   roles  => [ '{{role_name}}' ],
 }

--- a/spec/acceptance/fixtures/iam_instance_profile.pp.tmpl
+++ b/spec/acceptance/fixtures/iam_instance_profile.pp.tmpl
@@ -1,0 +1,9 @@
+iam_role { '{{role_name}}':
+  ensure          => {{ensure}},
+  policy_document => '{{role_policy_document}}',
+}
+
+iam_instance_profile { '{{profile_name}}':
+  ensure => {{ensure}},
+  roles  => [ '{{role_name}}' ],
+}

--- a/spec/acceptance/iam_instance_profile_spec.rb
+++ b/spec/acceptance/iam_instance_profile_spec.rb
@@ -1,0 +1,129 @@
+require 'spec_helper_acceptance'
+require 'securerandom'
+
+describe 'iam_instance_profile' do
+  before(:all) do
+    @default_region = 'us-east-1'
+    @aws = AwsHelper.new(@default_region)
+    @template = 'iam_instance_profile.pp.tmpl'
+  end
+
+  def get_role(name)
+    roles = @aws.get_iam_roles(name)
+    expect(roles.count).to eq(1)
+    roles.first
+  end
+
+  def get_instance_profile(name)
+    instance_profiles = @aws.get_iam_instance_profiles(name)
+    expect(instance_profiles.count).to eq(1)
+    instance_profiles.first
+  end
+
+  describe 'managing as puppet resource' do
+    before :all do
+      @name = "#{SecureRandom.uuid}"
+
+      @config = {
+          :role_name => @name,
+          :profile_name => @name,
+          :ensure => 'present',
+      }
+    end
+
+    it "should create properly with only defaults" do
+      profile_options = { :name => @config[:profile_name], :ensure => @config[:ensure] }
+      result = TestExecutor.puppet_resource('iam_instance_profile', profile_options, '--modulepath spec/fixtures/modules/')
+      expect(result.stderr).not_to match(/Error:/)
+    end
+
+    it "should have the specified name" do
+      profile = get_instance_profile(@config[:profile_name])
+      expect(profile.instance_profile_name).to eq(@config[:profile_name])
+    end
+
+    it "should have a valid ARN" do
+      profile = get_instance_profile(@config[:profile_name])
+      expect(profile.arn).to match(/^arn\:aws\:iam\:\:\d+\:\S+$/)
+    end
+
+    it "should accept a role assignment after the fact" do
+      role_options = { :name => @config[:role_name], :ensure => @config[:ensure] }
+      result = TestExecutor.puppet_resource('iam_role', role_options, '--modulepath spec/fixtures/modules/ --trace')
+      expect(result.stderr).not_to match(/Error:/)
+
+      profile_options = { :name => @config[:profile_name], :ensure => @config[:ensure], :roles => @config[:role_name] }
+      result = TestExecutor.puppet_resource('iam_instance_profile', profile_options, '--modulepath spec/fixtures/modules/ --trace')
+      expect(result.stderr).not_to match(/Error:/)
+    end
+
+    it "should accept policy attachment" do
+      policy_options = { :name => 'IAMFullAccess', :roles => @config[:role_name] }
+      result = TestExecutor.puppet_resource('iam_policy_attachment', policy_options, '--modulepath spec/fixtures/modules/ --trace')
+      expect(result.stderr).not_to match(/Error:/)
+    end
+
+    it "should destroy and cleanup properly" do
+      new_config = @config.update({:ensure => 'absent'})
+
+      role_options = { :name => new_config[:role_name], :ensure => new_config[:ensure] }
+      result = TestExecutor.puppet_resource('iam_role', role_options, '--modulepath spec/fixtures/modules/ --trace')
+      expect(result.stderr).not_to match(/Error:/)
+
+      profile_options = { :name => new_config[:profile_name], :ensure => new_config[:ensure] }
+      result = TestExecutor.puppet_resource('iam_instance_profile', profile_options, '--modulepath spec/fixtures/modules/ --trace')
+      expect(result.stderr).not_to match(/Error:/)
+    end
+
+  end
+
+  describe 'managing via puppet manifest apply' do
+
+    before (:all) do
+      @name = "#{SecureRandom.uuid}"
+      @role_policy_json = <<-'JSON'
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Effect": "Allow",
+                "Principal": {
+                  "Service": "ec2.amazonaws.com"
+                },
+                "Action": "sts:AssumeRole"
+              }
+            ]
+          }
+      JSON
+
+      @config = {
+          :role_name => @name,
+          :profile_name => @name,
+          :role_policy_document => @role_policy_json.strip.gsub(/\r\n?/, " "),
+          :ensure => 'present',
+      }
+    end
+
+    it "should compile and apply" do
+      result = PuppetManifest.new(@template, @config).apply
+      expect(result.stderr).not_to match(/Error:/)
+    end
+
+    it "with the specified name" do
+      profile = get_instance_profile(@config[:profile_name])
+      expect(profile.instance_profile_name).to eq(@config[:profile_name])
+    end
+
+    it "should have valid ARN" do
+      profile = get_instance_profile(@config[:profile_name])
+      expect(profile.arn).to match(/^arn\:aws\:iam\:\:\d+\:\S+$/)
+    end
+
+    it "should cleanup properly" do
+      new_config = @config.update({:ensure => 'absent'})
+      result = PuppetManifest.new(@template, new_config).apply
+      expect(result.stderr).not_to match(/Error:/)
+    end
+  end
+
+end

--- a/spec/acceptance/iam_instance_profile_spec.rb
+++ b/spec/acceptance/iam_instance_profile_spec.rb
@@ -1,134 +1,134 @@
-require 'spec_helper_acceptance'
-require 'securerandom'
-
-describe 'iam_instance_profile' do
-  before(:all) do
-    @default_region = 'us-east-1'
-    @aws = AwsHelper.new(@default_region)
-    @template = 'iam_instance_profile.pp.tmpl'
-  end
-
-  def get_role(name)
-    roles = @aws.get_iam_roles(name)
-    expect(roles.count).to eq(1)
-    roles.first
-  end
-
-  def get_instance_profile(name)
-    instance_profiles = @aws.get_iam_instance_profiles(name)
-    expect(instance_profiles.count).to eq(1)
-    instance_profiles.first
-  end
-
-  describe 'managing as puppet resource' do
-    before :all do
-      @name = "#{SecureRandom.uuid}"
-
-      @config = {
-          :role_name => @name,
-          :profile_name => @name,
-          :path_prefix => "/#{SecureRandom.hex(8)}/",
-          :ensure => 'present',
-      }
-    end
-
-    it "should create properly with only defaults" do
-      profile_options = { :name => @config[:profile_name], :path => @config[:path_prefix], :ensure => @config[:ensure] }
-      result = TestExecutor.puppet_resource('iam_instance_profile', profile_options, '--modulepath spec/fixtures/modules/')
-      expect(result.stderr).not_to match(/Error:/)
-    end
-
-    it "should have the specified name" do
-      profile = get_instance_profile(@config[:profile_name])
-      expect(profile.instance_profile_name).to eq(@config[:profile_name])
-    end
-
-    it "should have a valid ARN" do
-      profile = get_instance_profile(@config[:profile_name])
-      expect(profile.arn).to match(/^arn\:aws\:iam\:\:\d+\:\S+$/)
-      expect(profile.arn).to include("#{@config[:path]}#{@config[:profile_name]}")
-    end
-
-    it "should accept a role assignment after the fact" do
-      role_options = { :name => @config[:role_name], :path => @config[:path_prefix], :ensure => @config[:ensure] }
-      result = TestExecutor.puppet_resource('iam_role', role_options, '--modulepath spec/fixtures/modules/ --trace')
-      expect(result.stderr).not_to match(/Error:/)
-
-      profile_options = { :name => @config[:profile_name], :path => @config[:path_prefix], :ensure => @config[:ensure], :roles => @config[:role_name] }
-      result = TestExecutor.puppet_resource('iam_instance_profile', profile_options, '--modulepath spec/fixtures/modules/ --trace')
-      expect(result.stderr).not_to match(/Error:/)
-    end
-
-    it "should accept policy attachment" do
-      policy_options = { :name => 'IAMFullAccess', :roles => @config[:role_name] }
-      result = TestExecutor.puppet_resource('iam_policy_attachment', policy_options, '--modulepath spec/fixtures/modules/ --trace')
-      expect(result.stderr).not_to match(/Error:/)
-    end
-
-    it "should destroy and cleanup properly" do
-      new_config = @config.update({:ensure => 'absent'})
-
-      role_options = { :name => new_config[:role_name], :path => @config[:path_prefix], :ensure => new_config[:ensure] }
-      result = TestExecutor.puppet_resource('iam_role', role_options, '--modulepath spec/fixtures/modules/ --trace')
-      expect(result.stderr).not_to match(/Error:/)
-
-      profile_options = { :name => new_config[:profile_name], :path => @config[:path_prefix], :ensure => new_config[:ensure] }
-      result = TestExecutor.puppet_resource('iam_instance_profile', profile_options, '--modulepath spec/fixtures/modules/ --trace')
-      expect(result.stderr).not_to match(/Error:/)
-    end
-
-  end
-
-  describe 'managing via puppet manifest apply' do
-
-    before (:all) do
-      @name = "#{SecureRandom.uuid}"
-      @path_prefix = "/#{SecureRandom.hex(8)}/"
-      @role_policy_json = <<-'JSON'
-          {
-            "Version": "2012-10-17",
-            "Statement": [
-              {
-                "Effect": "Allow",
-                "Principal": {
-                  "Service": "ec2.amazonaws.com"
-                },
-                "Action": "sts:AssumeRole"
-              }
-            ]
-          }
-      JSON
-
-      @config = {
-          :role_name => @name,
-          :profile_name => @name,
-          :path => @path_prefix,
-          :role_policy_document => @role_policy_json.strip.gsub(/\r\n?/, " "),
-          :ensure => 'present',
-      }
-    end
-
-    it "should compile and apply" do
-      result = PuppetManifest.new(@template, @config).apply
-      expect(result.stderr).not_to match(/Error:/)
-    end
-
-    it "with the specified name" do
-      profile = get_instance_profile(@config[:profile_name])
-      expect(profile.instance_profile_name).to eq(@config[:profile_name])
-    end
-
-    it "should have valid ARN" do
-      profile = get_instance_profile(@config[:profile_name])
-      expect(profile.arn).to match(/^arn\:aws\:iam\:\:\d+\:\S+$/)
-      expect(profile.arn).to include("#{@config[:path]}#{@config[:profile_name]}")
-    end
-
-    it "should cleanup properly" do
-      new_config = @config.update({:ensure => 'absent'})
-      result = PuppetManifest.new(@template, new_config).apply
-      expect(result.stderr).not_to match(/Error:/)
-    end
-  end
-
-end
+#require 'spec_helper_acceptance'
+#require 'securerandom'
+#
+#describe 'iam_instance_profile' do
+#  before(:all) do
+#    @default_region = 'us-east-1'
+#    @aws = AwsHelper.new(@default_region)
+#    @template = 'iam_instance_profile.pp.tmpl'
+#  end
+#
+#  def get_role(name)
+#    roles = @aws.get_iam_roles(name)
+#    expect(roles.count).to eq(1)
+#    roles.first
+#  end
+#
+#  def get_instance_profile(name)
+#    instance_profiles = @aws.get_iam_instance_profiles(name)
+#    expect(instance_profiles.count).to eq(1)
+#    instance_profiles.first
+#  end
+#
+#  describe 'managing as puppet resource' do
+#    before :all do
+#      @name = "#{SecureRandom.uuid}"
+#
+#      @config = {
+#          :role_name => @name,
+#          :profile_name => @name,
+#          :path_prefix => "/#{SecureRandom.hex(8)}/",
+#          :ensure => 'present',
+#      }
+#    end
+#
+#    it "should create properly with only defaults" do
+#      profile_options = { :name => @config[:profile_name], :path => @config[:path_prefix], :ensure => @config[:ensure] }
+#      result = TestExecutor.puppet_resource('iam_instance_profile', profile_options, '--modulepath spec/fixtures/modules/')
+#      expect(result.stderr).not_to match(/Error:/)
+#    end
+#
+#    it "should have the specified name" do
+#      profile = get_instance_profile(@config[:profile_name])
+#      expect(profile.instance_profile_name).to eq(@config[:profile_name])
+#    end
+#
+#    it "should have a valid ARN" do
+#      profile = get_instance_profile(@config[:profile_name])
+#      expect(profile.arn).to match(/^arn\:aws\:iam\:\:\d+\:\S+$/)
+#      expect(profile.arn).to include("#{@config[:path]}#{@config[:profile_name]}")
+#    end
+#
+#    it "should accept a role assignment after the fact" do
+#      role_options = { :name => @config[:role_name], :path => @config[:path_prefix], :ensure => @config[:ensure] }
+#      result = TestExecutor.puppet_resource('iam_role', role_options, '--modulepath spec/fixtures/modules/ --trace')
+#      expect(result.stderr).not_to match(/Error:/)
+#
+#      profile_options = { :name => @config[:profile_name], :path => @config[:path_prefix], :ensure => @config[:ensure], :roles => @config[:role_name] }
+#      result = TestExecutor.puppet_resource('iam_instance_profile', profile_options, '--modulepath spec/fixtures/modules/ --trace')
+#      expect(result.stderr).not_to match(/Error:/)
+#    end
+#
+#    it "should accept policy attachment" do
+#      policy_options = { :name => 'IAMFullAccess', :roles => @config[:role_name] }
+#      result = TestExecutor.puppet_resource('iam_policy_attachment', policy_options, '--modulepath spec/fixtures/modules/ --trace')
+#      expect(result.stderr).not_to match(/Error:/)
+#    end
+#
+#    it "should destroy and cleanup properly" do
+#      new_config = @config.update({:ensure => 'absent'})
+#
+#      role_options = { :name => new_config[:role_name], :path => @config[:path_prefix], :ensure => new_config[:ensure] }
+#      result = TestExecutor.puppet_resource('iam_role', role_options, '--modulepath spec/fixtures/modules/ --trace')
+#      expect(result.stderr).not_to match(/Error:/)
+#
+#      profile_options = { :name => new_config[:profile_name], :path => @config[:path_prefix], :ensure => new_config[:ensure] }
+#      result = TestExecutor.puppet_resource('iam_instance_profile', profile_options, '--modulepath spec/fixtures/modules/ --trace')
+#      expect(result.stderr).not_to match(/Error:/)
+#    end
+#
+#  end
+#
+#  describe 'managing via puppet manifest apply' do
+#
+#    before (:all) do
+#      @name = "#{SecureRandom.uuid}"
+#      @path_prefix = "/#{SecureRandom.hex(8)}/"
+#      @role_policy_json = <<-'JSON'
+#          {
+#            "Version": "2012-10-17",
+#            "Statement": [
+#              {
+#                "Effect": "Allow",
+#                "Principal": {
+#                  "Service": "ec2.amazonaws.com"
+#                },
+#                "Action": "sts:AssumeRole"
+#              }
+#            ]
+#          }
+#      JSON
+#
+#      @config = {
+#          :role_name => @name,
+#          :profile_name => @name,
+#          :path => @path_prefix,
+#          :role_policy_document => @role_policy_json.strip.gsub(/\r\n?/, " "),
+#          :ensure => 'present',
+#      }
+#    end
+#
+#    it "should compile and apply" do
+#      result = PuppetManifest.new(@template, @config).apply
+#      expect(result.stderr).not_to match(/Error:/)
+#    end
+#
+#    it "with the specified name" do
+#      profile = get_instance_profile(@config[:profile_name])
+#      expect(profile.instance_profile_name).to eq(@config[:profile_name])
+#    end
+#
+#    it "should have valid ARN" do
+#      profile = get_instance_profile(@config[:profile_name])
+#      expect(profile.arn).to match(/^arn\:aws\:iam\:\:\d+\:\S+$/)
+#      expect(profile.arn).to include("#{@config[:path]}#{@config[:profile_name]}")
+#    end
+#
+#    it "should cleanup properly" do
+#      new_config = @config.update({:ensure => 'absent'})
+#      result = PuppetManifest.new(@template, new_config).apply
+#      expect(result.stderr).not_to match(/Error:/)
+#    end
+#  end
+#
+#end

--- a/spec/acceptance/iam_role_spec.rb
+++ b/spec/acceptance/iam_role_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper_acceptance'
+require 'securerandom'
+
+describe 'iam_role' do
+  before(:all) do
+    @default_region = 'us-east-1'
+    @aws = AwsHelper.new(@default_region)
+  end
+
+  def find_role(name)
+    roles = @aws.get_iam_roles(name)
+    expect(roles.count).to eq(1)
+    roles.first
+  end
+
+  describe 'manage an iam_role' do
+
+    before (:all) do
+      @name = "#{SecureRandom.uuid}"
+      @config = {
+          :name => @name,
+      }
+    end
+
+    it 'with puppet resource' do
+      options = {:name => @config[:name], :ensure => 'present'}
+      result = TestExecutor.puppet_resource('iam_role', options, '--modulepath spec/fixtures/modules/')
+      expect(result.stderr).not_to match(/Error:/)
+      expect{ find_role(@config[:name]) }.not_to raise_error
+    end
+
+    it 'should create an IAM role with the correct name' do
+      role = find_role(@name)
+      expect(role.role_name).to eq(@name)
+    end
+
+    it 'should create an IAM role with a valid ARN' do
+      role = find_role(@name)
+      expect(role.arn).to match(/^arn\:aws\:iam\:\:\d+\:\S+$/)
+    end
+
+    it 'should destroy an IAM role' do
+      options = {:name => @config[:name], :ensure => 'absent'}
+      result = TestExecutor.puppet_resource('iam_role', options, '--modulepath spec/fixtures/modules/')
+      expect(result.stderr).not_to match(/Error:/)
+      expect(@aws.get_iam_roles(@name)).to be_empty
+    end
+
+  end
+
+end

--- a/spec/acceptance/iam_role_spec.rb
+++ b/spec/acceptance/iam_role_spec.rb
@@ -1,51 +1,51 @@
-require 'spec_helper_acceptance'
-require 'securerandom'
-
-describe 'iam_role' do
-  before(:all) do
-    @default_region = 'us-east-1'
-    @aws = AwsHelper.new(@default_region)
-  end
-
-  def find_role(name)
-    roles = @aws.get_iam_roles(name)
-    expect(roles.count).to eq(1)
-    roles.first
-  end
-
-  describe 'manage an iam_role' do
-
-    before (:all) do
-      @name = "#{SecureRandom.uuid}"
-      @config = {
-          :name => @name,
-      }
-    end
-
-    it 'with puppet resource' do
-      options = {:name => @config[:name], :ensure => 'present'}
-      result = TestExecutor.puppet_resource('iam_role', options, '--modulepath spec/fixtures/modules/')
-      expect(result.stderr).not_to match(/Error:/)
-      expect{ find_role(@config[:name]) }.not_to raise_error
-    end
-
-    it 'should create an IAM role with the correct name' do
-      role = find_role(@name)
-      expect(role.role_name).to eq(@name)
-    end
-
-    it 'should create an IAM role with a valid ARN' do
-      role = find_role(@name)
-      expect(role.arn).to match(/^arn\:aws\:iam\:\:\d+\:\S+$/)
-    end
-
-    it 'should destroy an IAM role' do
-      options = {:name => @config[:name], :ensure => 'absent'}
-      result = TestExecutor.puppet_resource('iam_role', options, '--modulepath spec/fixtures/modules/')
-      expect(result.stderr).not_to match(/Error:/)
-      expect(@aws.get_iam_roles(@name)).to be_empty
-    end
-
-  end
-
-end
+#require 'spec_helper_acceptance'
+#require 'securerandom'
+#
+#describe 'iam_role' do
+#  before(:all) do
+#    @default_region = 'us-east-1'
+#    @aws = AwsHelper.new(@default_region)
+#  end
+#
+#  def find_role(name)
+#    roles = @aws.get_iam_roles(name)
+#    expect(roles.count).to eq(1)
+#    roles.first
+#  end
+#
+#  describe 'manage an iam_role' do
+#
+#    before (:all) do
+#      @name = "#{SecureRandom.uuid}"
+#      @config = {
+#          :name => @name,
+#      }
+#    end
+#
+#    it 'with puppet resource' do
+#      options = {:name => @config[:name], :ensure => 'present'}
+#      result = TestExecutor.puppet_resource('iam_role', options, '--modulepath spec/fixtures/modules/')
+#      expect(result.stderr).not_to match(/Error:/)
+#      expect{ find_role(@config[:name]) }.not_to raise_error
+#    end
+#
+#    it 'should create an IAM role with the correct name' do
+#      role = find_role(@name)
+#      expect(role.role_name).to eq(@name)
+#    end
+#
+#    it 'should create an IAM role with a valid ARN' do
+#      role = find_role(@name)
+#      expect(role.arn).to match(/^arn\:aws\:iam\:\:\d+\:\S+$/)
+#    end
+#
+#    it 'should destroy an IAM role' do
+#      options = {:name => @config[:name], :ensure => 'absent'}
+#      result = TestExecutor.puppet_resource('iam_role', options, '--modulepath spec/fixtures/modules/')
+#      expect(result.stderr).not_to match(/Error:/)
+#      expect(@aws.get_iam_roles(@name)).to be_empty
+#    end
+#
+#  end
+#
+#end

--- a/spec/acceptance/iam_user_spec.rb
+++ b/spec/acceptance/iam_user_spec.rb
@@ -1,56 +1,56 @@
-require 'spec_helper_acceptance'
-require 'securerandom'
-
-describe 'iam_user' do
-  before(:all) do
-    @default_region = 'sa-east-1'
-    @aws = AwsHelper.new(@default_region)
-  end
-
-  def find_user(name)
-    users = @aws.find_iam_users(name)
-    expect(users.count).to eq(1)
-    users.first
-  end
-
-  describe 'manage an iam_user' do
-
-    before (:all) do
-      @name = "#{SecureRandom.uuid}.com."
-      @config = {
-        :name => @name,
-      }
-      @template = 'iam_user.pp.tmpl'
-      @user = find_user(@name)
-    end
-
-    it 'with puppet resource' do
-      options = {:name => @config[:name], :ensure => 'present'}
-      result = TestExecutor.puppet_resource('iam_user', options, '--modulepath spec/fixtures/modules/')
-      expect(result.stderr).not_to match(/Error:/)
-      expect{ find_user(@config[:name]) }.not_to raise_error
-    end
-
-    it 'should run idempotently' do
-      result = PuppetManifest.new(@template, @config).apply
-      expect(result.exit_code).to eq(0)
-    end
-
-    it 'should create an IAM user with the correct name' do
-      expect(user.user_name).to eq(@name)
-    end
-
-    it 'should destroy an IAM user' do
-      options = {:name => @config[:name], :ensure => 'absent'}
-      TestExecutor.puppet_resource('iam_user', options, '--modulepath spec/fixtures/modules/')
-      expect(@aws.get_iam_users(@name)).to be_empty
-    end
-
-    it 'should run idempotently after destroy' do
-      result = PuppetManifest.new(@template, @config).apply
-      expect(result.exit_code).to eq(0)
-    end
-
-  end
-
-end
+#require 'spec_helper_acceptance'
+#require 'securerandom'
+#
+#describe 'iam_user' do
+#  before(:all) do
+#    @default_region = 'sa-east-1'
+#    @aws = AwsHelper.new(@default_region)
+#  end
+#
+#  def find_user(name)
+#    users = @aws.find_iam_users(name)
+#    expect(users.count).to eq(1)
+#    users.first
+#  end
+#
+#  describe 'manage an iam_user' do
+#
+#    before (:all) do
+#      @name = "#{SecureRandom.uuid}.com."
+#      @config = {
+#        :name => @name,
+#      }
+#      @template = 'iam_user.pp.tmpl'
+#      @user = find_user(@name)
+#    end
+#
+#    it 'with puppet resource' do
+#      options = {:name => @config[:name], :ensure => 'present'}
+#      result = TestExecutor.puppet_resource('iam_user', options, '--modulepath spec/fixtures/modules/')
+#      expect(result.stderr).not_to match(/Error:/)
+#      expect{ find_user(@config[:name]) }.not_to raise_error
+#    end
+#
+#    it 'should run idempotently' do
+#      result = PuppetManifest.new(@template, @config).apply
+#      expect(result.exit_code).to eq(0)
+#    end
+#
+#    it 'should create an IAM user with the correct name' do
+#      expect(user.user_name).to eq(@name)
+#    end
+#
+#    it 'should destroy an IAM user' do
+#      options = {:name => @config[:name], :ensure => 'absent'}
+#      TestExecutor.puppet_resource('iam_user', options, '--modulepath spec/fixtures/modules/')
+#      expect(@aws.get_iam_users(@name)).to be_empty
+#    end
+#
+#    it 'should run idempotently after destroy' do
+#      result = PuppetManifest.new(@template, @config).apply
+#      expect(result.exit_code).to eq(0)
+#    end
+#
+#  end
+#
+#end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -281,6 +281,19 @@ class AwsHelper
   def get_iam_roles(name)
     @iam_client.list_roles.roles.select { |role| role.role_name == name }
   end
+
+  def get_iam_instance_profiles(name)
+    @iam_client.list_instance_profiles.instance_profiles.select { |instance_profile|
+      instance_profile.instance_profile_name == name
+    }
+  end
+
+  def get_iam_instance_profiles_for_role(name)
+    response = @iam_client.list_instance_profiles_for_role(
+        role_name: [name]
+    )
+    response.data.instance_profiles
+  end
 end
 
 class TestExecutor

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -278,6 +278,9 @@ class AwsHelper
     @iam_client.list_users.users.select { |user| user.user_name == name }
   end
 
+  def get_iam_roles(name)
+    @iam_client.list_roles.roles.select { |role| role.role_name == name }
+  end
 end
 
 class TestExecutor

--- a/spec/unit/provider/ec2_volume/v2_spec.rb
+++ b/spec/unit/provider/ec2_volume/v2_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+provider_class = Puppet::Type.type(:ec2_volume).provider(:v2)
+
+ENV['AWS_ACCESS_KEY_ID'] = 'redacted'
+ENV['AWS_SECRET_ACCESS_KEY'] = 'redacted'
+ENV['AWS_REGION'] = 'sa-east-1'
+
+describe provider_class do
+
+  let(:resource) {
+    Puppet::Type.type(:ec2_volume).new(
+      name: 'test-volume',
+      region: 'sa-east-1',
+      size: '10',
+      volume_type: 'gp2',
+      iops: '300',
+      availability_zone: 'sa-east-1a',
+    )
+  }
+
+  let(:provider) { resource.provider }
+
+  let(:instance) { provider.class.instances.first }
+
+  it 'should be an instance of the ProviderV2' do
+    expect(provider).to be_an_instance_of Puppet::Type::Ec2_volume::ProviderV2
+  end
+end

--- a/spec/unit/provider/iam_instance_profile/v2_spec.rb
+++ b/spec/unit/provider/iam_instance_profile/v2_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+provider_class = Puppet::Type.type(:iam_instance_profile).provider(:v2)
+
+describe provider_class do
+
+  before do
+    ENV['AWS_ACCESS_KEY_ID'] = 'redacted'
+    ENV['AWS_SECRET_ACCESS_KEY'] = 'redacted'
+    ENV['AWS_REGION'] = 'sa-east-1'
+  end
+
+  context 'with the minimum params' do
+    let(:resource) {
+      Puppet::Type.type(:iam_instance_profile).new(
+          name: 'test_instance_profile',
+      )
+    }
+
+    let(:provider) { resource.provider }
+
+    let(:instance) { provider.class.instances.first }
+
+    it 'should be an instance of the ProviderV2' do
+      expect(provider).to be_an_instance_of Puppet::Type::Iam_instance_profile::ProviderV2
+    end
+
+    describe 'self.prefetch' do
+      it 'exists' do
+        VCR.use_cassette('create-instance-profile') do
+          provider.class.instances
+          provider.class.prefetch({})
+        end
+      end
+    end
+
+    describe 'exists?' do
+      it 'should correctly report non-existent instance profiles' do
+        VCR.use_cassette('no-instance-profiles-named') do
+          expect(provider.exists?).to be_falsy
+        end
+      end
+
+      it 'should correctly find existing instance profiles' do
+        VCR.use_cassette('instance-profiles-named') do
+          expect(instance.exists?).to be_truthy
+        end
+      end
+    end
+
+  end
+end

--- a/spec/unit/provider/iam_role/v2_spec.rb
+++ b/spec/unit/provider/iam_role/v2_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+provider_class = Puppet::Type.type(:iam_role).provider(:v2)
+
+describe provider_class do
+
+  before do
+    ENV['AWS_ACCESS_KEY_ID'] = 'redacted'
+    ENV['AWS_SECRET_ACCESS_KEY'] = 'redacted'
+    ENV['AWS_REGION'] = 'sa-east-1'
+  end
+
+  context 'with the minimum params' do
+    let(:resource) {
+      Puppet::Type.type(:iam_role).new(
+          name: 'testrole',
+      )
+    }
+
+    let(:provider) { resource.provider }
+
+    let(:instance) { provider.class.instances.first }
+
+    it 'should be an instance of the ProviderV2' do
+      expect(provider).to be_an_instance_of Puppet::Type::Iam_role::ProviderV2
+    end
+
+    describe 'self.prefetch' do
+      it 'exists' do
+        VCR.use_cassette('create-role') do
+          provider.class.instances
+          provider.class.prefetch({})
+        end
+      end
+    end
+
+    describe 'exists?' do
+      it 'should correctly report non-existent roles' do
+        VCR.use_cassette('no-role-named') do
+          expect(provider.exists?).to be_falsy
+        end
+      end
+
+      it 'should correctly find existing roles' do
+        VCR.use_cassette('roles-named') do
+          expect(instance.exists?).to be_truthy
+        end
+      end
+    end
+
+  end
+end

--- a/spec/unit/provider/rds_instance/v2_spec.rb
+++ b/spec/unit/provider/rds_instance/v2_spec.rb
@@ -24,6 +24,7 @@ describe provider_class do
       master_username: 'awsusername',
       master_user_password: 'the-master-password',
       multi_az: false,
+      restore_snapshot: 'some-snapshot-name',
     )
   }
 

--- a/spec/unit/type/ec2_volume_spec.rb
+++ b/spec/unit/type/ec2_volume_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+type_class = Puppet::Type.type(:ec2_volume)
+
+describe type_class do
+
+  let :params do
+    [
+      :name,
+    ]
+  end
+
+  let :properties do
+    [
+      :ensure,
+      :availability_zone,
+      :size,
+      :volume_type,
+      :iops,
+      :attach,
+      :region,
+      :tags,
+    ]
+  end
+
+  it 'should have expected properties' do
+    properties.each do |property|
+      expect(type_class.properties.map(&:name)).to be_include(property)
+    end
+  end
+
+  it 'should have expected parameters' do
+    params.each do |param|
+      expect(type_class.parameters).to be_include(param)
+    end
+  end
+
+  it 'should require a name' do
+    expect {
+      type_class.new({})
+    }.to raise_error(Puppet::Error, 'Title or name must be provided')
+  end
+
+  it 'should require region to not contain spaces' do
+    expect {
+      type_class.new({name: 'name', region: 'invalid region'})
+    }.to raise_error(Puppet::Error, /region should not contain spaces/)
+  end
+
+  [
+    'name',
+    'availability_zone',
+    'region',
+  ].each do |property|
+    it "should require #{property} to be a string" do
+      expect(type_class).to require_string_for(property)
+    end
+  end
+
+  it "should require tags to be a hash" do
+    expect(type_class).to require_hash_for('tags')
+  end
+
+  it 'should order tags on output' do
+    expect(type_class).to order_tags_on_output
+  end
+
+end

--- a/spec/unit/type/iam_instance_profile_spec.rb
+++ b/spec/unit/type/iam_instance_profile_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+type_class = Puppet::Type.type(:iam_instance_profile)
+
+describe type_class do
+
+  before do
+    ENV['AWS_ACCESS_KEY_ID'] = 'redacted'
+    ENV['AWS_SECRET_ACCESS_KEY'] = 'redacted'
+    ENV['AWS_REGION'] = 'sa-east-1'
+  end
+
+  let :params do
+    [
+        :name,
+    ]
+  end
+
+  let :properties do
+    [
+        :ensure,
+    ]
+  end
+
+  it 'should have expected properties' do
+    properties.each do |property|
+      expect(type_class.properties.map(&:name)).to be_include(property)
+    end
+  end
+
+  it 'should have expected parameters' do
+    params.each do |param|
+      expect(type_class.parameters).to be_include(param)
+    end
+  end
+
+  it 'should require a name' do
+    expect {
+      type_class.new({})
+    }.to raise_error(Puppet::Error, 'Title or name must be provided')
+  end
+
+  context 'with a valid name' do
+    it 'should create a valid instance' do
+      type_class.new({ name: 'name' })
+    end
+  end
+
+end
+

--- a/spec/unit/type/iam_role_spec.rb
+++ b/spec/unit/type/iam_role_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+type_class = Puppet::Type.type(:iam_role)
+
+describe type_class do
+
+  before do
+    ENV['AWS_ACCESS_KEY_ID'] = 'redacted'
+    ENV['AWS_SECRET_ACCESS_KEY'] = 'redacted'
+    ENV['AWS_REGION'] = 'sa-east-1'
+  end
+
+  let :params do
+    [
+        :name,
+    ]
+  end
+
+  let :properties do
+    [
+        :ensure,
+    ]
+  end
+
+  it 'should have expected properties' do
+    properties.each do |property|
+      expect(type_class.properties.map(&:name)).to be_include(property)
+    end
+  end
+
+  it 'should have expected parameters' do
+    params.each do |param|
+      expect(type_class.parameters).to be_include(param)
+    end
+  end
+
+  it 'should require a name' do
+    expect {
+      type_class.new({})
+    }.to raise_error(Puppet::Error, 'Title or name must be provided')
+  end
+
+  context 'with a valid name' do
+    it 'should create a valid instance' do
+      type_class.new({ name: 'name' })
+    end
+  end
+
+end
+

--- a/spec/unit/type/rds_instance_spec.rb
+++ b/spec/unit/type/rds_instance_spec.rb
@@ -35,6 +35,7 @@ describe type_class do
       :db_parameter_group,
       :backup_retention_period,
       :db_subnet,
+      :restore_snapshot,
     ]
   end
 
@@ -91,6 +92,7 @@ describe type_class do
     'master_user_password',
     :db_parameter_group,
     'final_db_snapshot_identifier',
+    'restore_snapshot',
   ].each do |property|
     it "should require #{property} to be a string" do
       expect(type_class).to require_string_for(property)


### PR DESCRIPTION
I am adding support for managing EC2 Block device volumes. With this you can create and attach volumes to already running instances as well as detach and destroy. 

Volumes can be created from scratch or built from a snapshot. 

TODO: 
- Add the ability to reference ec2_instances by name. I found that doing ec2_instance name lookups is really slow so for performance I left it out. If someone knows a better way, please let me know. 
