### PR TITLE
Improve ELB enumeration performance and stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,9 @@ The Amazon Resource Name for the associated IAM profile.
 ##### `ingress`
 *Optional* Rules for ingress traffic. Accepts an array.
 
+##### `id`
+*Read-only* Unique string enumerated from existing resources uniquely identifying the security group.
+
 ##### `tags`
 *Optional* The tags for the security group. Accepts a 'key => value' hash of tags.
 
@@ -816,6 +819,9 @@ The route table to attach to the subnet. This parameter is set at creation only;
 
 #####`routes`
 *Optional* Individual routes for the routing table. Accepts an array of 'destination_cidr_block' and 'gateway' values:
+
+##### `id`
+*Read-only* Unique string enumerated from existing resources uniquely identifying the subnet.
 
 
 ~~~

--- a/lib/puppet/type/ec2_securitygroup.rb
+++ b/lib/puppet/type/ec2_securitygroup.rb
@@ -56,6 +56,8 @@ Puppet::Type.newtype(:ec2_securitygroup) do
     end
   end
 
+  newproperty(:id)
+
   def should_autorequire?(rule)
     !rule.nil? and rule.key? 'security_group' and rule['security_group'] != name
   end

--- a/lib/puppet/type/ec2_vpc_subnet.rb
+++ b/lib/puppet/type/ec2_vpc_subnet.rb
@@ -62,6 +62,8 @@ Puppet::Type.newtype(:ec2_vpc_subnet) do
     end
   end
 
+  newproperty(:id)
+
   autorequire(:ec2_vpc) do
     self[:vpc]
   end

--- a/lib/puppet/type/elb_loadbalancer.rb
+++ b/lib/puppet/type/elb_loadbalancer.rb
@@ -45,7 +45,7 @@ Puppet::Type.newtype(:elb_loadbalancer) do
   newproperty(:health_check) do
     desc 'The health check configuration for the load balancer'
     def insync?(is)
-      is.sort.to_h == should.sort.to_h
+      provider.class.normalize_values(is) == provider.class.normalize_values(should)
     end
     validate do |value|
       ['target', 'interval', 'timeout', 'unhealthy_threshold', 'healthy_threshold'].each do |key|

--- a/spec/unit/type/ec2_securitygroup_spec.rb
+++ b/spec/unit/type/ec2_securitygroup_spec.rb
@@ -17,6 +17,7 @@ describe type_class do
       :region,
       :ingress,
       :tags,
+      :id,
     ]
   end
 

--- a/spec/unit/type/ec2_vpc_subnet_spec.rb
+++ b/spec/unit/type/ec2_vpc_subnet_spec.rb
@@ -17,6 +17,7 @@ describe type_class do
       :region,
       :availability_zone,
       :vpc,
+      :id,
     ]
   end
 


### PR DESCRIPTION
Without this change, when we need to generate a Hash of all the
information about a particular ELB during the resolution of instances,
and in the process, convert any security group, subnet, and instances
that the ELB is attached to from ID strings into resource names,
subsequent calls are made to the API for each of these enumerations.
This presents a problem due to the number of calls made to the API,
which is three calls to the Ec2 API per ELB.  This is inefficient,
because we have an autorequire that ensures the instances calls on the
relevant puppet resources are already enumerated, meaning that much of
the data we require in the ELB hash generation is already present in
memory, but we make the API calls anyway.  This is only true for
resources under Puppet management, as resources not under puppet
management are thrown away during the instances call for a given
provider.  In environments with lots of ELBs, this can mean that the API
limit on Ec2 is reached, and puppet fails to run, which prevents scaling
and clean runs of Puppet, thus raising the occurrences of swearing.

This work changes the behaviour of the ELB enumeration to first look in
the catalog catalog for the resources that might match, and see if the
relevant data is present before we make the calls to the API.  The
result is that for resources under Puppet management, no extra calls
need to be made to the Ec2 API, thus improving performance and reducing
the risk of reaching the Ec2 API limits.  This also means that there is
an incentive for moving resources under Puppet management, as even those
ELBs that are not managed by Puppet, but are present in the environment
will drag performance down by requiring subsequent calls for the
security groups, subnets, and Ec2 instances related to the particular
ELB.