### PR TITLE
Fixed typo for ec2:CreateSecurityGroup action in the example policy.

### DIFF
--- a/examples/iam-profile/README.md
+++ b/examples/iam-profile/README.md
@@ -42,7 +42,7 @@ add to this profile.
         "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
         "elasticloadbalancing:DeleteLoadBalancer",
         "ec2:DescribeSecurityGroups",
-        "ec2:CreateSecurityGroups",
+        "ec2:CreateSecurityGroup",
         "ec2:AuthorizeSecurityGroupIngress",
         "ec2:RevokeSecurityGroupIngress",
         "ec2:DeleteSecurityGroup",

--- a/examples/iam-profile/profile.json
+++ b/examples/iam-profile/profile.json
@@ -17,7 +17,7 @@
         "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
         "elasticloadbalancing:DeleteLoadBalancer",
         "ec2:DescribeSecurityGroups",
-        "ec2:CreateSecurityGroups",
+        "ec2:CreateSecurityGroup",
         "ec2:AuthorizeSecurityGroupIngress",
         "ec2:RevokeSecurityGroupIngress",
         "ec2:DeleteSecurityGroup",


### PR DESCRIPTION
I created a policy as described in your documentation at
https://github.com/puppetlabs/puppetlabs-aws/tree/master/examples/iam-profile
but had problems creating a security group.  The example policy had an action called
`ec2:CreateSecurityGroups` but checking the AWS documentation (see
http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-policies-ec2-console.html) it seems that the action is called `ec2:CreateSecurityGroup`.  I changed the policy in my setup and everything seemed to work OK.  I have submitted this pull request for future reference.