### PR TITLE
Add initial iam_user resource

### DIFF
--- a/fixtures/vcr_cassettes/create-user.yml
+++ b/fixtures/vcr_cassettes/create-user.yml
@@ -14,13 +14,13 @@ http_interactions:
       User-Agent:
       - aws-sdk-ruby2/2.0.5 ruby/2.2.3 x86_64-darwin15
       X-Amz-Date:
-      - 20160520T211454Z
+      - 20160523T185231Z
       X-Amz-Content-Sha256:
       - b6359072c78d70ebee1e81adcbab4f01bf2c23245fa365ef83fe8f1f955085e2
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=redacted/20160520/us-east-1/iam/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=redacterd/20160523/us-east-1/iam/aws4_request,
         SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date,
-        Signature=270839ae34b9e857252ec574d90da7a1396864421914927c612f6bc938dbcbb3
+        Signature=df19351c465e533b6168da0530af88b1e87f464e8fe7324a0cb97abb13bac5c8
       Content-Length:
       - '35'
       Accept:
@@ -31,13 +31,13 @@ http_interactions:
       message: OK
     headers:
       X-Amzn-Requestid:
-      - e61b2219-1ecf-11e6-b905-2f308342ffb7
+      - 812d8fd4-2117-11e6-a813-d3092ea6021a
       Content-Type:
       - text/xml
       Content-Length:
-      - '1121'
+      - '617'
       Date:
-      - Fri, 20 May 2016 21:14:54 GMT
+      - Mon, 23 May 2016 18:52:31 GMT
     body:
       encoding: UTF-8
       string: |
@@ -48,33 +48,19 @@ http_interactions:
               <member>
                 <Path>/</Path>
                 <PasswordLastUsed>2016-05-20T20:59:26Z</PasswordLastUsed>
-                <UserName>zleslie</UserName>
                 <Arn>arn:aws:iam::111111111111:user/zleslie</Arn>
+                <UserName>zleslie</UserName>
                 <UserId>AAAAAAAAAAAAAAAAAAAAA</UserId>
                 <CreateDate>2016-05-20T20:58:02Z</CreateDate>
-              </member>
-              <member>
-                <Path>/</Path>
-                <UserName>zleslie2</UserName>
-                <Arn>arn:aws:iam::111111111111:user/zleslie2</Arn>
-                <UserId>AIDAJDVWXRMEXSPKTT6PW</UserId>
-                <CreateDate>2016-05-20T21:13:24Z</CreateDate>
-              </member>
-              <member>
-                <Path>/</Path>
-                <UserName>zleslie3</UserName>
-                <Arn>arn:aws:iam::111111111111:user/zleslie3</Arn>
-                <UserId>AIDAJM7L5OUPVRIXYNEB6</UserId>
-                <CreateDate>2016-05-20T21:13:24Z</CreateDate>
               </member>
             </Users>
           </ListUsersResult>
           <ResponseMetadata>
-            <RequestId>e61b2219-1ecf-11e6-b905-2f308342ffb7</RequestId>
+            <RequestId>812d8fd4-2117-11e6-a813-d3092ea6021a</RequestId>
           </ResponseMetadata>
         </ListUsersResponse>
     http_version: 
-  recorded_at: Fri, 20 May 2016 21:14:54 GMT
+  recorded_at: Mon, 23 May 2016 18:52:31 GMT
 - request:
     method: post
     uri: https://iam.amazonaws.com/
@@ -89,13 +75,13 @@ http_interactions:
       User-Agent:
       - aws-sdk-ruby2/2.0.5 ruby/2.2.3 x86_64-darwin15
       X-Amz-Date:
-      - 20160520T211454Z
+      - 20160523T185231Z
       X-Amz-Content-Sha256:
       - b6359072c78d70ebee1e81adcbab4f01bf2c23245fa365ef83fe8f1f955085e2
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=redacted/20160520/us-east-1/iam/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=redacterd/20160523/us-east-1/iam/aws4_request,
         SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date,
-        Signature=270839ae34b9e857252ec574d90da7a1396864421914927c612f6bc938dbcbb3
+        Signature=df19351c465e533b6168da0530af88b1e87f464e8fe7324a0cb97abb13bac5c8
       Content-Length:
       - '35'
       Accept:
@@ -106,13 +92,13 @@ http_interactions:
       message: OK
     headers:
       X-Amzn-Requestid:
-      - e64c1d1e-1ecf-11e6-8976-4705a560bd07
+      - 816011c3-2117-11e6-b1c6-3fe7c950cb83
       Content-Type:
       - text/xml
       Content-Length:
-      - '1121'
+      - '617'
       Date:
-      - Fri, 20 May 2016 21:14:54 GMT
+      - Mon, 23 May 2016 18:52:31 GMT
     body:
       encoding: UTF-8
       string: |
@@ -128,26 +114,12 @@ http_interactions:
                 <UserId>AAAAAAAAAAAAAAAAAAAAA</UserId>
                 <CreateDate>2016-05-20T20:58:02Z</CreateDate>
               </member>
-              <member>
-                <Path>/</Path>
-                <UserName>zleslie2</UserName>
-                <Arn>arn:aws:iam::111111111111:user/zleslie2</Arn>
-                <UserId>AIDAJDVWXRMEXSPKTT6PW</UserId>
-                <CreateDate>2016-05-20T21:13:24Z</CreateDate>
-              </member>
-              <member>
-                <Path>/</Path>
-                <UserName>zleslie3</UserName>
-                <Arn>arn:aws:iam::111111111111:user/zleslie3</Arn>
-                <UserId>AIDAJM7L5OUPVRIXYNEB6</UserId>
-                <CreateDate>2016-05-20T21:13:24Z</CreateDate>
-              </member>
             </Users>
           </ListUsersResult>
           <ResponseMetadata>
