### PR TITLE
New provider and types: iam_instance_profile, iam_role

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ You can use the aws module to audit AWS resources, launch autoscaling groups in 
 * `ec2_vpc_vpn`: Sets up an AWS Virtual Private Network.
 * `ec2_vpc_vpn_gateway`: Sets up a VPN gateway.
 * `iam_group`: Manage IAM groups and their membership.
+* `iam_instance_profile`: Manage IAM instance profiles.
 * `iam_policy`: Manage an IAM 'managed' policy.
 * `iam_policy_attachment`: Manage an IAM 'managed' policy attachments.
 * `iam_role`: Manage an IAM role.
@@ -851,6 +852,24 @@ iam_group { 'root':
 
 #####`members`
 *Required* An array of user names to include in the group.  Users not specified in this array will be removed.
+
+#### Type: iam_instance_profile
+
+```Puppet
+iam_instance_profile { 'my_iam_role':
+  ensure  => present,
+  roles => [ 'my_iam_role' ],
+}
+```
+
+#####`ensure`
+Specifies the basic state of the resource. Valid values are 'present', 'absent'.
+
+#####`name`
+*Required* The name of the IAM instance profile.
+
+#####`roles`
+*Optional* The IAM role(s) to associate this instance profile with.  Accepts an array for multiple roles.
 
 #### Type: iam_policy
 

--- a/README.md
+++ b/README.md
@@ -323,6 +323,7 @@ You can use the aws module to audit AWS resources, launch autoscaling groups in 
 * `iam_group`: Manage IAM groups and their membership.
 * `iam_policy`: Manage an IAM 'managed' policy.
 * `iam_policy_attachment`: Manage an IAM 'managed' policy attachments.
+* `iam_role`: Manage an IAM role.
 * `iam_user`: Manage IAM users.
 * `rds_db_parameter_group`: Allows read access to DB Parameter Groups.
 * `rds_db_securitygroup`: Sets up an RDS DB Security Group.
@@ -910,6 +911,56 @@ iam_policy_attachment { 'root':
 
 #####`roles`
 *Optional* An array of role names to attach to the policy.  **Role names not mentioned in this array will be detached from the policy.**
+
+#### Type: iam_role
+The `iam_role` type manages IAM roles.  
+
+```
+iam_role { 'devtesting':
+  ensure => present,
+  policy_document => '[
+      {
+        "Effect": "Allow",
+        "Principal": {
+          "Service": "ec2.amazonaws.com"
+        },
+        "Action": "sts:AssumeRole"
+      }
+    ]',
+}
+```
+
+All parameters are read-only once created.
+
+#####`ensure`
+Specifies the basic state of the resource. Valid values are 'present', 'absent'
+
+#####`name`
+The name of the IAM role
+
+#####`path`
+Role path (optional)
+
+#####`policy_document`
+A string containing the IAM policy in JSON format which controls which entities may assume this role, e.g. the default:
+ 
+```
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+```
+
+#####`arn`
+The Amazon Resource Name for this IAM role.
 
 #### Type: iam_user
 The `iam_user` type manages user accounts in IAM.  Only the user's name is

--- a/fixtures/vcr_cassettes/create-instance-profile.yml
+++ b/fixtures/vcr_cassettes/create-instance-profile.yml
@@ -1,0 +1,141 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://iam.amazonaws.com/
+    body:
+      encoding: UTF-8
+      string: Action=ListInstanceProfiles&Version=2010-05-08
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby2/2.3.3 ruby/2.1.7 x86_64-darwin14.0
+      X-Amz-Date:
+      - 20160802T182439Z
+      X-Amz-Content-Sha256:
+      - 44d83e3a0f5f6915cab0b95802111050b054a3353097341089af8a6c2ee48399
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=redacted/20160802/us-east-1/iam/aws4_request,
+        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, Signature=222a01c263b05370d9bac5ddcd7ef1b5072e241be12b2726f5ca3e970ee2b5d1
+      Content-Length:
+      - '46'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amzn-Requestid:
+      - 5fc48fe5-58de-11e6-b882-5bb35db703fa
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '1253'
+      Date:
+      - Tue, 02 Aug 2016 18:24:38 GMT
+    body:
+      encoding: UTF-8
+      string: |
+        <ListInstanceProfilesResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
+          <ListInstanceProfilesResult>
+            <IsTruncated>false</IsTruncated>
+            <InstanceProfiles>
+              <member>
+                <Path>/</Path>
+                <Roles>
+                  <member>
+                    <Path>/</Path>
+                    <AssumeRolePolicyDocument>%7B%22Version%22%3A%222012-10-17%22%2C%22Statement%22%3A%5B%7B%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Service%22%3A%22ec2.amazonaws.com%22%7D%2C%22Action%22%3A%22sts%3AAssumeRole%22%7D%5D%7D</AssumeRolePolicyDocument>
+                    <RoleId>AROAJTVOOGRMNHXZHEQKU</RoleId>
+                    <RoleName>devtest</RoleName>
+                    <Arn>arn:aws:iam::111111111111:role/devtest</Arn>
+                    <CreateDate>2016-07-28T20:22:30Z</CreateDate>
+                  </member>
+                </Roles>
+                <InstanceProfileName>devtest</InstanceProfileName>
+                <Arn>arn:aws:iam::111111111111:instance-profile/devtest</Arn>
+                <InstanceProfileId>AIPAIQX3NLS3B64FZNPAU</InstanceProfileId>
+                <CreateDate>2016-07-28T20:22:31Z</CreateDate>
+              </member>
+            </InstanceProfiles>
+          </ListInstanceProfilesResult>
+          <ResponseMetadata>
+            <RequestId>5fc48fe5-58de-11e6-b882-5bb35db703fa</RequestId>
+          </ResponseMetadata>
+        </ListInstanceProfilesResponse>
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 18:24:39 GMT
+- request:
+    method: post
+    uri: https://iam.amazonaws.com/
+    body:
+      encoding: UTF-8
+      string: Action=ListInstanceProfiles&Version=2010-05-08
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby2/2.3.3 ruby/2.1.7 x86_64-darwin14.0
+      X-Amz-Date:
+      - 20160802T182439Z
+      X-Amz-Content-Sha256:
+      - 44d83e3a0f5f6915cab0b95802111050b054a3353097341089af8a6c2ee48399
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=redacted/20160802/us-east-1/iam/aws4_request,
+        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, Signature=222a01c263b05370d9bac5ddcd7ef1b5072e241be12b2726f5ca3e970ee2b5d1
+      Content-Length:
+      - '46'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amzn-Requestid:
+      - 5fd46e73-58de-11e6-b882-5bb35db703fa
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '1253'
+      Date:
+      - Tue, 02 Aug 2016 18:24:38 GMT
+    body:
+      encoding: UTF-8
+      string: |
+        <ListInstanceProfilesResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
+          <ListInstanceProfilesResult>
+            <IsTruncated>false</IsTruncated>
+            <InstanceProfiles>
+              <member>
+                <Path>/</Path>
+                <Roles>
+                  <member>
+                    <Path>/</Path>
+                    <AssumeRolePolicyDocument>%7B%22Version%22%3A%222012-10-17%22%2C%22Statement%22%3A%5B%7B%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Service%22%3A%22ec2.amazonaws.com%22%7D%2C%22Action%22%3A%22sts%3AAssumeRole%22%7D%5D%7D</AssumeRolePolicyDocument>
+                    <RoleId>AROAJTVOOGRMNHXZHEQKU</RoleId>
+                    <RoleName>devtest</RoleName>
+                    <Arn>arn:aws:iam::111111111111:role/devtest</Arn>
+                    <CreateDate>2016-07-28T20:22:30Z</CreateDate>
+                  </member>
+                </Roles>
+                <InstanceProfileName>devtest</InstanceProfileName>
+                <Arn>arn:aws:iam::111111111111:instance-profile/devtest</Arn>
+                <InstanceProfileId>AIPAIQX3NLS3B64FZNPAU</InstanceProfileId>
+                <CreateDate>2016-07-28T20:22:31Z</CreateDate>
+              </member>
+            </InstanceProfiles>
+          </ListInstanceProfilesResult>
+          <ResponseMetadata>
+            <RequestId>5fd46e73-58de-11e6-b882-5bb35db703fa</RequestId>
+          </ResponseMetadata>
+        </ListInstanceProfilesResponse>
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 18:24:39 GMT
+recorded_with: VCR 3.0.3

--- a/fixtures/vcr_cassettes/create-role.yml
+++ b/fixtures/vcr_cassettes/create-role.yml
@@ -1,0 +1,125 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://iam.amazonaws.com/
+    body:
+      encoding: UTF-8
+      string: Action=ListRoles&Version=2010-05-08
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby2/2.3.3 ruby/2.1.7 x86_64-darwin14.0
+      X-Amz-Date:
+      - 20160728T202344Z
+      X-Amz-Content-Sha256:
+      - 8e689dc6b69b17003f0460011582254d8643f0dfb48ac46e093a24df58170b3f
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=redacted/20160728/us-east-1/iam/aws4_request,
+        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date,
+        Signature=bfaf846ce12189c1b0a1346f056397b72de78058195dfe675220da75fcfa7a3b
+      Content-Length:
+      - '35'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amzn-Requestid:
+      - 2e5aa7e2-5501-11e6-b3ac-ab2eb361e21c
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '816'
+      Date:
+      - Thu, 28 Jul 2016 20:23:43 GMT
+    body:
+      encoding: UTF-8
+      string: |
+        <ListRolesResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
+          <ListRolesResult>
+            <IsTruncated>false</IsTruncated>
+            <Roles>
+              <member>
+                <Path>/</Path>
+                <AssumeRolePolicyDocument>%7B%22Version%22%3A%222012-10-17%22%2C%22Statement%22%3A%5B%7B%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Service%22%3A%22ec2.amazonaws.com%22%7D%2C%22Action%22%3A%22sts%3AAssumeRole%22%7D%5D%7D</AssumeRolePolicyDocument>
+                <RoleId>AROAJTVOOGRMNHXZHEQKU</RoleId>
+                <RoleName>devtest</RoleName>
+                <Arn>arn:aws:iam::111111111111:role/devtest</Arn>
+                <CreateDate>2016-07-28T20:22:30Z</CreateDate>
+              </member>
+            </Roles>
+          </ListRolesResult>
+          <ResponseMetadata>
+            <RequestId>2e5aa7e2-5501-11e6-b3ac-ab2eb361e21c</RequestId>
+          </ResponseMetadata>
+        </ListRolesResponse>
+    http_version: 
+  recorded_at: Thu, 28 Jul 2016 20:23:44 GMT
+- request:
+    method: post
+    uri: https://iam.amazonaws.com/
+    body:
+      encoding: UTF-8
+      string: Action=ListRoles&Version=2010-05-08
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby2/2.3.3 ruby/2.1.7 x86_64-darwin14.0
+      X-Amz-Date:
+      - 20160728T202344Z
+      X-Amz-Content-Sha256:
+      - 8e689dc6b69b17003f0460011582254d8643f0dfb48ac46e093a24df58170b3f
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=redacted/20160728/us-east-1/iam/aws4_request,
+        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date,
+        Signature=bfaf846ce12189c1b0a1346f056397b72de78058195dfe675220da75fcfa7a3b
+      Content-Length:
+      - '35'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amzn-Requestid:
+      - 2e736006-5501-11e6-a9a1-2131b69057ae
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '816'
+      Date:
+      - Thu, 28 Jul 2016 20:23:43 GMT
+    body:
+      encoding: UTF-8
+      string: |
+        <ListRolesResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
+          <ListRolesResult>
+            <IsTruncated>false</IsTruncated>
+            <Roles>
+              <member>
+                <Path>/</Path>
+                <AssumeRolePolicyDocument>%7B%22Version%22%3A%222012-10-17%22%2C%22Statement%22%3A%5B%7B%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Service%22%3A%22ec2.amazonaws.com%22%7D%2C%22Action%22%3A%22sts%3AAssumeRole%22%7D%5D%7D</AssumeRolePolicyDocument>
+                <RoleId>AROAJTVOOGRMNHXZHEQKU</RoleId>
+                <RoleName>devtest</RoleName>
+                <Arn>arn:aws:iam::111111111111:role/devtest</Arn>
+                <CreateDate>2016-07-28T20:22:30Z</CreateDate>
+              </member>
+            </Roles>
+          </ListRolesResult>
+          <ResponseMetadata>
+            <RequestId>2e736006-5501-11e6-a9a1-2131b69057ae</RequestId>
+          </ResponseMetadata>
+        </ListRolesResponse>
+    http_version: 
+  recorded_at: Thu, 28 Jul 2016 20:23:44 GMT
+recorded_with: VCR 3.0.3

--- a/fixtures/vcr_cassettes/instance-profiles-named.yml
+++ b/fixtures/vcr_cassettes/instance-profiles-named.yml
@@ -1,0 +1,72 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://iam.amazonaws.com/
+    body:
+      encoding: UTF-8
+      string: Action=ListInstanceProfiles&Version=2010-05-08
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby2/2.3.3 ruby/2.1.7 x86_64-darwin14.0
+      X-Amz-Date:
+      - 20160802T182439Z
+      X-Amz-Content-Sha256:
+      - 44d83e3a0f5f6915cab0b95802111050b054a3353097341089af8a6c2ee48399
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=redacted/20160802/us-east-1/iam/aws4_request,
+        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date, Signature=222a01c263b05370d9bac5ddcd7ef1b5072e241be12b2726f5ca3e970ee2b5d1
+      Content-Length:
+      - '46'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amzn-Requestid:
+      - 5fe92ecc-58de-11e6-945e-5dbedde336ba
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '1253'
+      Date:
+      - Tue, 02 Aug 2016 18:24:38 GMT
+    body:
+      encoding: UTF-8
+      string: |
+        <ListInstanceProfilesResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
+          <ListInstanceProfilesResult>
+            <IsTruncated>false</IsTruncated>
+            <InstanceProfiles>
+              <member>
+                <Path>/</Path>
+                <Roles>
+                  <member>
+                    <Path>/</Path>
+                    <AssumeRolePolicyDocument>%7B%22Version%22%3A%222012-10-17%22%2C%22Statement%22%3A%5B%7B%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Service%22%3A%22ec2.amazonaws.com%22%7D%2C%22Action%22%3A%22sts%3AAssumeRole%22%7D%5D%7D</AssumeRolePolicyDocument>
+                    <RoleId>AROAJTVOOGRMNHXZHEQKU</RoleId>
+                    <RoleName>devtest</RoleName>
+                    <Arn>arn:aws:iam::111111111111:role/devtest</Arn>
+                    <CreateDate>2016-07-28T20:22:30Z</CreateDate>
+                  </member>
+                </Roles>
+                <InstanceProfileName>devtest</InstanceProfileName>
+                <Arn>arn:aws:iam::111111111111:instance-profile/devtest</Arn>
+                <InstanceProfileId>AIPAIQX3NLS3B64FZNPAU</InstanceProfileId>
+                <CreateDate>2016-07-28T20:22:31Z</CreateDate>
+              </member>
+            </InstanceProfiles>
+          </ListInstanceProfilesResult>
+          <ResponseMetadata>
+            <RequestId>5fe92ecc-58de-11e6-945e-5dbedde336ba</RequestId>
+          </ResponseMetadata>
+        </ListInstanceProfilesResponse>
+    http_version: 
+  recorded_at: Tue, 02 Aug 2016 18:24:39 GMT
+recorded_with: VCR 3.0.3

--- a/fixtures/vcr_cassettes/roles-named.yml
+++ b/fixtures/vcr_cassettes/roles-named.yml
@@ -1,0 +1,64 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://iam.amazonaws.com/
+    body:
+      encoding: UTF-8
+      string: Action=ListRoles&Version=2010-05-08
+    headers:
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=utf-8
+      Accept-Encoding:
+      - ''
+      User-Agent:
+      - aws-sdk-ruby2/2.3.3 ruby/2.1.7 x86_64-darwin14.0
+      X-Amz-Date:
+      - 20160728T202344Z
+      X-Amz-Content-Sha256:
+      - 8e689dc6b69b17003f0460011582254d8643f0dfb48ac46e093a24df58170b3f
+      Authorization:
+      - AWS4-HMAC-SHA256 Credential=redacted/20160728/us-east-1/iam/aws4_request,
+        SignedHeaders=content-type;host;x-amz-content-sha256;x-amz-date,
+        Signature=bfaf846ce12189c1b0a1346f056397b72de78058195dfe675220da75fcfa7a3b
+      Content-Length:
+      - '35'
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Amzn-Requestid:
+      - 2e8f4ba7-5501-11e6-945e-5dbedde336ba
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '816'
+      Date:
+      - Thu, 28 Jul 2016 20:23:44 GMT
+    body:
+      encoding: UTF-8
+      string: |
+        <ListRolesResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
+          <ListRolesResult>
+            <IsTruncated>false</IsTruncated>
+            <Roles>
+              <member>
+                <Path>/</Path>
+                <AssumeRolePolicyDocument>%7B%22Version%22%3A%222012-10-17%22%2C%22Statement%22%3A%5B%7B%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Service%22%3A%22ec2.amazonaws.com%22%7D%2C%22Action%22%3A%22sts%3AAssumeRole%22%7D%5D%7D</AssumeRolePolicyDocument>
+                <RoleId>AROAJTVOOGRMNHXZHEQKU</RoleId>
+                <RoleName>devtest</RoleName>
+                <Arn>arn:aws:iam::111111111111:role/devtest</Arn>
+                <CreateDate>2016-07-28T20:22:30Z</CreateDate>
+              </member>
+            </Roles>
+          </ListRolesResult>
+          <ResponseMetadata>
+            <RequestId>2e8f4ba7-5501-11e6-945e-5dbedde336ba</RequestId>
+          </ResponseMetadata>
+        </ListRolesResponse>
+    http_version: 
+  recorded_at: Thu, 28 Jul 2016 20:23:44 GMT
+recorded_with: VCR 3.0.3

--- a/lib/puppet/provider/iam_instance_profile/v2.rb
+++ b/lib/puppet/provider/iam_instance_profile/v2.rb
@@ -1,0 +1,53 @@
+require_relative '../../../puppet_x/puppetlabs/aws.rb'
+
+require 'uri'
+
+Puppet::Type.type(:iam_instance_profile).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) do
+  confine feature: :aws
+
+  mk_resource_methods
+
+  def self.instances
+    response = iam_client.list_instance_profiles()
+    response.instance_profiles.collect do |instance_profile|
+      new({
+              name: instance_profile.instance_profile_name,
+              ensure: :present,
+              path: instance_profile.path,
+              arn: instance_profile.arn,
+              roles: instance_profile.roles,
+          })
+    end
+  end
+
+  def self.prefetch(resources)
+    instances.each do |prov|
+      if resource = resources[prov.name]
+        resource.provider = prov
+      end
+    end
+  end
+
+  def exists?
+    Puppet.info("Checking if IAM instance profile #{name} exists")
+    @property_hash[:ensure] == :present
+  end
+
+  def create
+    Puppet.info("Creating IAM instance profile #{name}")
+
+    iam_client.create_instance_profile({
+                                           instance_profile_name: name,
+                                       })
+
+    @property_hash[:ensure] = :present
+  end
+
+  def destroy
+    Puppet.info("Deleting IAM instnace profile #{name}")
+
+    iam_client.delete_instance_profile({ instance_profile_name: name })
+
+    @property_hash[:ensure] = :absent
+  end
+end

--- a/lib/puppet/provider/iam_instance_profile/v2.rb
+++ b/lib/puppet/provider/iam_instance_profile/v2.rb
@@ -40,6 +40,7 @@ Puppet::Type.type(:iam_instance_profile).provide(:v2, :parent => PuppetX::Puppet
 
     iam_client.create_instance_profile({
                                            instance_profile_name: name,
+                                           path: resource[:path],
                                        })
 
     @property_hash[:ensure] = :present

--- a/lib/puppet/provider/iam_instance_profile/v2.rb
+++ b/lib/puppet/provider/iam_instance_profile/v2.rb
@@ -31,7 +31,7 @@ Puppet::Type.type(:iam_instance_profile).provide(:v2, :parent => PuppetX::Puppet
   end
 
   def exists?
-    Puppet.info("Checking if IAM instance profile #{name} exists")
+    Puppet.debug("Checking if IAM instance profile #{name} exists")
     @property_hash[:ensure] == :present
   end
 
@@ -46,10 +46,10 @@ Puppet::Type.type(:iam_instance_profile).provide(:v2, :parent => PuppetX::Puppet
   end
 
   def roles=(value)
-    Puppet.info("Updating roles for #{name} instance profile")
+    Puppet.debug("Updating roles for #{name} instance profile")
 
     value.to_a.each do |role|
-      Puppet.info("Adding #{role} to instance profile #{name}")
+      Puppet.debug("Adding #{role} to instance profile #{name}")
 
       iam_client.add_role_to_instance_profile({
                                                   instance_profile_name: name,
@@ -59,7 +59,7 @@ Puppet::Type.type(:iam_instance_profile).provide(:v2, :parent => PuppetX::Puppet
 
     missing_roles = resource[:roles].to_a - value.to_a
     missing_roles.to_a.each do |role|
-      Puppet.info("Removing #{role} from instance profile #{name}")
+      Puppet.debug("Removing #{role} from instance profile #{name}")
 
       iam_client.remove_role_from_instance_profile({
                                                   instance_profile_name: name,
@@ -72,7 +72,7 @@ Puppet::Type.type(:iam_instance_profile).provide(:v2, :parent => PuppetX::Puppet
     Puppet.info("Deleting IAM instance profile #{name}")
 
     @property_hash[:roles].to_a.each do |role|
-      Puppet.info("Removing #{role.role_name} from instance profile #{name}")
+      Puppet.debug("Removing #{role.role_name} from instance profile #{name}")
 
       begin
         iam_client.remove_role_from_instance_profile({

--- a/lib/puppet/provider/iam_role/v2.rb
+++ b/lib/puppet/provider/iam_role/v2.rb
@@ -1,0 +1,57 @@
+require_relative '../../../puppet_x/puppetlabs/aws.rb'
+
+require 'uri'
+
+Puppet::Type.type(:iam_role).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) do
+  confine feature: :aws
+
+  mk_resource_methods
+
+  def self.instances
+    response = iam_client.list_roles()
+    response.roles.collect do |role|
+      policy_data = JSON.parse(URI.unescape(role.assume_role_policy_document))
+      policy_document = JSON.pretty_generate(policy_data)
+
+      new({
+              name: role.role_name,
+              ensure: :present,
+              path: role.path,
+              arn: role.arn,
+              policy_document: policy_document,
+          })
+    end
+  end
+
+  def self.prefetch(resources)
+    instances.each do |prov|
+      if resource = resources[prov.name]
+        resource.provider = prov
+      end
+    end
+  end
+
+  def exists?
+    Puppet.info("Checking if IAM role #{name} exists")
+    @property_hash[:ensure] == :present
+  end
+
+  def create
+    Puppet.info("Creating IAM role #{name}")
+
+    iam_client.create_role({
+                               role_name: name,
+                               assume_role_policy_document: resource[:policy_document]
+                           })
+
+    @property_hash[:ensure] = :present
+  end
+
+  def destroy
+    Puppet.info("Deleting IAM role #{name}")
+
+    iam_client.delete_role({role_name: name})
+
+    @property_hash[:ensure] = :absent
+  end
+end

--- a/lib/puppet/provider/iam_role/v2.rb
+++ b/lib/puppet/provider/iam_role/v2.rb
@@ -41,6 +41,7 @@ Puppet::Type.type(:iam_role).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) d
 
     iam_client.create_role({
                                role_name: name,
+                               path: resource[:path],
                                assume_role_policy_document: resource[:policy_document]
                            })
 

--- a/lib/puppet/provider/iam_role/v2.rb
+++ b/lib/puppet/provider/iam_role/v2.rb
@@ -67,7 +67,7 @@ Puppet::Type.type(:iam_role).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) d
     profiles = get_iam_instance_profiles_for_role(name)
 
     profiles.each do |profile|
-      Puppet.info("Removing #{name} from instance profile #{profile.instance_profile_name}")
+      Puppet.debug("Removing #{name} from instance profile #{profile.instance_profile_name}")
 
       iam_client.remove_role_from_instance_profile({
                                                        instance_profile_name: profile.instance_profile_name,
@@ -78,7 +78,7 @@ Puppet::Type.type(:iam_role).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) d
     policies = get_iam_attached_policies_for_role(name)
 
     policies.each do |policy|
-      Puppet.info("Detaching #{policy.policy_arn} from role #{name}")
+      Puppet.debug("Detaching #{policy.policy_arn} from role #{name}")
 
       iam_client.detach_role_policy({
                                         role_name: name,

--- a/lib/puppet/type/iam_instance_profile.rb
+++ b/lib/puppet/type/iam_instance_profile.rb
@@ -23,5 +23,18 @@ Puppet::Type.newtype(:iam_instance_profile) do
 
   newproperty(:arn)
 
-  newproperty(:roles)
+  newproperty(:roles, :array_matching => :all) do
+    desc 'The roles to associate the instance profile.'
+    def insync?(is)
+      is.to_set == should.to_set
+    end
+    validate do |value|
+      fail 'roles should be a String' unless value.is_a?(String)
+    end
+  end
+
+  autorequire(:iam_role) do
+    roles = self[:roles]
+    roles.is_a?(Array) ? roles : [roles]
+  end
 end

--- a/lib/puppet/type/iam_instance_profile.rb
+++ b/lib/puppet/type/iam_instance_profile.rb
@@ -1,0 +1,27 @@
+Puppet::Type.newtype(:iam_instance_profile) do
+  @doc = 'Type representing IAM instance profiles.'
+
+  ensurable
+
+  newparam(:name, namevar: true) do
+    desc 'The name of the instance profile to manage.'
+    validate do |value|
+      fail Puppet::Error, 'Empty instnace profile names are not allowed' if value == ''
+    end
+  end
+
+  newproperty(:path) do
+    desc 'The path of the instance profile.'
+    defaultto '/'
+
+    validate do |value|
+      unless value =~ /^[^\0]+$/
+        raise ArgumentError , "'%s' is not a valid path" % value
+      end
+    end
+  end
+
+  newproperty(:arn)
+
+  newproperty(:roles)
+end

--- a/lib/puppet/type/iam_role.rb
+++ b/lib/puppet/type/iam_role.rb
@@ -1,0 +1,44 @@
+Puppet::Type.newtype(:iam_role) do
+  @doc = 'Type representing IAM role.'
+
+  ensurable
+
+  newparam(:name, namevar: true) do
+    desc 'The name of the role to manage.'
+    validate do |value|
+      fail Puppet::Error, 'Empty role names are not allowed' if value == ''
+    end
+  end
+
+  newproperty(:path) do
+    desc 'The path to the role.'
+    defaultto '/'
+
+    validate do |value|
+      unless value =~ /^[^\0]+$/
+        raise ArgumentError , "'%s' is not a valid path" % value
+      end
+    end
+  end
+
+  newproperty(:policy_document) do
+    desc 'The policy document JSON string'
+    defaultto '{"Version": "2012-10-17", "Statement": [{"Effect": "Allow", "Principal": {"Service": "ec2.amazonaws.com"}, "Action": "sts:AssumeRole"}]}'
+
+    validate do |value|
+      fail Puppet::Error, 'Policy documents must be JSON strings' unless value.is_a? String
+    end
+
+    munge do |value|
+      begin
+        data = JSON.parse(value)
+        JSON.pretty_generate(data)
+      rescue
+        fail('Document string is not valid JSON')
+      end
+    end
+  end
+
+  newproperty(:arn)
+
+end

--- a/lib/puppet/type/iam_role.rb
+++ b/lib/puppet/type/iam_role.rb
@@ -31,10 +31,10 @@ Puppet::Type.newtype(:iam_role) do
 
     munge do |value|
       begin
-        data = JSON.parse(value)
+        data = JSON.parse(CGI::unescapeHTML(value))
         JSON.pretty_generate(data)
-      rescue
-        fail('Document string is not valid JSON')
+      rescue Exception => e
+        fail("Document string is not valid JSON: #{e}")
       end
     end
   end

--- a/spec/acceptance/fixtures/iam_instance_profile.pp.tmpl
+++ b/spec/acceptance/fixtures/iam_instance_profile.pp.tmpl
@@ -1,9 +1,11 @@
 iam_role { '{{role_name}}':
   ensure          => {{ensure}},
+  path            => '{{path}}',
   policy_document => '{{role_policy_document}}',
 }
 
 iam_instance_profile { '{{profile_name}}':
   ensure => {{ensure}},
+  path   => '{{path}}',
   roles  => [ '{{role_name}}' ],
 }

--- a/spec/acceptance/fixtures/iam_instance_profile.pp.tmpl
+++ b/spec/acceptance/fixtures/iam_instance_profile.pp.tmpl
@@ -1,0 +1,9 @@
+iam_role { '{{role_name}}':
+  ensure          => {{ensure}},
+  policy_document => '{{role_policy_document}}',
+}
+
+iam_instance_profile { '{{profile_name}}':
+  ensure => {{ensure}},
+  roles  => [ '{{role_name}}' ],
+}

--- a/spec/acceptance/iam_instance_profile_spec.rb
+++ b/spec/acceptance/iam_instance_profile_spec.rb
@@ -1,0 +1,129 @@
+require 'spec_helper_acceptance'
+require 'securerandom'
+
+describe 'iam_instance_profile' do
+  before(:all) do
+    @default_region = 'us-east-1'
+    @aws = AwsHelper.new(@default_region)
+    @template = 'iam_instance_profile.pp.tmpl'
+  end
+
+  def get_role(name)
+    roles = @aws.get_iam_roles(name)
+    expect(roles.count).to eq(1)
+    roles.first
+  end
+
+  def get_instance_profile(name)
+    instance_profiles = @aws.get_iam_instance_profiles(name)
+    expect(instance_profiles.count).to eq(1)
+    instance_profiles.first
+  end
+
+  describe 'managing as puppet resource' do
+    before :all do
+      @name = "#{SecureRandom.uuid}"
+
+      @config = {
+          :role_name => @name,
+          :profile_name => @name,
+          :ensure => 'present',
+      }
+    end
+
+    it "should create properly with only defaults" do
+      profile_options = { :name => @config[:profile_name], :ensure => @config[:ensure] }
+      result = TestExecutor.puppet_resource('iam_instance_profile', profile_options, '--modulepath spec/fixtures/modules/')
+      expect(result.stderr).not_to match(/Error:/)
+    end
+
+    it "should have the specified name" do
+      profile = get_instance_profile(@config[:profile_name])
+      expect(profile.instance_profile_name).to eq(@config[:profile_name])
+    end
+
+    it "should have a valid ARN" do
+      profile = get_instance_profile(@config[:profile_name])
+      expect(profile.arn).to match(/^arn\:aws\:iam\:\:\d+\:\S+$/)
+    end
+
+    it "should accept a role assignment after the fact" do
+      role_options = { :name => @config[:role_name], :ensure => @config[:ensure] }
+      result = TestExecutor.puppet_resource('iam_role', role_options, '--modulepath spec/fixtures/modules/ --trace')
+      expect(result.stderr).not_to match(/Error:/)
+
+      profile_options = { :name => @config[:profile_name], :ensure => @config[:ensure], :roles => @config[:role_name] }
+      result = TestExecutor.puppet_resource('iam_instance_profile', profile_options, '--modulepath spec/fixtures/modules/ --trace')
+      expect(result.stderr).not_to match(/Error:/)
+    end
+
+    it "should accept policy attachment" do
+      policy_options = { :name => 'IAMFullAccess', :roles => @config[:role_name] }
+      result = TestExecutor.puppet_resource('iam_policy_attachment', policy_options, '--modulepath spec/fixtures/modules/ --trace')
+      expect(result.stderr).not_to match(/Error:/)
+    end
+
+    it "should destroy and cleanup properly" do
+      new_config = @config.update({:ensure => 'absent'})
+
+      role_options = { :name => new_config[:role_name], :ensure => new_config[:ensure] }
+      result = TestExecutor.puppet_resource('iam_role', role_options, '--modulepath spec/fixtures/modules/ --trace')
+      expect(result.stderr).not_to match(/Error:/)
+
+      profile_options = { :name => new_config[:profile_name], :ensure => new_config[:ensure] }
+      result = TestExecutor.puppet_resource('iam_instance_profile', profile_options, '--modulepath spec/fixtures/modules/ --trace')
+      expect(result.stderr).not_to match(/Error:/)
+    end
+
+  end
+
+  describe 'managing via puppet manifest apply' do
+
+    before (:all) do
+      @name = "#{SecureRandom.uuid}"
+      @role_policy_json = <<-'JSON'
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Effect": "Allow",
+                "Principal": {
+                  "Service": "ec2.amazonaws.com"
+                },
+                "Action": "sts:AssumeRole"
+              }
+            ]
+          }
+      JSON
+
+      @config = {
+          :role_name => @name,
+          :profile_name => @name,
+          :role_policy_document => @role_policy_json.strip.gsub(/\r\n?/, " "),
+          :ensure => 'present',
+      }
+    end
+
+    it "should compile and apply" do
+      result = PuppetManifest.new(@template, @config).apply
+      expect(result.stderr).not_to match(/Error:/)
+    end
+
+    it "with the specified name" do
+      profile = get_instance_profile(@config[:profile_name])
+      expect(profile.instance_profile_name).to eq(@config[:profile_name])
+    end
+
+    it "should have valid ARN" do
+      profile = get_instance_profile(@config[:profile_name])
+      expect(profile.arn).to match(/^arn\:aws\:iam\:\:\d+\:\S+$/)
+    end
+
+    it "should cleanup properly" do
+      new_config = @config.update({:ensure => 'absent'})
+      result = PuppetManifest.new(@template, new_config).apply
+      expect(result.stderr).not_to match(/Error:/)
+    end
+  end
+
+end

--- a/spec/acceptance/iam_role_spec.rb
+++ b/spec/acceptance/iam_role_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper_acceptance'
+require 'securerandom'
+
+describe 'iam_role' do
+  before(:all) do
+    @default_region = 'us-east-1'
+    @aws = AwsHelper.new(@default_region)
+  end
+
+  def find_role(name)
+    roles = @aws.get_iam_roles(name)
+    expect(roles.count).to eq(1)
+    roles.first
+  end
+
+  describe 'manage an iam_role' do
+
+    before (:all) do
+      @name = "#{SecureRandom.uuid}"
+      @config = {
+          :name => @name,
+      }
+    end
+
+    it 'with puppet resource' do
+      options = {:name => @config[:name], :ensure => 'present'}
+      result = TestExecutor.puppet_resource('iam_role', options, '--modulepath spec/fixtures/modules/')
+      expect(result.stderr).not_to match(/Error:/)
+      expect{ find_role(@config[:name]) }.not_to raise_error
+    end
+
+    it 'should create an IAM role with the correct name' do
+      role = find_role(@name)
+      expect(role.role_name).to eq(@name)
+    end
+
+    it 'should create an IAM role with a valid ARN' do
+      role = find_role(@name)
+      expect(role.arn).to match(/^arn\:aws\:iam\:\:\d+\:\S+$/)
+    end
+
+    it 'should destroy an IAM role' do
+      options = {:name => @config[:name], :ensure => 'absent'}
+      result = TestExecutor.puppet_resource('iam_role', options, '--modulepath spec/fixtures/modules/')
+      expect(result.stderr).not_to match(/Error:/)
+      expect(@aws.get_iam_roles(@name)).to be_empty
+    end
+
+  end
+
+end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -281,6 +281,19 @@ class AwsHelper
   def get_iam_roles(name)
     @iam_client.list_roles.roles.select { |role| role.role_name == name }
   end
+
+  def get_iam_instance_profiles(name)
+    @iam_client.list_instance_profiles.instance_profiles.select { |instance_profile|
+      instance_profile.instance_profile_name == name
+    }
+  end
+
+  def get_iam_instance_profiles_for_role(name)
+    response = @iam_client.list_instance_profiles_for_role(
+        role_name: [name]
+    )
+    response.data.instance_profiles
+  end
 end
 
 class TestExecutor

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -278,6 +278,9 @@ class AwsHelper
     @iam_client.list_users.users.select { |user| user.user_name == name }
   end
 
+  def get_iam_roles(name)
+    @iam_client.list_roles.roles.select { |role| role.role_name == name }
+  end
 end
 
 class TestExecutor

--- a/spec/unit/provider/iam_instance_profile/v2_spec.rb
+++ b/spec/unit/provider/iam_instance_profile/v2_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+provider_class = Puppet::Type.type(:iam_instance_profile).provider(:v2)
+
+describe provider_class do
+
+  before do
+    ENV['AWS_ACCESS_KEY_ID'] = 'redacted'
+    ENV['AWS_SECRET_ACCESS_KEY'] = 'redacted'
+    ENV['AWS_REGION'] = 'sa-east-1'
+  end
+
+  context 'with the minimum params' do
+    let(:resource) {
+      Puppet::Type.type(:iam_instance_profile).new(
+          name: 'test_instance_profile',
+      )
+    }
+
+    let(:provider) { resource.provider }
+
+    let(:instance) { provider.class.instances.first }
+
+    it 'should be an instance of the ProviderV2' do
+      expect(provider).to be_an_instance_of Puppet::Type::Iam_instance_profile::ProviderV2
+    end
+
+    describe 'self.prefetch' do
+      it 'exists' do
+        VCR.use_cassette('create-instance-profile') do
+          provider.class.instances
+          provider.class.prefetch({})
+        end
+      end
+    end
+
+    describe 'exists?' do
+      it 'should correctly report non-existent instance profiles' do
+        VCR.use_cassette('no-instance-profiles-named') do
+          expect(provider.exists?).to be_falsy
+        end
+      end
+
+      it 'should correctly find existing instance profiles' do
+        VCR.use_cassette('instance-profiles-named') do
+          expect(instance.exists?).to be_truthy
+        end
+      end
+    end
+
+  end
+end

--- a/spec/unit/provider/iam_role/v2_spec.rb
+++ b/spec/unit/provider/iam_role/v2_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+provider_class = Puppet::Type.type(:iam_role).provider(:v2)
+
+describe provider_class do
+
+  before do
+    ENV['AWS_ACCESS_KEY_ID'] = 'redacted'
+    ENV['AWS_SECRET_ACCESS_KEY'] = 'redacted'
+    ENV['AWS_REGION'] = 'sa-east-1'
+  end
+
+  context 'with the minimum params' do
+    let(:resource) {
+      Puppet::Type.type(:iam_role).new(
+          name: 'testrole',
+      )
+    }
+
+    let(:provider) { resource.provider }
+
+    let(:instance) { provider.class.instances.first }
+
+    it 'should be an instance of the ProviderV2' do
+      expect(provider).to be_an_instance_of Puppet::Type::Iam_role::ProviderV2
+    end
+
+    describe 'self.prefetch' do
+      it 'exists' do
+        VCR.use_cassette('create-role') do
+          provider.class.instances
+          provider.class.prefetch({})
+        end
+      end
+    end
+
+    describe 'exists?' do
+      it 'should correctly report non-existent roles' do
+        VCR.use_cassette('no-role-named') do
+          expect(provider.exists?).to be_falsy
+        end
+      end
+
+      it 'should correctly find existing roles' do
+        VCR.use_cassette('roles-named') do
+          expect(instance.exists?).to be_truthy
+        end
+      end
+    end
+
+  end
+end

--- a/spec/unit/type/iam_instance_profile_spec.rb
+++ b/spec/unit/type/iam_instance_profile_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+type_class = Puppet::Type.type(:iam_instance_profile)
+
+describe type_class do
+
+  before do
+    ENV['AWS_ACCESS_KEY_ID'] = 'redacted'
+    ENV['AWS_SECRET_ACCESS_KEY'] = 'redacted'
+    ENV['AWS_REGION'] = 'sa-east-1'
+  end
+
+  let :params do
+    [
+        :name,
+    ]
+  end
+
+  let :properties do
+    [
+        :ensure,
+    ]
+  end
+
+  it 'should have expected properties' do
+    properties.each do |property|
+      expect(type_class.properties.map(&:name)).to be_include(property)
+    end
+  end
+
+  it 'should have expected parameters' do
+    params.each do |param|
+      expect(type_class.parameters).to be_include(param)
+    end
+  end
+
+  it 'should require a name' do
+    expect {
+      type_class.new({})
+    }.to raise_error(Puppet::Error, 'Title or name must be provided')
+  end
+
+  context 'with a valid name' do
+    it 'should create a valid instance' do
+      type_class.new({ name: 'name' })
+    end
+  end
+
+end
+

--- a/spec/unit/type/iam_role_spec.rb
+++ b/spec/unit/type/iam_role_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+type_class = Puppet::Type.type(:iam_role)
+
+describe type_class do
+
+  before do
+    ENV['AWS_ACCESS_KEY_ID'] = 'redacted'
+    ENV['AWS_SECRET_ACCESS_KEY'] = 'redacted'
+    ENV['AWS_REGION'] = 'sa-east-1'
+  end
+
+  let :params do
+    [
+        :name,
+    ]
+  end
+
+  let :properties do
+    [
+        :ensure,
+    ]
+  end
+
+  it 'should have expected properties' do
+    properties.each do |property|
+      expect(type_class.properties.map(&:name)).to be_include(property)
+    end
+  end
+
+  it 'should have expected parameters' do
+    params.each do |param|
+      expect(type_class.parameters).to be_include(param)
+    end
+  end
+
+  it 'should require a name' do
+    expect {
+      type_class.new({})
+    }.to raise_error(Puppet::Error, 'Title or name must be provided')
+  end
+
+  context 'with a valid name' do
+    it 'should create a valid instance' do
+      type_class.new({ name: 'name' })
+    end
+  end
+
+end
+


### PR DESCRIPTION
In order to satisfy our use case of creating IAM roles which can be assigned to EC2 instances, there is the need to introduce the iam_instance_profile resource type, and an associated iam_role resource type.
