### PR TITLE
Tags support for rds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1396,6 +1396,9 @@ that skip_final_snapshot must be set to false.
 #####`backup_retention_period`
 The number of days to retain backups. Defaults to 30 days.
 
+#####`tags`
+*Optional* The tags for the instance. Accepts a 'key => value' hash of tags.
+
 #### Type: route53
 
 The route53 types set up various types of Route53 records:

--- a/lib/puppet/type/rds_instance.rb
+++ b/lib/puppet/type/rds_instance.rb
@@ -1,4 +1,5 @@
 require_relative '../../puppet_x/puppetlabs/property/region.rb'
+require_relative '../../puppet_x/puppetlabs/property/tag.rb'
 
 Puppet::Type.newtype(:rds_instance) do
   @doc = 'Type representing an RDS instance.'
@@ -223,4 +224,7 @@ Not applicable. Must be null.'
     groups.is_a?(Array) ? groups : [groups]
   end
 
+  newproperty(:rds_tags, :parent => PuppetX::Property::AwsTag) do
+    desc 'The tags for the db instance.'
+  end
 end

--- a/lib/puppet_x/puppetlabs/aws.rb
+++ b/lib/puppet_x/puppetlabs/aws.rb
@@ -274,6 +274,20 @@ This could be because some other process is modifying AWS at the same time."""
         ) unless missing_tags.empty?
       end
 
+      def rds_tags=(value)
+        Puppet.info("Updating RDS tags for #{name} in region #{target_region}")
+        rds = rds_client(target_region)
+        rds.add_tags_to_resource(
+          resource_name: @property_hash[:arn],
+          tags: value.collect { |k,v| { :key => k, :value => v } }
+        ) unless value.empty?
+        missing_tags = rds_tags.keys - value.keys
+        rds.remove_tags_from_resource(
+          resource_name: @property_hash[:arn],
+          tag_keys: missing_tags.collect { |k| { :key => k } }
+        ) unless missing_tags.empty?
+      end
+
       def self.has_name?(hash)
         !hash[:name].nil? && !hash[:name].empty?
       end

--- a/spec/acceptance/rds_spec.rb
+++ b/spec/acceptance/rds_spec.rb
@@ -34,6 +34,11 @@ describe "rds_instance" do
         :multi_az => false,
         :skip_final_snapshot => true,
         :backup_retention_period => 5,
+        :rds_tags => {
+          :department => 'engineering',
+          :project    => 'cloud',
+          :created_by => 'aws-acceptance'
+        },
       }
 
       @result = PuppetManifest.new(@template, @config).apply
@@ -56,6 +61,10 @@ describe "rds_instance" do
 
     it 'with the specified name' do
       expect(@rds_instance.db_instance_identifier).to eq(@config[:name])
+    end
+
+    it "with the specified tags" do
+      expect(@aws.tag_difference(@rds_instance, @config[:rds_tags])).to be_empty
     end
 
     it 'with the specified db_name' do


### PR DESCRIPTION
Manages RDS tags. Needs sdk version 2.6.11 or greater. 

Allows in manifest:

```
rds_instance { 'foo':
  ...

  rds_tags {
      'key'  => 'value',
      ...
  },
}
```
