### PR TITLE
Make SSD-based EBS volumes the default.

### DIFF
--- a/lib/puppet/provider/ec2_instance/v2.rb
+++ b/lib/puppet/provider/ec2_instance/v2.rb
@@ -223,7 +223,7 @@ Found #{matching_groups.length}:
           volume_size: device['volume_size'],
           snapshot_id: device['snapshot_id'],
           delete_on_termination: device['delete_on_termination'] || true,
-          volume_type: device['volume_type'] || 'standard',
+          volume_type: device['volume_type'] || 'gp2',
           iops: device['iops'],
           encrypted: device['encrypted'] ? true : nil
         },


### PR DESCRIPTION
Without this change all EBS volumes provisioned by the the puppetlabs aws code will default to magnetic media for backing.  This change will make the use of SSD-based data storage default.