-            <RequestId>e64c1d1e-1ecf-11e6-8976-4705a560bd07</RequestId>
+            <RequestId>816011c3-2117-11e6-b1c6-3fe7c950cb83</RequestId>
           </ResponseMetadata>
         </ListUsersResponse>
     http_version: 
-  recorded_at: Fri, 20 May 2016 21:14:55 GMT
+  recorded_at: Mon, 23 May 2016 18:52:32 GMT
 recorded_with: VCR 3.0.1

--- a/fixtures/vcr_cassettes/create-user.yml
+++ b/fixtures/vcr_cassettes/create-user.yml
@@ -14,13 +14,13 @@ http_interactions:
       User-Agent:
       - aws-sdk-ruby2/2.0.5 ruby/2.2.3 x86_64-darwin15
       X-Amz-Date:
-      - 20160523T185231Z
+      - 20160523T191019Z
       X-Amz-Content-Sha256:
       - b6359072c78d70ebee1e81adcbab4f01bf2c23245fa365ef83fe8f1f955085e2
       Authorization:
       - AWS4-HMAC-SHA256 Credential=redacterd/20160523/us-east-1/iam/aws4_request,
         SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date,
-        Signature=df19351c465e533b6168da0530af88b1e87f464e8fe7324a0cb97abb13bac5c8
+        Signature=14925d85ab7c5f62eee479280483f756a67361483edd024b1a7808555c6c4c08
       Content-Length:
       - '35'
       Accept:
@@ -31,13 +31,13 @@ http_interactions:
       message: OK
     headers:
       X-Amzn-Requestid:
-      - 812d8fd4-2117-11e6-a813-d3092ea6021a
+      - fdd8ed5a-2119-11e6-a1a2-718946016691
       Content-Type:
       - text/xml
       Content-Length:
       - '617'
       Date:
-      - Mon, 23 May 2016 18:52:31 GMT
+      - Mon, 23 May 2016 19:10:19 GMT
     body:
       encoding: UTF-8
       string: |
@@ -48,19 +48,19 @@ http_interactions:
               <member>
                 <Path>/</Path>
                 <PasswordLastUsed>2016-05-20T20:59:26Z</PasswordLastUsed>
-                <Arn>arn:aws:iam::111111111111:user/zleslie</Arn>
                 <UserName>zleslie</UserName>
+                <Arn>arn:aws:iam::111111111111:user/zleslie</Arn>
                 <UserId>AAAAAAAAAAAAAAAAAAAAA</UserId>
                 <CreateDate>2016-05-20T20:58:02Z</CreateDate>
               </member>
             </Users>
           </ListUsersResult>
           <ResponseMetadata>
-            <RequestId>812d8fd4-2117-11e6-a813-d3092ea6021a</RequestId>
+            <RequestId>fdd8ed5a-2119-11e6-a1a2-718946016691</RequestId>
           </ResponseMetadata>
         </ListUsersResponse>
     http_version: 
-  recorded_at: Mon, 23 May 2016 18:52:31 GMT
+  recorded_at: Mon, 23 May 2016 19:10:19 GMT
 - request:
     method: post
     uri: https://iam.amazonaws.com/
@@ -75,13 +75,13 @@ http_interactions:
       User-Agent:
       - aws-sdk-ruby2/2.0.5 ruby/2.2.3 x86_64-darwin15
       X-Amz-Date:
-      - 20160523T185231Z
+      - 20160523T191019Z
       X-Amz-Content-Sha256:
       - b6359072c78d70ebee1e81adcbab4f01bf2c23245fa365ef83fe8f1f955085e2
       Authorization:
       - AWS4-HMAC-SHA256 Credential=redacterd/20160523/us-east-1/iam/aws4_request,
         SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date,
-        Signature=df19351c465e533b6168da0530af88b1e87f464e8fe7324a0cb97abb13bac5c8
+        Signature=14925d85ab7c5f62eee479280483f756a67361483edd024b1a7808555c6c4c08
       Content-Length:
       - '35'
       Accept:
@@ -92,13 +92,13 @@ http_interactions:
       message: OK
     headers:
       X-Amzn-Requestid:
-      - 816011c3-2117-11e6-b1c6-3fe7c950cb83
+      - fe0d9296-2119-11e6-96d0-5da17d99c5f9
       Content-Type:
       - text/xml
       Content-Length:
       - '617'
       Date:
-      - Mon, 23 May 2016 18:52:31 GMT
+      - Mon, 23 May 2016 19:10:19 GMT
     body:
       encoding: UTF-8
       string: |
@@ -117,9 +117,9 @@ http_interactions:
             </Users>
           </ListUsersResult>
           <ResponseMetadata>
-            <RequestId>816011c3-2117-11e6-b1c6-3fe7c950cb83</RequestId>
+            <RequestId>fe0d9296-2119-11e6-96d0-5da17d99c5f9</RequestId>
           </ResponseMetadata>
         </ListUsersResponse>
     http_version: 
-  recorded_at: Mon, 23 May 2016 18:52:32 GMT
+  recorded_at: Mon, 23 May 2016 19:10:20 GMT
 recorded_with: VCR 3.0.1

