### PR TITLE
Add health check management on ELBs

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,25 +187,32 @@ ec2_securitygroup { 'name-of-group':
 
 ~~~
 elb_loadbalancer { 'name-of-load-balancer':
-  ensure               => present,
-  region               => 'us-east-1',
-  availability_zones   => ['us-east-1a', 'us-east-1b'],
-  instances            => ['name-of-instance', 'another-instance'],
-  security_groups      => ['name-of-security-group'],
-  listeners            => [{
-    protocol           => 'HTTP',
-    load_balancer_port => 80,
-    instance_protocol  => 'HTTP',
-    instance_port      => 80,
+  ensure                  => present,
+  region                  => 'us-east-1',
+  availability_zones      => ['us-east-1a', 'us-east-1b'],
+  instances               => ['name-of-instance', 'another-instance'],
+  security_groups         => ['name-of-security-group'],
+  listeners               => [{
+    protocol              => 'HTTP',
+    load_balancer_port    => 80,
+    instance_protocol     => 'HTTP',
+    instance_port         => 80,
   },{
-    protocol           => 'HTTPS',
-    load_balancer_port => 443,
-    instance_protocol  => 'HTTPS',
-    instance_port      => 8080,
-    ssl_certificate_id => 'arn:aws:iam::123456789000:server-certificate/yourcert.com',
+    protocol              => 'HTTPS',
+    load_balancer_port    => 443,
+    instance_protocol     => 'HTTPS',
+    instance_port         => 8080,
+    ssl_certificate_id    => 'arn:aws:iam::123456789000:server-certificate/yourcert.com',
   }],
-  tags                 => {
-    tag_name => 'value',
+  health_check            => {
+    'healthy_threshold'   => '10',
+    'interval'            => '30',
+    'target'              => 'HTTP:80/health_check',
+    'timeout'             => '5',
+    'unhealthy_threshold' => '2'
+  },
+  tags                    => {
+    tag_name              => 'value',
   },
 }
 ~~~
@@ -479,6 +486,15 @@ The Amazon Resource Name for the associated IAM profile.
   * instance_protocol
   * instance_port
   * ssl_certificate_id (optional if protocol is HTTPS )
+
+#####`health_check`
+The configuration for an ELB health check used to determine the health of the
+back- end instances.  Accepts a hash with the following keys:
+  * healthy_threshold
+  * interval
+  * target
+  * timeout
+  * unhealthy_threshold
 
 #####`tags`
 *Optional* The tags for the load balancer. This parameter is set at creation only; it is not affected by updates. Accepts a 'key => value' hash of tags.

--- a/lib/puppet/type/elb_loadbalancer.rb
+++ b/lib/puppet/type/elb_loadbalancer.rb
@@ -42,6 +42,18 @@ Puppet::Type.newtype(:elb_loadbalancer) do
     end
   end
 
+  newproperty(:health_check) do
+    desc 'The health check configuration for the load balancer'
+    def insync?(is)
+      is.sort.to_h == should.sort.to_h
+    end
+    validate do |value|
+      ['target', 'interval', 'timeout', 'unhealthy_threshold', 'healthy_threshold'].each do |key|
+        fail "health_check must include #{key}" unless value.keys.include?(key)
+      end
+    end
+  end
+
   newproperty(:tags, :parent => PuppetX::Property::AwsTag) do
     desc 'The tags for the load balancer.'
   end


### PR DESCRIPTION
Without this change, there is no ability to manage the configuration of
the health_check property on an ELB.  Here we add support for
configuring the healthcheck properties of an ELB.