### PR TITLE
Add VPC support for RDS instance creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -925,6 +925,10 @@ This parameter is set at creation only; it is not affected by updates.
 Names of the database security groups to associate with the instance.
 This parameter is set at creation only; it is not affected by updates.
 
+#####`vpc_security_groups`
+IDs of the database security groups within a VPC to associate the instance
+with.  This parameter is set at creation only; it is not affected by updates.
+
 #####`endpoint`
 The DNS address of the database. Read-only.
 

--- a/lib/puppet/provider/rds_instance/v2.rb
+++ b/lib/puppet/provider/rds_instance/v2.rb
@@ -20,10 +20,11 @@ Puppet::Type.type(:rds_instance).provide(:v2, :parent => PuppetX::Puppetlabs::Aw
     end.flatten
   end
 
-  read_only(:iops, :master_username, :multi_az, :license_model,
-            :db_name, :region, :db_instance_class, :availability_zone,
-            :engine, :engine_version, :allocated_storage, :storage_type,
-            :db_security_groups, :db_parameter_group, :backup_retention_period, :db_subnet)
+  read_only(:iops, :master_username, :multi_az, :license_model, :db_name,
+            :region, :db_instance_class, :availability_zone, :engine,
+            :engine_version, :allocated_storage, :storage_type,
+            :db_security_groups, :db_parameter_group, :backup_retention_period,
+            :db_subnet, :vpc_security_groups)
 
   def self.prefetch(resources)
     instances.each do |prov|
@@ -52,6 +53,7 @@ Puppet::Type.type(:rds_instance).provide(:v2, :parent => PuppetX::Puppetlabs::Aw
       db_subnet: db_subnet,
       db_parameter_group: instance.db_parameter_groups.collect(&:db_parameter_group_name).first,
       db_security_groups: instance.db_security_groups.collect(&:db_security_group_name),
+      vpc_security_groups: instance.vpc_security_groups.collect(&:vpc_security_group_id),
       backup_retention_period: instance.backup_retention_period
     }
     if instance.respond_to?('endpoint') && !instance.endpoint.nil?
@@ -85,6 +87,7 @@ Puppet::Type.type(:rds_instance).provide(:v2, :parent => PuppetX::Puppetlabs::Aw
       db_subnet_group_name: resource[:db_subnet],
       db_security_groups: resource[:db_security_groups],
       db_parameter_group_name: resource[:db_parameter_group],
+      vpc_security_group_ids: resource[:vpc_security_groups],
       backup_retention_period: resource[:backup_retention_period],
     }
 

--- a/lib/puppet/type/rds_instance.rb
+++ b/lib/puppet/type/rds_instance.rb
@@ -163,6 +163,10 @@ Not applicable. Must be null.'
     desc 'The DB security groups to assign to this RDS instance.'
   end
 
+  newproperty(:vpc_security_groups, :array_matching => :all) do
+    desc 'An array of security group IDs within the VPC to assign to the instance.'
+  end
+
   newproperty(:endpoint) do
     desc 'The connection endpoint for the database.'
     validate do |value|

--- a/spec/unit/type/rds_instance_spec.rb
+++ b/spec/unit/type/rds_instance_spec.rb
@@ -29,6 +29,7 @@ describe type_class do
       :master_username,
       :multi_az,
       :db_security_groups,
+      :vpc_security_groups,
       :endpoint,
       :port,
       :db_parameter_group,


### PR DESCRIPTION
Without this change, it is not possible to create an RDS instance
attached to a VPC security group.  This work extends the current
rds_instance provider to include the handling of the vpc_security_groups
parameter and adds the necessary configuration for the API calls to
manage the state as requested.