--- a/fixtures/vcr_cassettes/create-user.yml
+++ b/fixtures/vcr_cassettes/create-user.yml
@@ -1,0 +1,153 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://iam.amazonaws.com/
+    body:
+      encoding: UTF-8
+      string: Action=ListUsers&Version=2010-05-08
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby2/2.0.5 ruby/2.2.3 x86_64-darwin15
+      X-Amz-Date:
+      - 20160520T211454Z
+      X-Amz-Content-Sha256:
+      - b6359072c78d70ebee1e81adcbab4f01bf2c23245fa365ef83fe8f1f955085e2
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=redacted/20160520/us-east-1/iam/aws4_request,
+        SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date,
+        Signature=270839ae34b9e857252ec574d90da7a1396864421914927c612f6bc938dbcbb3
+      Content-Length:
+      - '35'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amzn-Requestid:
+      - e61b2219-1ecf-11e6-b905-2f308342ffb7
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '1121'
+      Date:
+      - Fri, 20 May 2016 21:14:54 GMT
+    body:
+      encoding: UTF-8
+      string: |
+        <ListUsersResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
+          <ListUsersResult>
+            <IsTruncated>false</IsTruncated>
+            <Users>
+              <member>
+                <Path>/</Path>
+                <PasswordLastUsed>2016-05-20T20:59:26Z</PasswordLastUsed>
+                <UserName>zleslie</UserName>
+                <Arn>arn:aws:iam::111111111111:user/zleslie</Arn>
+                <UserId>AAAAAAAAAAAAAAAAAAAAA</UserId>
+                <CreateDate>2016-05-20T20:58:02Z</CreateDate>
+              </member>
+              <member>
+                <Path>/</Path>
+                <UserName>zleslie2</UserName>
+                <Arn>arn:aws:iam::111111111111:user/zleslie2</Arn>
+                <UserId>AIDAJDVWXRMEXSPKTT6PW</UserId>
+                <CreateDate>2016-05-20T21:13:24Z</CreateDate>
+              </member>
+              <member>
+                <Path>/</Path>
+                <UserName>zleslie3</UserName>
+                <Arn>arn:aws:iam::111111111111:user/zleslie3</Arn>
+                <UserId>AIDAJM7L5OUPVRIXYNEB6</UserId>
+                <CreateDate>2016-05-20T21:13:24Z</CreateDate>
+              </member>
+            </Users>
+          </ListUsersResult>
+          <ResponseMetadata>
+            <RequestId>e61b2219-1ecf-11e6-b905-2f308342ffb7</RequestId>
+          </ResponseMetadata>
+        </ListUsersResponse>
+    http_version: 
+  recorded_at: Fri, 20 May 2016 21:14:54 GMT
+- request:
+    method: post
+    uri: https://iam.amazonaws.com/
+    body:
+      encoding: UTF-8
+      string: Action=ListUsers&Version=2010-05-08
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby2/2.0.5 ruby/2.2.3 x86_64-darwin15
+      X-Amz-Date:
+      - 20160520T211454Z
+      X-Amz-Content-Sha256:
+      - b6359072c78d70ebee1e81adcbab4f01bf2c23245fa365ef83fe8f1f955085e2
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=redacted/20160520/us-east-1/iam/aws4_request,
+        SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date,
+        Signature=270839ae34b9e857252ec574d90da7a1396864421914927c612f6bc938dbcbb3
+      Content-Length:
+      - '35'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amzn-Requestid:
+      - e64c1d1e-1ecf-11e6-8976-4705a560bd07
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '1121'
+      Date:
+      - Fri, 20 May 2016 21:14:54 GMT
+    body:
+      encoding: UTF-8
+      string: |
+        <ListUsersResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
+          <ListUsersResult>
+            <IsTruncated>false</IsTruncated>
+            <Users>
+              <member>
+                <Path>/</Path>
+                <PasswordLastUsed>2016-05-20T20:59:26Z</PasswordLastUsed>
+                <UserName>zleslie</UserName>
+                <Arn>arn:aws:iam::111111111111:user/zleslie</Arn>
+                <UserId>AAAAAAAAAAAAAAAAAAAAA</UserId>
+                <CreateDate>2016-05-20T20:58:02Z</CreateDate>
+              </member>
+              <member>
+                <Path>/</Path>
+                <UserName>zleslie2</UserName>
+                <Arn>arn:aws:iam::111111111111:user/zleslie2</Arn>
+                <UserId>AIDAJDVWXRMEXSPKTT6PW</UserId>
+                <CreateDate>2016-05-20T21:13:24Z</CreateDate>
+              </member>
+              <member>
+                <Path>/</Path>
+                <UserName>zleslie3</UserName>
+                <Arn>arn:aws:iam::111111111111:user/zleslie3</Arn>
+                <UserId>AIDAJM7L5OUPVRIXYNEB6</UserId>
+                <CreateDate>2016-05-20T21:13:24Z</CreateDate>
+              </member>
+            </Users>
+          </ListUsersResult>
+          <ResponseMetadata>
+            <RequestId>e64c1d1e-1ecf-11e6-8976-4705a560bd07</RequestId>
+          </ResponseMetadata>
+        </ListUsersResponse>
+    http_version: 
+  recorded_at: Fri, 20 May 2016 21:14:55 GMT
+recorded_with: VCR 3.0.1

