### PR TITLE
Bump the SDK version to accommodate Ruby 1.9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ def location_for(place, fake_version = nil)
   end
 end
 
-gem 'aws-sdk-core', '2.3.3'
+gem 'aws-sdk-core', '2.4.3'
 gem 'retries'
 
 group :test do


### PR DESCRIPTION
Changes outside of this repo have caused some failures with the
installation of json_pure on Ruby 1.9.  Here just seeing what happens
when we bump to a new version of the SDK.