### PR TITLE
Delete IAM login profile during user delete

### DIFF
--- a/lib/puppet/provider/iam_user/v2.rb
+++ b/lib/puppet/provider/iam_user/v2.rb
@@ -57,6 +57,40 @@ Puppet::Type.type(:iam_user).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) d
     Puppet.info("Deleting IAM user #{name}")
     users = iam_client.list_users.users.select { |user| user.user_name == name }
     users.each do |user|
+      begin
+        iam_client.delete_login_profile({user_name: user.user_name})
+      rescue => e
+        Puppet.debug("Failed to delete the login profile for user #{user.user_name}: #{e.message}")
+      end
+
+      begin
+        iam_client.list_access_keys({user_name: user.user_name}).access_key_metadata.each {|k|
+          pp k
+          iam_client.delete_access_key({
+            user_name: user.user_name,
+            access_key_id: k['access_key_id'],
+          })
+        }
+      rescue => e
+        Puppet.debug("Failed to delete the access keys for user #{user.user_name}: #{e.message}")
+      end
+
+      begin
+        iam_client.list_mfa_devices({user_name: user.user_name}).mfa_devices.each {|k|
+
+          iam_client.deactivate_mfa_device({
+            user_name: user.user_name,
+            serial_number: k['serial_number'],
+          })
+
+          iam_client.delete_virtual_mfa_device({
+            serial_number: k['serial_number'],
+          })
+        }
+      rescue => e
+        Puppet.debug("Failed to delete the MFA devices for user #{user.user_name}: #{e.message}")
+      end
+
       iam_client.delete_user({user_name: user.user_name})
     end
     @property_hash[:ensure] = :absent


### PR DESCRIPTION
Without this change, IAM user deletion fails if the account has MFA
tokens, passwords set, or other access keys assigned to the account.

Here we remove the login profile, access keys, and associated MFA tokens
for the user account.  This allows successful removal of the account.