--- a/fixtures/vcr_cassettes/destroy-user.yml
+++ b/fixtures/vcr_cassettes/destroy-user.yml
@@ -1,0 +1,126 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://iam.amazonaws.com/
+    body:
+      encoding: UTF-8
+      string: Action=ListUsers&Version=2010-05-08
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby2/2.0.5 ruby/2.2.3 x86_64-darwin15
+      X-Amz-Date:
+      - 20160520T211455Z
+      X-Amz-Content-Sha256:
+      - b6359072c78d70ebee1e81adcbab4f01bf2c23245fa365ef83fe8f1f955085e2
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=redacted/20160520/us-east-1/iam/aws4_request,
+        SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date,
+        Signature=1ce46cedb9b20b7b53c30af0ec7c98e234f3b4fca9a35eee3baaa8ec1e8ce42f
+      Content-Length:
+      - '35'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amzn-Requestid:
+      - e6b00ecd-1ecf-11e6-838c-db1a688b016b
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '1121'
+      Date:
+      - Fri, 20 May 2016 21:14:55 GMT
+    body:
+      encoding: UTF-8
+      string: |
+        <ListUsersResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
+          <ListUsersResult>
+            <IsTruncated>false</IsTruncated>
+            <Users>
+              <member>
+                <Path>/</Path>
+                <PasswordLastUsed>2016-05-20T20:59:26Z</PasswordLastUsed>
+                <UserName>zleslie</UserName>
+                <Arn>arn:aws:iam::111111111111:user/zleslie</Arn>
+                <UserId>AAAAAAAAAAAAAAAAAAAAA</UserId>
+                <CreateDate>2016-05-20T20:58:02Z</CreateDate>
+              </member>
+              <member>
+                <Path>/</Path>
+                <UserName>zleslie2</UserName>
+                <Arn>arn:aws:iam::111111111111:user/zleslie2</Arn>
+                <UserId>AIDAJDVWXRMEXSPKTT6PW</UserId>
+                <CreateDate>2016-05-20T21:13:24Z</CreateDate>
+              </member>
+              <member>
+                <Path>/</Path>
+                <UserName>zleslie3</UserName>
+                <Arn>arn:aws:iam::111111111111:user/zleslie3</Arn>
+                <UserId>AIDAJM7L5OUPVRIXYNEB6</UserId>
+                <CreateDate>2016-05-20T21:13:24Z</CreateDate>
+              </member>
+            </Users>
+          </ListUsersResult>
+          <ResponseMetadata>
+            <RequestId>e6b00ecd-1ecf-11e6-838c-db1a688b016b</RequestId>
+          </ResponseMetadata>
+        </ListUsersResponse>
+    http_version: 
+  recorded_at: Fri, 20 May 2016 21:14:55 GMT
+- request:
+    method: post
+    uri: https://iam.amazonaws.com/
+    body:
+      encoding: UTF-8
+      string: Action=DeleteUser&UserName=zleslie2&Version=2010-05-08
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby2/2.0.5 ruby/2.2.3 x86_64-darwin15
+      X-Amz-Date:
+      - 20160520T211455Z
+      X-Amz-Content-Sha256:
+      - b6404416b3ee21d6378bf8caaaa0b853827f7fd00deb132053aab43ae17bcbd4
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=redacted/20160520/us-east-1/iam/aws4_request,
+        SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date,
+        Signature=5e4b879fcedb70e93f43eae09d360d89fda509421f334f68c8ed41d399b9f0b3
+      Content-Length:
+      - '54'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amzn-Requestid:
+      - e6e109bb-1ecf-11e6-964c-7b76c530a910
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '200'
+      Date:
+      - Fri, 20 May 2016 21:14:55 GMT
+    body:
+      encoding: UTF-8
+      string: |
+        <DeleteUserResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
+          <ResponseMetadata>
+            <RequestId>e6e109bb-1ecf-11e6-964c-7b76c530a910</RequestId>
+          </ResponseMetadata>
+        </DeleteUserResponse>
+    http_version: 
+  recorded_at: Fri, 20 May 2016 21:14:56 GMT
+recorded_with: VCR 3.0.1

--- a/fixtures/vcr_cassettes/destroy-user.yml
+++ b/fixtures/vcr_cassettes/destroy-user.yml
@@ -14,13 +14,13 @@ http_interactions:
       User-Agent:
       - aws-sdk-ruby2/2.0.5 ruby/2.2.3 x86_64-darwin15
       X-Amz-Date:
-      - 20160523T185045Z
+      - 20160523T191020Z
       X-Amz-Content-Sha256:
       - b6359072c78d70ebee1e81adcbab4f01bf2c23245fa365ef83fe8f1f955085e2
       Authorization:
       - AWS4-HMAC-SHA256 Credential=redacterd/20160523/us-east-1/iam/aws4_request,
         SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date,
-        Signature=7347c192a3044bb0eccea7a93d6ca23cb228e88005eea73698b636923fa6e909
+        Signature=582d4b396d43288e53c781afd197361dfcce49e42bb9b91e23aa68f72c838a43
       Content-Length:
       - '35'
       Accept:
@@ -31,13 +31,13 @@ http_interactions:
       message: OK
     headers:
       X-Amzn-Requestid:
-      - 41d45e22-2117-11e6-838c-db1a688b016b
+      - fe77ed14-2119-11e6-a1a2-718946016691
       Content-Type:
       - text/xml
       Content-Length:
       - '617'
       Date:
-      - Mon, 23 May 2016 18:50:45 GMT
+      - Mon, 23 May 2016 19:10:20 GMT
     body:
       encoding: UTF-8
       string: |
@@ -56,9 +56,9 @@ http_interactions:
             </Users>
           </ListUsersResult>
           <ResponseMetadata>
