### PR TITLE
Add insync method to load_balancers property

### DIFF
--- a/lib/puppet/type/ecs_service.rb
+++ b/lib/puppet/type/ecs_service.rb
@@ -31,6 +31,10 @@ Puppet::Type.newtype(:ecs_service) do
     munge do |value|
       provider.class.normalize_values(value)
     end
+
+    def insync?(is)
+      provider.class.normalize_values(should) == provider.class.normalize_values(is)
+    end
   end
 
   newproperty(:desired_count) do


### PR DESCRIPTION
Without this change, the comparison of load_balancers fails to detect
identical blobs.  Here we normalize that data during the comparison to
ensure that no changes are reported when the load_balancer that is
matches that load_balancer that should be.