### PR TITLE
Add param to skip image comparison on ECS container

### DIFF
--- a/README.md
+++ b/README.md
@@ -987,6 +987,14 @@ above.
 ##### `volumes`
 An array of hashes to handle for the task.
 
+##### `replace_image`
+A boolean to turn off the replacement of container images.  This enables Puppet
+to create, but not modify the image of a container once created.
+
+This is useful in environments where external CI tooling is responsible for
+modifying the image of a container, allowing a dualistic approach for managing
+ECS.
+
 #### Type: iam_group
 
 ```Puppet

--- a/lib/puppet/type/ecs_task_definition.rb
+++ b/lib/puppet/type/ecs_task_definition.rb
@@ -10,6 +10,12 @@ Puppet::Type.newtype(:ecs_task_definition) do
     end
   end
 
+  newparam(:replace_image) do
+    desc 'Take the image into consideration when comparing the containers'
+    newvalues(:true, :false)
+    defaultto :true
+  end
+
   newproperty(:arn) do
     desc 'Read-only unique AWS resource name assigned to the ECS service'
   end
@@ -27,10 +33,11 @@ Puppet::Type.newtype(:ecs_task_definition) do
     isrequired
     def insync?(is)
       # Compare the merged result of the container_definitions with what *is* currently.
-      one = provider.class.rectify_container_delta(is, should)
+      one = provider.rectify_container_delta(is, should)
       two = provider.class.normalize_values(is)
       one == two
     end
+
   end
 end
 

--- a/spec/unit/provider/ecs_task_definition/v2_spec.rb
+++ b/spec/unit/provider/ecs_task_definition/v2_spec.rb
@@ -69,7 +69,7 @@ describe provider_class do
     end
   end
 
-  describe 'self.rectify_container_delta' do
+  describe 'rectify_container_delta' do
     it 'should return zero results when containers match' do
       VCR.use_cassette('ecs-setup') do
         container_defs = [
@@ -96,7 +96,7 @@ describe provider_class do
           }
         ]
 
-        result = provider.class.rectify_container_delta(container_defs, {})
+        result = provider.rectify_container_delta(container_defs, {})
         expect(result.size).to eq(0)
       end
     end
@@ -152,7 +152,7 @@ describe provider_class do
           }
         ]
 
-        result = provider.class.rectify_container_delta(hsh, wanted)
+        result = provider.rectify_container_delta(hsh, wanted)
         expect(result).to eq(wanted)
         expect(result[0]['image']).to eq('debian:jessie')
         expect(result[1]['image']).to eq('debian:jessie')

--- a/spec/unit/type/ecs_task_definition_spec.rb
+++ b/spec/unit/type/ecs_task_definition_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+type_class = Puppet::Type.type(:ecs_task_definition)
+
+describe type_class do
+  let :params do
+    [
+      :name,
+      :replace_image,
+    ]
+  end
+
+  let :properties do
+    [
+      :arn,
+      :revision,
+      :volumes,
+      :container_definitions,
+    ]
+  end
+
+  it 'should have expected properties' do
+    properties.each do |property|
+      expect(type_class.properties.map(&:name)).to be_include(property)
+    end
+  end
+
+  it 'should have expected parameters' do
+    params.each do |param|
+      expect(type_class.parameters).to be_include(param)
+    end
+  end
+
+end


### PR DESCRIPTION
Without this change, the behavior of puppet is to take all container
properties into consideration during comparison what is with what should
be.  Normally this makes a great deal of sense, but becomes a problem in
environments where an external tool (as part of CI) modifies the image
of a container to reflect the current desired build.  This results in
puppet overwriting the image due to correctly taking the responsibility
of managing the entire container definition.

This change adds a new parameter to the ecs_task_definition type called
'replace_image', which when set to false, will copy the existing image
value from the existing container into the container that puppet reports
"should" be.  This has the effect of ignoring the image that has been
set in Puppet, while still allowing the comparison for all other aspects
of a container to retain existing comparison functionality.