-            <RequestId>41d45e22-2117-11e6-838c-db1a688b016b</RequestId>
+            <RequestId>fe77ed14-2119-11e6-a1a2-718946016691</RequestId>
           </ResponseMetadata>
         </ListUsersResponse>
     http_version: 
-  recorded_at: Mon, 23 May 2016 18:50:45 GMT
+  recorded_at: Mon, 23 May 2016 19:10:20 GMT
 recorded_with: VCR 3.0.1

--- a/fixtures/vcr_cassettes/destroy-user.yml
+++ b/fixtures/vcr_cassettes/destroy-user.yml
@@ -14,13 +14,13 @@ http_interactions:
       User-Agent:
       - aws-sdk-ruby2/2.0.5 ruby/2.2.3 x86_64-darwin15
       X-Amz-Date:
-      - 20160520T211455Z
+      - 20160523T185045Z
       X-Amz-Content-Sha256:
       - b6359072c78d70ebee1e81adcbab4f01bf2c23245fa365ef83fe8f1f955085e2
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=redacted/20160520/us-east-1/iam/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=redacterd/20160523/us-east-1/iam/aws4_request,
         SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date,
-        Signature=1ce46cedb9b20b7b53c30af0ec7c98e234f3b4fca9a35eee3baaa8ec1e8ce42f
+        Signature=7347c192a3044bb0eccea7a93d6ca23cb228e88005eea73698b636923fa6e909
       Content-Length:
       - '35'
       Accept:
@@ -31,13 +31,13 @@ http_interactions:
       message: OK
     headers:
       X-Amzn-Requestid:
-      - e6b00ecd-1ecf-11e6-838c-db1a688b016b
+      - 41d45e22-2117-11e6-838c-db1a688b016b
       Content-Type:
       - text/xml
       Content-Length:
-      - '1121'
+      - '617'
       Date:
-      - Fri, 20 May 2016 21:14:55 GMT
+      - Mon, 23 May 2016 18:50:45 GMT
     body:
       encoding: UTF-8
       string: |
@@ -53,74 +53,12 @@ http_interactions:
                 <UserId>AAAAAAAAAAAAAAAAAAAAA</UserId>
                 <CreateDate>2016-05-20T20:58:02Z</CreateDate>
               </member>
-              <member>
-                <Path>/</Path>
-                <UserName>zleslie2</UserName>
-                <Arn>arn:aws:iam::111111111111:user/zleslie2</Arn>
-                <UserId>AIDAJDVWXRMEXSPKTT6PW</UserId>
-                <CreateDate>2016-05-20T21:13:24Z</CreateDate>
-              </member>
-              <member>
-                <Path>/</Path>
-                <UserName>zleslie3</UserName>
-                <Arn>arn:aws:iam::111111111111:user/zleslie3</Arn>
-                <UserId>AIDAJM7L5OUPVRIXYNEB6</UserId>
-                <CreateDate>2016-05-20T21:13:24Z</CreateDate>
-              </member>
             </Users>
           </ListUsersResult>
           <ResponseMetadata>
-            <RequestId>e6b00ecd-1ecf-11e6-838c-db1a688b016b</RequestId>
+            <RequestId>41d45e22-2117-11e6-838c-db1a688b016b</RequestId>
           </ResponseMetadata>
         </ListUsersResponse>
     http_version: 
-  recorded_at: Fri, 20 May 2016 21:14:55 GMT
-- request:
-    method: post
-    uri: https://iam.amazonaws.com/
-    body:
-      encoding: UTF-8
-      string: Action=DeleteUser&UserName=zleslie2&Version=2010-05-08
-    headers:
-      Content-Type:
-      - application/x-www-form-urlencoded; charset=utf-8
-      Accept-Encoding:
-      - ''
-      User-Agent:
-      - aws-sdk-ruby2/2.0.5 ruby/2.2.3 x86_64-darwin15
-      X-Amz-Date:
-      - 20160520T211455Z
-      X-Amz-Content-Sha256:
-      - b6404416b3ee21d6378bf8caaaa0b853827f7fd00deb132053aab43ae17bcbd4
-      Authorization:
-      - AWS4-HMAC-SHA256 Credential=redacted/20160520/us-east-1/iam/aws4_request,
-        SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date,
-        Signature=5e4b879fcedb70e93f43eae09d360d89fda509421f334f68c8ed41d399b9f0b3
-      Content-Length:
-      - '54'
-      Accept:
-      - "*/*"
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      X-Amzn-Requestid:
-      - e6e109bb-1ecf-11e6-964c-7b76c530a910
-      Content-Type:
-      - text/xml
-      Content-Length:
-      - '200'
-      Date:
-      - Fri, 20 May 2016 21:14:55 GMT
-    body:
-      encoding: UTF-8
-      string: |
-        <DeleteUserResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
-          <ResponseMetadata>
-            <RequestId>e6e109bb-1ecf-11e6-964c-7b76c530a910</RequestId>
-          </ResponseMetadata>
-        </DeleteUserResponse>
-    http_version: 
-  recorded_at: Fri, 20 May 2016 21:14:56 GMT
+  recorded_at: Mon, 23 May 2016 18:50:45 GMT
 recorded_with: VCR 3.0.1

