### PR TITLE
Implement retry for ELB request limits

### DIFF
--- a/lib/puppet/provider/elb_loadbalancer/v2.rb
+++ b/lib/puppet/provider/elb_loadbalancer/v2.rb
@@ -7,6 +7,7 @@ Puppet::Type.type(:elb_loadbalancer).provide(:v2, :parent => PuppetX::Puppetlabs
 
   def self.instances
     regions.collect do |region|
+      retries = 0
       begin
         load_balancers = []
         region_client = elb_client(region)
@@ -16,6 +17,16 @@ Puppet::Type.type(:elb_loadbalancer).provide(:v2, :parent => PuppetX::Puppetlabs
           end
         end
         load_balancers
+      rescue Aws::EC2::Errors::RequestLimitExceeded => e
+        retries += 1
+        if retries <= 8
+          sleep_time = 2 ** retries
+          Puppet.debug("Request limit exceeded, retry in #{sleep_time} seconds")
+          sleep(sleep_time)
+          retry
+        else
+          raise PuppetX::Puppetlabs::FetchingAWSDataError.new(region, self.resource_type.name.to_s, e.message)
+        end
       rescue Timeout::Error, StandardError => e
         raise PuppetX::Puppetlabs::FetchingAWSDataError.new(region, self.resource_type.name.to_s, e.message)
       end


### PR DESCRIPTION
During the enumeration of ELB resources, several calls to the AWS API
are made in a short amount of time.  In some cases, this can cause the
API query limits imposed by AWS to be reached.  This is a problem
because puppet fails the resource and all dependent resources when this
occurs.  This change rescues the exception thrown by the aws-sdk
specific to this condition and sleeps a period of time before retrying.