### PR TITLE
Replace read-only failure with warning

### DIFF
--- a/lib/puppet_x/puppetlabs/aws.rb
+++ b/lib/puppet_x/puppetlabs/aws.rb
@@ -52,7 +52,7 @@ This could be because some other process is modifying AWS at the same time."""
       def self.read_only(*methods)
         methods.each do |method|
           define_method("#{method}=") do |v|
-            fail "#{method} property is read-only once #{resource.type} created."
+            Puppet.warning "#{method} property is read-only once #{resource.type} created."
           end
         end
       end


### PR DESCRIPTION
Currently, if a read-only property is called upon to make a change to an
existing resource, a fail() is called to throw an error to the user,
even though the rest of the run continues.  Notifying the user that the
change will not be made, while definitely useful, is not a failure
condition when operating AWS infrastructure.  If a change is made to
either the resource in Puppet, or the live resource in AWS, which
results in a difference in desired and actual state for one of these
properties, this condition is raised.

To fill in the gaps of what this module currently provides and what is
necessary to be done outside of Puppet, I believe a warning is much more
appropriate, as we still notify the user that a change will not be made,
but also allow for clean(ish) catalog runs so reports report clean.