--- a/fixtures/vcr_cassettes/users-named.yml
+++ b/fixtures/vcr_cassettes/users-named.yml
@@ -1,0 +1,78 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://iam.amazonaws.com/
+    body:
+      encoding: UTF-8
+      string: Action=ListUsers&Version=2010-05-08
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby2/2.0.5 ruby/2.2.3 x86_64-darwin15
+      X-Amz-Date:
+      - 20160520T211455Z
+      X-Amz-Content-Sha256:
+      - b6359072c78d70ebee1e81adcbab4f01bf2c23245fa365ef83fe8f1f955085e2
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=redacted/20160520/us-east-1/iam/aws4_request,
+        SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date,
+        Signature=1ce46cedb9b20b7b53c30af0ec7c98e234f3b4fca9a35eee3baaa8ec1e8ce42f
+      Content-Length:
+      - '35'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amzn-Requestid:
+      - e67ddb11-1ecf-11e6-a9b3-9347fe68fd42
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '1121'
+      Date:
+      - Fri, 20 May 2016 21:14:55 GMT
+    body:
+      encoding: UTF-8
+      string: |
+        <ListUsersResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
+          <ListUsersResult>
+            <IsTruncated>false</IsTruncated>
+            <Users>
+              <member>
+                <Path>/</Path>
+                <PasswordLastUsed>2016-05-20T20:59:26Z</PasswordLastUsed>
+                <UserName>zleslie</UserName>
+                <Arn>arn:aws:iam::111111111111:user/zleslie</Arn>
+                <UserId>AAAAAAAAAAAAAAAAAAAAA</UserId>
+                <CreateDate>2016-05-20T20:58:02Z</CreateDate>
+              </member>
+              <member>
+                <Path>/</Path>
+                <UserName>zleslie2</UserName>
+                <Arn>arn:aws:iam::111111111111:user/zleslie2</Arn>
+                <UserId>AIDAJDVWXRMEXSPKTT6PW</UserId>
+                <CreateDate>2016-05-20T21:13:24Z</CreateDate>
+              </member>
+              <member>
+                <Path>/</Path>
+                <UserName>zleslie3</UserName>
+                <Arn>arn:aws:iam::111111111111:user/zleslie3</Arn>
+                <UserId>AIDAJM7L5OUPVRIXYNEB6</UserId>
+                <CreateDate>2016-05-20T21:13:24Z</CreateDate>
+              </member>
+            </Users>
+          </ListUsersResult>
+          <ResponseMetadata>
+            <RequestId>e67ddb11-1ecf-11e6-a9b3-9347fe68fd42</RequestId>
+          </ResponseMetadata>
+        </ListUsersResponse>
+    http_version: 
+  recorded_at: Fri, 20 May 2016 21:14:55 GMT
+recorded_with: VCR 3.0.1

--- a/fixtures/vcr_cassettes/users-named.yml
+++ b/fixtures/vcr_cassettes/users-named.yml
@@ -14,13 +14,13 @@ http_interactions:
       User-Agent:
       - aws-sdk-ruby2/2.0.5 ruby/2.2.3 x86_64-darwin15
       X-Amz-Date:
-      - 20160523T185044Z
+      - 20160523T191020Z
       X-Amz-Content-Sha256:
       - b6359072c78d70ebee1e81adcbab4f01bf2c23245fa365ef83fe8f1f955085e2
       Authorization:
       - AWS4-HMAC-SHA256 Credential=redacterd/20160523/us-east-1/iam/aws4_request,
         SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date,
-        Signature=2ad7d5b547cd50d5a3fdbf10459923397e13b1f433b346ea179f76ecddce5d7d
+        Signature=582d4b396d43288e53c781afd197361dfcce49e42bb9b91e23aa68f72c838a43
       Content-Length:
       - '35'
       Accept:
@@ -31,13 +31,13 @@ http_interactions:
       message: OK
     headers:
       X-Amzn-Requestid:
-      - 41a1dcdb-2117-11e6-8976-4705a560bd07
+      - fe41e8f3-2119-11e6-aa8d-9b4f3d48f980
       Content-Type:
       - text/xml
       Content-Length:
       - '617'
       Date:
-      - Mon, 23 May 2016 18:50:44 GMT
+      - Mon, 23 May 2016 19:10:20 GMT
     body:
       encoding: UTF-8
       string: |
@@ -56,9 +56,9 @@ http_interactions:
             </Users>
           </ListUsersResult>
           <ResponseMetadata>
-            <RequestId>41a1dcdb-2117-11e6-8976-4705a560bd07</RequestId>
+            <RequestId>fe41e8f3-2119-11e6-aa8d-9b4f3d48f980</RequestId>
           </ResponseMetadata>
         </ListUsersResponse>
     http_version: 
-  recorded_at: Mon, 23 May 2016 18:50:45 GMT
+  recorded_at: Mon, 23 May 2016 19:10:20 GMT
 recorded_with: VCR 3.0.1

--- a/fixtures/vcr_cassettes/users-named.yml
+++ b/fixtures/vcr_cassettes/users-named.yml
@@ -14,13 +14,13 @@ http_interactions:
       User-Agent:
       - aws-sdk-ruby2/2.0.5 ruby/2.2.3 x86_64-darwin15
       X-Amz-Date:
-      - 20160520T211455Z
+      - 20160523T185044Z
       X-Amz-Content-Sha256:
       - b6359072c78d70ebee1e81adcbab4f01bf2c23245fa365ef83fe8f1f955085e2
       Authorization:
-      - AWS4-HMAC-SHA256 Credential=redacted/20160520/us-east-1/iam/aws4_request,
+      - AWS4-HMAC-SHA256 Credential=redacterd/20160523/us-east-1/iam/aws4_request,
         SignedHeaders=content-type;host;user-agent;x-amz-content-sha256;x-amz-date,
