### PR TITLE
Replace "checking" info with debug

### DIFF
--- a/lib/puppet/provider/cloudwatch_alarm/v2.rb
+++ b/lib/puppet/provider/cloudwatch_alarm/v2.rb
@@ -54,7 +54,7 @@ Puppet::Type.type(:cloudwatch_alarm).provide(:v2, :parent => PuppetX::Puppetlabs
   end
 
   def exists?
-    Puppet.info("Checking if alarm #{name} exists in region #{target_region}")
+    Puppet.debug("Checking if alarm #{name} exists in region #{target_region}")
     @property_hash[:ensure] == :present
   end
 

--- a/lib/puppet/provider/ec2_autoscalinggroup/v2.rb
+++ b/lib/puppet/provider/ec2_autoscalinggroup/v2.rb
@@ -73,7 +73,7 @@ Puppet::Type.type(:ec2_autoscalinggroup).provide(:v2, :parent => PuppetX::Puppet
   end
 
   def exists?
-    Puppet.info("Checking if auto scaling group #{name} exists in region #{target_region}")
+    Puppet.debug("Checking if auto scaling group #{name} exists in region #{target_region}")
     @property_hash[:ensure] == :present
   end
 

--- a/lib/puppet/provider/ec2_elastic_ip/v2.rb
+++ b/lib/puppet/provider/ec2_elastic_ip/v2.rb
@@ -48,7 +48,7 @@ Puppet::Type.type(:ec2_elastic_ip).provide(:v2, :parent => PuppetX::Puppetlabs::
   end
 
   def exists?
-    Puppet.info("Checking if Elastic IP #{name} is associated")
+    Puppet.debug("Checking if Elastic IP #{name} is associated")
     @property_hash[:ensure] == :attached
   end
 

--- a/lib/puppet/provider/ec2_instance/v2.rb
+++ b/lib/puppet/provider/ec2_instance/v2.rb
@@ -102,17 +102,17 @@ Puppet::Type.type(:ec2_instance).provide(:v2, :parent => PuppetX::Puppetlabs::Aw
   end
 
   def exists?
-    Puppet.info("Checking if instance #{name} exists in region #{target_region}")
+    Puppet.debug("Checking if instance #{name} exists in region #{target_region}")
     running? || stopped?
   end
 
   def running?
-    Puppet.info("Checking if instance #{name} is running in region #{target_region}")
+    Puppet.debug("Checking if instance #{name} is running in region #{target_region}")
     [:present, :pending, :running].include? @property_hash[:ensure]
   end
 
   def stopped?
-    Puppet.info("Checking if instance #{name} is stopped in region #{target_region}")
+    Puppet.debug("Checking if instance #{name} is stopped in region #{target_region}")
     [:stopping, :stopped].include? @property_hash[:ensure]
   end
 

--- a/lib/puppet/provider/ec2_launchconfiguration/v2.rb
+++ b/lib/puppet/provider/ec2_launchconfiguration/v2.rb
@@ -54,7 +54,7 @@ Puppet::Type.type(:ec2_launchconfiguration).provide(:v2, :parent => PuppetX::Pup
   end
 
   def exists?
-    Puppet.info("Checking if launch configuration #{name} exists in region #{target_region}")
+    Puppet.debug("Checking if launch configuration #{name} exists in region #{target_region}")
     @property_hash[:ensure] == :present
   end
 

--- a/lib/puppet/provider/ec2_scalingpolicy/v2.rb
+++ b/lib/puppet/provider/ec2_scalingpolicy/v2.rb
@@ -44,7 +44,7 @@ Puppet::Type.type(:ec2_scalingpolicy).provide(:v2, :parent => PuppetX::Puppetlab
   end
 
   def exists?
-    Puppet.info("Checking if scaling policy #{name} exists in region #{target_region}")
+    Puppet.debug("Checking if scaling policy #{name} exists in region #{target_region}")
     @property_hash[:ensure] == :present
   end
 

--- a/lib/puppet/provider/ec2_securitygroup/v2.rb
+++ b/lib/puppet/provider/ec2_securitygroup/v2.rb
@@ -91,7 +91,7 @@ Puppet::Type.type(:ec2_securitygroup).provide(:v2, :parent => PuppetX::Puppetlab
   end
 
   def exists?
-    Puppet.info("Checking if security group #{name} exists in region #{target_region}")
+    Puppet.debug("Checking if security group #{name} exists in region #{target_region}")
     @property_hash[:ensure] == :present
   end
 

--- a/lib/puppet/provider/ec2_vpc/v2.rb
+++ b/lib/puppet/provider/ec2_vpc/v2.rb
@@ -49,7 +49,7 @@ Puppet::Type.type(:ec2_vpc).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) do
   end
 
   def exists?
-    Puppet.info("Checking if VPC #{name} exists in #{target_region}")
+    Puppet.debug("Checking if VPC #{name} exists in #{target_region}")
     @property_hash[:ensure] == :present
   end
 

--- a/lib/puppet/provider/ec2_vpc_customer_gateway/v2.rb
+++ b/lib/puppet/provider/ec2_vpc_customer_gateway/v2.rb
@@ -49,7 +49,7 @@ Puppet::Type.type(:ec2_vpc_customer_gateway).provide(:v2, :parent => PuppetX::Pu
   end
 
   def exists?
-    Puppet.info("Checking if Customer gateway #{name} exists in #{target_region}")
+    Puppet.debug("Checking if Customer gateway #{name} exists in #{target_region}")
     @property_hash[:ensure] == :present
   end
 

--- a/lib/puppet/provider/ec2_vpc_dhcp_options/v2.rb
+++ b/lib/puppet/provider/ec2_vpc_dhcp_options/v2.rb
@@ -55,7 +55,7 @@ Puppet::Type.type(:ec2_vpc_dhcp_options).provide(:v2, :parent => PuppetX::Puppet
   end
 
   def exists?
-    Puppet.info("Checking if DHCP options #{name} exists in region #{target_region}")
+    Puppet.debug("Checking if DHCP options #{name} exists in region #{target_region}")
     @property_hash[:ensure] == :present
   end
 

--- a/lib/puppet/provider/ec2_vpc_internet_gateway/v2.rb
+++ b/lib/puppet/provider/ec2_vpc_internet_gateway/v2.rb
@@ -60,7 +60,7 @@ Puppet::Type.type(:ec2_vpc_internet_gateway).provide(:v2, :parent => PuppetX::Pu
   end
 
   def exists?
-    Puppet.info("Checking if internet gateway #{name} exists in #{target_region}")
+    Puppet.debug("Checking if internet gateway #{name} exists in #{target_region}")
     @property_hash[:ensure] == :present
   end
 

--- a/lib/puppet/provider/ec2_vpc_routetable/v2.rb
+++ b/lib/puppet/provider/ec2_vpc_routetable/v2.rb
@@ -60,7 +60,7 @@ Puppet::Type.type(:ec2_vpc_routetable).provide(:v2, :parent => PuppetX::Puppetla
   end
 
   def exists?
-    Puppet.info("Checking if Route table #{name} exists in #{target_region}")
+    Puppet.debug("Checking if Route table #{name} exists in #{target_region}")
     @property_hash[:ensure] == :present
   end
 

--- a/lib/puppet/provider/ec2_vpc_subnet/v2.rb
+++ b/lib/puppet/provider/ec2_vpc_subnet/v2.rb
@@ -58,7 +58,7 @@ Puppet::Type.type(:ec2_vpc_subnet).provide(:v2, :parent => PuppetX::Puppetlabs::
   end
 
   def exists?
-    Puppet.info("Checking if subnet #{name} exists in #{target_region}")
+    Puppet.debug("Checking if subnet #{name} exists in #{target_region}")
     @property_hash[:ensure] == :present
   end
 

--- a/lib/puppet/provider/ec2_vpc_vpn/v2.rb
+++ b/lib/puppet/provider/ec2_vpc_vpn/v2.rb
@@ -61,7 +61,7 @@ Puppet::Type.type(:ec2_vpc_vpn).provide(:v2, :parent => PuppetX::Puppetlabs::Aws
   end
 
   def exists?
-    Puppet.info("Checking if VPN #{name} exists in region #{target_region}")
+    Puppet.debug("Checking if VPN #{name} exists in region #{target_region}")
     @property_hash[:ensure] == :present
   end
 

--- a/lib/puppet/provider/ec2_vpc_vpn_gateway/v2.rb
+++ b/lib/puppet/provider/ec2_vpc_vpn_gateway/v2.rb
@@ -60,7 +60,7 @@ Puppet::Type.type(:ec2_vpc_vpn_gateway).provide(:v2, :parent => PuppetX::Puppetl
   end
 
   def exists?
-    Puppet.info("Checking if VPN gateway #{name} exists in region #{target_region}")
+    Puppet.debug("Checking if VPN gateway #{name} exists in region #{target_region}")
     @property_hash[:ensure] == :present
   end
 

--- a/lib/puppet/provider/elb_loadbalancer/v2.rb
+++ b/lib/puppet/provider/elb_loadbalancer/v2.rb
@@ -96,7 +96,7 @@ Puppet::Type.type(:elb_loadbalancer).provide(:v2, :parent => PuppetX::Puppetlabs
   end
 
   def exists?
-    Puppet.info("Checking if load balancer #{name} exists in region #{target_region}")
+    Puppet.debug("Checking if load balancer #{name} exists in region #{target_region}")
     @property_hash[:ensure] == :present
   end
 

--- a/lib/puppet/provider/iam_group/v2.rb
+++ b/lib/puppet/provider/iam_group/v2.rb
@@ -30,7 +30,7 @@ Puppet::Type.type(:iam_group).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) 
   end
 
   def exists?
-    Puppet.info("Checking if IAM group #{name} exists")
+    Puppet.debug("Checking if IAM group #{name} exists")
     @property_hash[:ensure] == :present
   end
 

--- a/lib/puppet/provider/iam_policy/v2.rb
+++ b/lib/puppet/provider/iam_policy/v2.rb
@@ -43,7 +43,7 @@ Puppet::Type.type(:iam_policy).provide(:v2, :parent => PuppetX::Puppetlabs::Aws)
   end
 
   def exists?
-    Puppet.info("Checking if IAM policy #{name} exists")
+    Puppet.debug("Checking if IAM policy #{name} exists")
     @property_hash[:ensure] == :present
   end
 

--- a/lib/puppet/provider/iam_user/v2.rb
+++ b/lib/puppet/provider/iam_user/v2.rb
@@ -25,7 +25,7 @@ Puppet::Type.type(:iam_user).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) d
   end
 
   def exists?
-    Puppet.info("Checking if IAM user #{name} exists")
+    Puppet.debug("Checking if IAM user #{name} exists")
     @property_hash[:ensure] == :present
   end
 

--- a/lib/puppet/provider/rds_db_securitygroup/v2.rb
+++ b/lib/puppet/provider/rds_db_securitygroup/v2.rb
@@ -44,7 +44,7 @@ Puppet::Type.type(:rds_db_securitygroup).provide(:v2, :parent => PuppetX::Puppet
   end
 
   def exists?
-    Puppet.info("Checking if DB Security Group #{name} exists")
+    Puppet.debug("Checking if DB Security Group #{name} exists")
     [:present, :creating, :available].include? @property_hash[:ensure]
   end
 

--- a/lib/puppet/provider/rds_instance/v2.rb
+++ b/lib/puppet/provider/rds_instance/v2.rb
@@ -65,7 +65,7 @@ Puppet::Type.type(:rds_instance).provide(:v2, :parent => PuppetX::Puppetlabs::Aw
 
   def exists?
     dest_region = resource[:region] if resource
-    Puppet.info("Checking if instance #{name} exists in region #{dest_region || region}")
+    Puppet.debug("Checking if instance #{name} exists in region #{dest_region || region}")
     [:present, :creating, :available, :backing_up].include? @property_hash[:ensure]
   end
 

--- a/lib/puppet/provider/route53_zone/v2.rb
+++ b/lib/puppet/provider/route53_zone/v2.rb
@@ -25,7 +25,7 @@ Puppet::Type.type(:route53_zone).provide(:v2, :parent => PuppetX::Puppetlabs::Aw
   end
 
   def exists?
-    Puppet.info("Checking if zone #{name} exists")
+    Puppet.debug("Checking if zone #{name} exists")
     @property_hash[:ensure] == :present
   end
 

--- a/lib/puppet/provider/sqs_queue/v2.rb
+++ b/lib/puppet/provider/sqs_queue/v2.rb
@@ -57,7 +57,7 @@ Puppet::Type.type(:sqs_queue).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) 
   end
 
   def exists?
-    Puppet.info("Checking if queue is present")
+    Puppet.debug("Checking if queue is present")
     @property_hash[:ensure] == :present
   end
 


### PR DESCRIPTION
Checking to see if a resource already exists in AWS is something that is
common enough that printing an info message each run for each resource
is not informative.  Knowing what the agent is doing during a catalog
application would be useful for debugging.  As such, here we convert the
Puppet.info to Puppet.debug for the providers' exists?() method to
suppresses the message.