### PR TITLE
Add dns_name property to the elb_loadbalancer type

### DIFF
--- a/lib/puppet/provider/elb_loadbalancer/v2.rb
+++ b/lib/puppet/provider/elb_loadbalancer/v2.rb
@@ -22,7 +22,7 @@ Puppet::Type.type(:elb_loadbalancer).provide(:v2, :parent => PuppetX::Puppetlabs
     end.flatten
   end
 
-  read_only(:region, :scheme, :listeners, :tags)
+  read_only(:region, :scheme, :listeners, :tags, :dns_name)
 
   def self.prefetch(resources)
     instances.each do |prov|
@@ -92,6 +92,7 @@ Puppet::Type.type(:elb_loadbalancer).provide(:v2, :parent => PuppetX::Puppetlabs
       subnets: subnet_names,
       security_groups: security_group_names,
       scheme: load_balancer.scheme,
+      dns_name: load_balancer.dns_name,
     }
   end
 

--- a/lib/puppet/type/elb_loadbalancer.rb
+++ b/lib/puppet/type/elb_loadbalancer.rb
@@ -92,6 +92,10 @@ Puppet::Type.newtype(:elb_loadbalancer) do
     end
   end
 
+  newproperty(:dns_name) do
+    desc 'The DNS name of the load balancer'
+  end
+
   validate do
     subnets = self[:subnets] || []
     zones = self[:availability_zones] || []

--- a/spec/unit/type/elb_loadbalancer_spec.rb
+++ b/spec/unit/type/elb_loadbalancer_spec.rb
@@ -36,6 +36,7 @@ describe type_class do
       :security_groups,
       :subnets,
       :scheme,
+      :dns_name,
     ]
   end
 


### PR DESCRIPTION
Without this change, enumerating the elb_loadbalancers does not record
the DNS name of the load balancer.  Here we add a new property so that
the information is available when running 'puppet resource'.