### PR TITLE
Pin json_pure for ruby 1.9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ group :test do
   gem 'vcr'
   gem 'rspec-puppet', :git => 'https://github.com/rodjek/rspec-puppet.git'
   gem 'metadata-json-lint'
+  gem 'json_pure', '~>1.0' if RUBY_VERSION == '1.9.3'
 end
 
 group :development do


### PR DESCRIPTION
Without this change, building on ruby 1.9 complains about the latest
version of json_pure requiring Ruby 2.x.  Here we pin the version of
json_pure in the case where RUBY_VERSION is set to 1.9.3.  This should
allow us to build on both 1.9 and 2.x.