### PR TITLE
Add image_id to read_only Ec2 properties

### DIFF
--- a/lib/puppet/provider/ec2_instance/v2.rb
+++ b/lib/puppet/provider/ec2_instance/v2.rb
@@ -37,9 +37,9 @@ Puppet::Type.type(:ec2_instance).provide(:v2, :parent => PuppetX::Puppetlabs::Aw
     end.flatten
   end
 
-  read_only(:instance_id, :instance_type, :region, :user_data, :key_name,
-            :availability_zones, :security_groups, :monitoring, :subnet,
-            :ebs_optimized, :block_devices, :private_ip_address,
+  read_only(:instance_id, :instance_type, :image_id, :region, :user_data,
+            :key_name, :availability_zones, :security_groups, :monitoring,
+            :subnet, :ebs_optimized, :block_devices, :private_ip_address,
             :iam_instance_profile_arn, :iam_instance_profile_name)
 
   def self.prefetch(resources)


### PR DESCRIPTION
Without this change, modifying the EC2 instance image_id on an existing
instance results in an error from AWS.  Here we append add the image_id
property to the existing list of read-only properties to avoid
attempting the call to AWS.