### PR TITLE
Fix wording for failure

### DIFF
--- a/lib/puppet_x/puppetlabs/route53_record.rb
+++ b/lib/puppet_x/puppetlabs/route53_record.rb
@@ -44,7 +44,7 @@ module PuppetX
           desc 'The name of the alias resource to target'
           validate do |value|
             fail 'alias_target values must be strings' unless value.is_a? String
-            fail 'Record names must end with a .' if value[-1] != '.'
+            fail 'alias_target names must end with a .' if value[-1] != '.'
           end
         end
 


### PR DESCRIPTION
This is a copy paste error that is misleading, as it incorrectly
identifies the property that is failing.