### PR TITLE
(MAINT) workaround different loading rules between puppet 3 and 4

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -288,7 +288,7 @@ class TestExecutor
     end
     cmd << "#{@name} "
     cmd << options
-    cmd << " #{command_flags}"
+    cmd << " --libdir lib #{command_flags}"
     # apply the command
     response = PuppetRunProxy.new.resource(cmd)
     response
@@ -310,7 +310,7 @@ class PuppetRunProxy
   def apply(manifest)
     case @mode
     when :local
-      cmd = "bundle exec puppet apply --detailed-exitcodes -e \"#{manifest.gsub("\n", '')}\" --modulepath ../ --debug --trace"
+      cmd = "bundle exec puppet apply --detailed-exitcodes -e \"#{manifest.gsub("\n", '')}\" --modulepath ../ --libdir lib --debug --trace"
       use_local_shell(cmd)
     else
       # acceptable_exit_codes and expect_changes are passed because we want detailed-exit-codes but want to
@@ -366,5 +366,3 @@ class BeakerLikeResponse
   end
 
 end
-
-


### PR DESCRIPTION
Without this, puppet looks only in a few locations inside the module,
instead of loading everything from the lib/ directory. For example it
would cause lib/puppet/feature/aws.rb to not be loaded, failing all
providers.