### PR TITLE
Rds snapshot restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -1237,6 +1237,9 @@ is deleted. Defaults to false.
 The name of an associated DB parameter group. Should be a string. This
 parameter is set at creation only; it is not affected by updates.
 
+#####`restore_snapshot
+Specify the snapshot name to optionally trigger creating the RDS DB from a snapshot.
+
 #####`final_db_snapshot_identifier`
 The name of the snapshot created when the instance is terminated. Note
 that skip_final_snapshot must be set to false.

--- a/lib/puppet/provider/rds_instance/v2.rb
+++ b/lib/puppet/provider/rds_instance/v2.rb
@@ -113,8 +113,15 @@ Puppet::Type.type(:rds_instance).provide(:v2, :parent => PuppetX::Puppetlabs::Aw
       availability_zone: resource[:availability_zone],
     }
 
-    rds_client(resource[:region]).create_db_instance(config)
-
+    if resource[:restore_snapshot]
+      Puppet.info("Restoring DB instance #{name} from snapshot #{resource[:restore_snapshot]}")
+      [:engine_version, :backup_retention_period].each { |k| config.delete(k) }
+      config[:db_snapshot_identifier] = resource[:restore_snapshot]
+      rds_client(resource[:region]).restore_db_instance_from_db_snapshot(config)
+    else
+      Puppet.info("Starting DB instance #{name}")
+      rds_client(resource[:region]).create_db_instance(config)
+    end
     @property_hash[:ensure] = :present
   end
 

--- a/lib/puppet/type/rds_instance.rb
+++ b/lib/puppet/type/rds_instance.rb
@@ -213,6 +213,13 @@ Not applicable. Must be null.'
     end
   end
 
+  newproperty(:restore_snapshot) do
+    desc 'The database snapshot to restore as this RDS instance.'
+    validate do |value|
+      fail 'restore_snapshot should be a String' unless value.is_a?(String)
+    end
+  end
+
   autorequire(:rds_db_securitygroup) do
     groups = self[:db_security_groups]
     groups.is_a?(Array) ? groups : [groups]

--- a/spec/unit/provider/rds_instance/v2_spec.rb
+++ b/spec/unit/provider/rds_instance/v2_spec.rb
@@ -24,6 +24,7 @@ describe provider_class do
       master_username: 'awsusername',
       master_user_password: 'the-master-password',
       multi_az: false,
+      restore_snapshot: 'some-snapshot-name',
     )
   }
 

--- a/spec/unit/type/rds_instance_spec.rb
+++ b/spec/unit/type/rds_instance_spec.rb
@@ -35,6 +35,7 @@ describe type_class do
       :db_parameter_group,
       :backup_retention_period,
       :db_subnet,
+      :restore_snapshot,
     ]
   end
 
@@ -91,6 +92,7 @@ describe type_class do
     'master_user_password',
     :db_parameter_group,
     'final_db_snapshot_identifier',
+    'restore_snapshot',
   ].each do |property|
     it "should require #{property} to be a string" do
       expect(type_class).to require_string_for(property)


### PR DESCRIPTION
Adds support for issue #209. Adding the parameter creates the RDS instance using a DB snapshot.

  restore_snapshot => 'some-snapshot-name'
