### PR TITLE
Move provider checking to debug

### DIFF
--- a/lib/puppet/provider/route53_record.rb
+++ b/lib/puppet/provider/route53_record.rb
@@ -42,7 +42,7 @@ class Puppet::Provider::Route53Record < PuppetX::Puppetlabs::Aws
   end
 
   def exists?
-    Puppet.info("Checking if #{self.class.record_type} record #{name} exists")
+    Puppet.debug("Checking if #{self.class.record_type} record #{name} exists")
     @property_hash[:ensure] == :present
   end
 


### PR DESCRIPTION
This was missed the last time around due to being outside of the
providers directory.  Here we just move the info to debug as applied to
the rest of the providers duing this same step.