### PR TITLE
Initial Ec2 Volume management

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,6 +312,7 @@ You can use the aws module to audit AWS resources, launch autoscaling groups in 
 * `ec2_elastic_ip`: Sets up an Elastic IP and its association.
 * `ec2_launchconfiguration`: Sets up an EC2 launch configuration to provide autoscaling support.
 * `ec2_scalingpolicy`: Sets up an EC2 scaling policy.
+* `ec2_volume`: Ec2 block volume management.
 * `ec2_vpc`: Sets up an AWS VPC.
 * `ec2_vpc_customer_gateway`: Sets up an AWS VPC customer gateway.
 * `ec2_vpc_dhcp_options`: Sets a DHCP option AWS VPC.
@@ -630,6 +631,32 @@ Specifies that basic state of the resource. Valid values are 'attached', 'detach
 
 #####`auto_scaling_group`
 *Required* The name of the auto scaling group to attach the policy to. This is the value of the AWS Name tag. This parameter is set at creation only; it is not affected by updates.
+
+#### Type: ec2_volume
+
+This type manges the creation and destruction of Ec2 volumes.  The naming of
+volumes is something users of this type should take into consideration.
+
+Volumes are most commonly referred to by the `volume_id` property of the
+volume, which represents the unique volume for the given availability zone.
+This presents a problem when referring to and creating volumes, since the
+`volume_id` is not known until after creation of the volume.  To work around
+this oddity, the `ec2_volume` type only recognizes volumes that have the 'Name'
+tag set.  This also means that the title of the `ec2_volume` will be set as the
+'Name' tag upon creation of a volume.  Volumes without a 'Name' tag are not
+seen and are ignored.
+
+#####`name`
+*Required* The name to give to a volume. This is the value of the AWS Name tag.
+
+#####`volume_type`
+This is the type of volume to create.  This value should be one of standard, gp2 or io1.
+
+#####`size`
+Number of gigabytes a volume should allocate.
+
+#####`availability_zone`
+The AWS availability zone in which to create and look for the volume.
 
 #### Type: ec2_vpc
 

--- a/lib/puppet/provider/ec2_volume/v2.rb
+++ b/lib/puppet/provider/ec2_volume/v2.rb
@@ -1,0 +1,86 @@
+require_relative '../../../puppet_x/puppetlabs/aws.rb'
+
+Puppet::Type.type(:ec2_volume).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) do
+  confine feature: :aws
+
+  mk_resource_methods
+
+  def self.tag_hash(volume)
+    tags = {}
+    volume.tags.each {|tag|
+      tags[tag.key] = tag.value
+    }
+    tags
+  end
+
+  def self.instances
+    response = ec2_client.describe_volumes
+
+    # Due to the confusing nature of volume naming, only volumes with a 'Name'
+    # tag are managed.  As such, here we reduce the working set by detecting
+    # Name-tagged volumes for collection.
+    named_volumes = response.volumes.select {|volume|
+      tags = tag_hash(volume)
+      tags.keys.include? 'Name' and tags['Name'].size > 0
+    }
+
+    named_volumes.collect {|volume|
+      tags = tag_hash(volume)
+      volume_name = tags['Name']
+
+      new({
+        name: volume_name,
+        ensure: :present,
+        state: volume.state,
+        size: volume.size,
+        volume_id: volume.volume_id,
+        volume_type: volume.volume_type,
+        tags: tags,
+        availability_zone: volume.availability_zone,
+      })
+    }
+  end
+
+  def self.prefetch(resources)
+    instances.each do |prov|
+      if resource = resources[prov.name]
+        resource.provider = prov
+      end
+    end
+  end
+
+  read_only(:size, :volume_type, :availability_zone)
+
+  def exists?
+    @property_hash[:ensure] == :present
+  end
+
+  def create
+    Puppet.info("Creating ec2_volume #{resource[:name]}")
+
+    option_hash = {
+      size: resource[:size],
+      volume_type: resource[:volume_type],
+      availability_zone: resource[:availability_zone],
+    }
+
+    response = ec2_client.create_volume(option_hash)
+
+    ec2_client.create_tags({
+      resources: [response.volume_id],
+      tags: [
+        {
+          key: 'Name',
+          value: resource[:name],
+        }
+      ]
+    })
+  end
+
+  def destroy
+    ec2_client.delete_volume({
+      volume_id: @property_hash[:volume_id]
+    })
+  end
+end
+

--- a/lib/puppet/type/ec2_volume.rb
+++ b/lib/puppet/type/ec2_volume.rb
@@ -1,0 +1,27 @@
+require_relative '../../puppet_x/puppetlabs/property/tag.rb'
+
+Puppet::Type.newtype(:ec2_volume) do
+  @doc= 'Type representing EC2 Volumes'
+
+  ensurable
+
+  newparam(:name, namevar: true) do
+    validate do |value|
+      fail Puppet::Error, 'Empty volume names are not allowed' if value == ''
+    end
+  end
+
+  newproperty(:volume_id)
+  newproperty(:volume_type)
+  newproperty(:size)
+  newproperty(:state)
+  newproperty(:availability_zone) do
+    isrequired
+  end
+
+  newproperty(:tags, :parent => PuppetX::Property::AwsTag) do
+    desc 'The tags for the instance.'
+  end
+
+end
+


### PR DESCRIPTION
Without this work, managing volumes independent of Ec2 instances is not
possible using this module.  This is the preliminary work to get
Ec2 Volume management operational under Puppet.

Expect that this will be followed up with adjustments to the
ec2_instance type to allow for attachment of volumes that are managed
outside of the ec2_instance type.  Future work will allow volumes to be
carried from one instance to another as instances are decommissioned,
etc.