### PR TITLE
Correction and addition to sample IAM policy for ec2_vpc_dhcp_options

### DIFF
--- a/examples/iam-profile/README.md
+++ b/examples/iam-profile/README.md
@@ -49,6 +49,7 @@ add to this profile.
         "ec2:DescribeVpcs",
         "ec2:CreateVpc",
         "ec2:DeleteVpc",
+        "ec2:AssociateDhcpOptions",
         "ec2:DescribeDhcpOptions",
         "ec2:CreateDhcpOptions",
         "ec2:DeleteDhcpOptions",

--- a/examples/iam-profile/README.md
+++ b/examples/iam-profile/README.md
@@ -51,7 +51,7 @@ add to this profile.
         "ec2:DeleteVpc",
         "ec2:DescribeDhcpOptions",
         "ec2:CreateDhcpOptions",
-        "ec2:DeleteDhcp_options",
+        "ec2:DeleteDhcpOptions",
         "ec2:DescribeCustomerGateways",
         "ec2:CreateCustomerGateway",
         "ec2:DeleteCustomerGateway",

--- a/examples/iam-profile/profile.json
+++ b/examples/iam-profile/profile.json
@@ -26,7 +26,7 @@
         "ec2:DeleteVpc",
         "ec2:DescribeDhcpOptions",
         "ec2:CreateDhcpOptions",
-        "ec2:DeleteDhcp_options",
+        "ec2:DeleteDhcpOptions",
         "ec2:DescribeCustomerGateways",
         "ec2:CreateCustomerGateway",
         "ec2:DeleteCustomerGateway",

--- a/examples/iam-profile/profile.json
+++ b/examples/iam-profile/profile.json
@@ -24,6 +24,7 @@
         "ec2:DescribeVpcs",
         "ec2:CreateVpc",
         "ec2:DeleteVpc",
+        "ec2:AssociateDhcpOptions",
         "ec2:DescribeDhcpOptions",
         "ec2:CreateDhcpOptions",
         "ec2:DeleteDhcpOptions",


### PR DESCRIPTION
Following on from my previous PR (#337).  This PR does the following to ensure that the sample policy operates correctly with `ec2_vpc_dhcp_options`:
- Fixes a typo in `ec2:DeleteDhcpOptions`.
- The `ec2:AssociateDhcpOptions` action is required.