-        Signature=1ce46cedb9b20b7b53c30af0ec7c98e234f3b4fca9a35eee3baaa8ec1e8ce42f
+        Signature=2ad7d5b547cd50d5a3fdbf10459923397e13b1f433b346ea179f76ecddce5d7d
       Content-Length:
       - '35'
       Accept:
@@ -31,13 +31,13 @@ http_interactions:
       message: OK
     headers:
       X-Amzn-Requestid:
-      - e67ddb11-1ecf-11e6-a9b3-9347fe68fd42
+      - 41a1dcdb-2117-11e6-8976-4705a560bd07
       Content-Type:
       - text/xml
       Content-Length:
-      - '1121'
+      - '617'
       Date:
-      - Fri, 20 May 2016 21:14:55 GMT
+      - Mon, 23 May 2016 18:50:44 GMT
     body:
       encoding: UTF-8
       string: |
@@ -53,26 +53,12 @@ http_interactions:
                 <UserId>AAAAAAAAAAAAAAAAAAAAA</UserId>
                 <CreateDate>2016-05-20T20:58:02Z</CreateDate>
               </member>
-              <member>
-                <Path>/</Path>
-                <UserName>zleslie2</UserName>
-                <Arn>arn:aws:iam::111111111111:user/zleslie2</Arn>
-                <UserId>AIDAJDVWXRMEXSPKTT6PW</UserId>
-                <CreateDate>2016-05-20T21:13:24Z</CreateDate>
-              </member>
-              <member>
-                <Path>/</Path>
-                <UserName>zleslie3</UserName>
-                <Arn>arn:aws:iam::111111111111:user/zleslie3</Arn>
-                <UserId>AIDAJM7L5OUPVRIXYNEB6</UserId>
-                <CreateDate>2016-05-20T21:13:24Z</CreateDate>
-              </member>
             </Users>
           </ListUsersResult>
           <ResponseMetadata>
-            <RequestId>e67ddb11-1ecf-11e6-a9b3-9347fe68fd42</RequestId>
+            <RequestId>41a1dcdb-2117-11e6-8976-4705a560bd07</RequestId>
           </ResponseMetadata>
         </ListUsersResponse>
     http_version: 
-  recorded_at: Fri, 20 May 2016 21:14:55 GMT
+  recorded_at: Mon, 23 May 2016 18:50:45 GMT
 recorded_with: VCR 3.0.1

--- a/lib/puppet/provider/iam_user/v2.rb
+++ b/lib/puppet/provider/iam_user/v2.rb
@@ -31,9 +31,9 @@ Puppet::Type.type(:iam_user).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) d
 
   def create
     Puppet.info("Creating IAM user #{name}")
-    iam_client.create_user(
+    iam_client.create_user({
       user_name: name,
-    )
+    })
     @property_hash[:ensure] = :present
   end
 

--- a/lib/puppet/provider/iam_user/v2.rb
+++ b/lib/puppet/provider/iam_user/v2.rb
@@ -1,0 +1,49 @@
+require_relative '../../../puppet_x/puppetlabs/aws.rb'
+
+Puppet::Type.type(:iam_user).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) do
+  confine feature: :aws
+
+  mk_resource_methods
+
+  def self.instances
+    response = iam_client.list_users()
+    response.users.collect do |user|
+      new({
+        name: user.user_name,
+        ensure: :present,
+        path: user.path
+      })
+    end
+  end
+
+  def self.prefetch(resources)
+    instances.each do |prov|
+      if resource = resources[prov.name]
+        resource.provider = prov
+      end
+    end
+  end
+
+  def exists?
+    Puppet.info("Checking if IAM user #{name} exists")
+    @property_hash[:ensure] == :present
+  end
+
+  def create
+    Puppet.info("Creating IAM user #{name}")
+    iam_client.create_user(
+      user_name: name,
+    )
+    @property_hash[:ensure] = :present
+  end
+
+  def destroy
+    Puppet.info("Deleting IAM user #{name}")
+    users = iam_client.list_users.users.select { |user| user.user_name == name }
+    users.each do |user|
+      iam_client.delete_user(user_name: user.user_name)
+    end
+    @property_hash[:ensure] = :absent
+  end
+
+end

--- a/lib/puppet/type/iam_user.rb
+++ b/lib/puppet/type/iam_user.rb
@@ -1,0 +1,12 @@
+Puppet::Type.newtype(:iam_user) do
+  @doc = 'Type representing IAM users.'
+
+  ensurable
+
+  newparam(:name, namevar: true) do
+    desc 'The name of the user to manage.'
+    validate do |value|
+      fail Puppet::Error, 'Empty usernames are not allowed' if value == ''
+    end
+  end
+end

