### PR TITLE
Add alias_target property for Route53 types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1097,10 +1097,18 @@ All Route53 record types use the same parameters:
 *Optional* The time to live for the record. Accepts an integer.
 
 #####`values`
-*Required* The values of the record. Accepts an array.
+*Required when not using alias_target* The values of the record. Accepts an array.
+*Conflicts with alias_target*
 
 #####`name`
 *Required* The name of DNS zone group. This is the value of the AWS Name tag.
+
+#####`alias_target`
+*Required when not using values* The name of the alias resource to target.
+*Conflicts with values*
+
+#####`alias_target_zone`
+*Required when using alias_target* The ID of the zone in which the alias_target resides.
 
 #### Type: route53_zone
 

--- a/lib/puppet_x/puppetlabs/route53_record.rb
+++ b/lib/puppet_x/puppetlabs/route53_record.rb
@@ -40,6 +40,21 @@ module PuppetX
           end
         end
 
+        newproperty(:alias_target) do
+          desc 'The name of the alias resource to target'
+          validate do |value|
+            fail 'alias_target values must be strings' unless value.is_a? String
+            fail 'Record names must end with a .' if value[-1] != '.'
+          end
+        end
+
+        newproperty(:alias_target_zone) do
+          desc 'The ID of the zone in which the alias_target resides'
+          validate do |value|
+            fail 'alias_target_zone values must be strings' unless value.is_a? String
+          end
+        end
+
         autorequire(:route53_zone) do
           self[:zone]
         end


### PR DESCRIPTION
The alias_target of a route53 resource record is a stand in value that
allows resources to shift behind the scenes without requiring action on
the part of the user.  Without this change, we are unable to set or
retrieve the alias_target of a route53 record.  Here we simply add a
alias_target property to enumerate the value if its found to exist.