--- a/lib/puppet_x/puppetlabs/aws.rb
+++ b/lib/puppet_x/puppetlabs/aws.rb
@@ -202,6 +202,13 @@ This could be because some other process is modifying AWS at the same time."""
         ::Aws::SQS::Client.new({region: region})
       end
 
+      def self.iam_client(region = default_region)
+        ::Aws::IAM::Client.new(client_config(region))
+      end
+
+      def iam_client(region = default_region)
+        self.class.iam_client(region)
+      end
 
       def tags_for_resource
         tags = resource[:tags] ? resource[:tags].map { |k,v| {key: k, value: v} } : []

--- a/spec/acceptance/iam_user_spec.rb
+++ b/spec/acceptance/iam_user_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper_acceptance'
+require 'securerandom'
+
+describe 'iam_user' do
+  before(:all) do
+    @default_region = 'sa-east-1'
+    @aws = AwsHelper.new(@default_region)
+  end
+
+  def find_user(name)
+    users = @aws.find_iam_users(name)
+    expect(users.count).to eq(1)
+    users.first
+  end
+
+  describe 'manage an iam_user' do
+
+    before (:all) do
+      @name = "#{SecureRandom.uuid}.com."
+      @config = {
+        :name => @name,
+      }
+      @template = 'iam_user.pp.tmpl'
+      @user = find_user(@name)
+    end
+
+    it 'with puppet resource' do
+      options = {:name => @config[:name], :ensure => 'present'}
+      result = TestExecutor.puppet_resource('iam_user', options, '--modulepath spec/fixtures/modules/')
+      expect(result.stderr).not_to match(/Error:/)
+      expect{ find_user(@config[:name]) }.not_to raise_error
+    end
+
+    it 'should run idempotently' do
+      result = PuppetManifest.new(@template, @config).apply
+      expect(result.exit_code).to eq(0)
+    end
+
+    it 'should create an IAM user with the correct name' do
+      expect(user.user_name).to eq(@name)
+    end
+
+    it 'should destroy an IAM user' do
+      options = {:name => @config[:name], :ensure => 'absent'}
+      TestExecutor.puppet_resource('iam_user', options, '--modulepath spec/fixtures/modules/')
+      expect(@aws.get_iam_users(@name)).to be_empty
+    end
+
+    it 'should run idempotently after destroy' do
+      result = PuppetManifest.new(@template, @config).apply
+      expect(result.exit_code).to eq(0)
+    end
+
+  end
+
+end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -106,6 +106,7 @@ class AwsHelper
     @route53_client = ::Aws::Route53::Client.new({region: region})
     @rds_client = ::Aws::RDS::Client.new({region: region})
     @sqs_client = ::Aws::SQS::Client.new({region: region})
+    @iam_client = ::Aws::IAM::Client.new({region: region})
   end
 
 
@@ -271,6 +272,10 @@ class AwsHelper
   def get_dns_records(name, zone, type)
     records = @route53_client.list_resource_record_sets(hosted_zone_id: zone.id)
     records.data.resource_record_sets.select { |r| r.type == type && r.name == name}
+  end
+
+  def get_iam_users(name)
+    @iam_client.list_users.users.select { |user| user.user_name == name }
   end
 
 end

--- a/spec/unit/provider/iam_user/v2_spec.rb
+++ b/spec/unit/provider/iam_user/v2_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+
+provider_class = Puppet::Type.type(:iam_user).provider(:v2)
+
+ENV['AWS_ACCESS_KEY_ID'] = 'redacted'
+ENV['AWS_SECRET_ACCESS_KEY'] = 'redacted'
+ENV['AWS_REGION'] = 'sa-east-1'
+
+describe provider_class do
+
+  context 'with the minimum params' do
+    let(:resource) {
+      Puppet::Type.type(:iam_user).new(
+        name: 'zleslie2',
+      )
+    }
+
+    let(:provider) { resource.provider }
+
+    let(:instance) { provider.class.instances.first }
+
+    it 'should be an instance of the ProviderV2' do
+      expect(provider).to be_an_instance_of Puppet::Type::Iam_user::ProviderV2
+    end
+
+    describe 'self.prefetch' do
+      it 'exists' do
+        VCR.use_cassette('create-user') do
+          provider.class.instances
+          provider.class.prefetch({})
+        end
+      end
+    end
+
+    describe 'exists?' do
+      it 'should correctly report non-existent users' do
+        VCR.use_cassette('no-user-named') do
+          expect(provider.exists?).to be_falsy
+        end
+      end
+
+      it 'should correctly find existing users' do
+        VCR.use_cassette('users-named') do
+          expect(instance.exists?).to be_truthy
+        end
+      end
+    end
+
+    describe 'create' do
+      it 'should send a request to the EC2 API to create the users' do
+        VCR.use_cassette('create-user') do
+          expect(provider.create).to be_truthy
+        end
+      end
+    end
+
+    describe 'destroy' do
+      it 'should send a request to the EC2 API to destroy the user' do
+        VCR.use_cassette('destroy-user') do
+          expect(provider.destroy).to be_truthy
+        end
+      end
+    end
+
+  end
+
+end

--- a/spec/unit/type/iam_user_spec.rb
+++ b/spec/unit/type/iam_user_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+type_class = Puppet::Type.type(:iam_user)
+
+describe type_class do
+
+  let :params do
+    [
+      :name,
+    ]
+  end
+
+  let :properties do
+    [
+      :ensure,
+    ]
+  end
+
+  it 'should have expected properties' do
+    properties.each do |property|
+      expect(type_class.properties.map(&:name)).to be_include(property)
+    end
+  end
+
+  it 'should have expected parameters' do
+    params.each do |param|
+      expect(type_class.parameters).to be_include(param)
+    end
+  end
+
+  it 'should require a name' do
+    expect {
+      type_class.new({})
+    }.to raise_error(Puppet::Error, 'Title or name must be provided')
+  end
+
+  it 'should require a non-blank name' do
+    expect {
+      type_class.new({ name: '' })
+    }.to raise_error(Puppet::Error, /Empty usernames are not allowed/)
+  end
+
+  context 'with a valid name' do
+    it 'should create a valid instance' do
+      type_class.new({ name: 'name' })
+    end
+  end
+
+end
+


### PR DESCRIPTION
This work builds on the examples provided by other types and replicates
the work into a new type for 'iam_user'.  Without this change, it is not
possible to manage IAM users in AWS using puppet.