### PR TITLE
Remove requirement for unique gateway in route table

### DIFF
--- a/lib/puppet/provider/s3_bucket/v2.rb
+++ b/lib/puppet/provider/s3_bucket/v2.rb
@@ -44,11 +44,8 @@ Puppet::Type.type(:s3_bucket).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) 
   end
 
   def create
-    Puppet.debug("Creating S3 Bucket #{name}")
-    s3_client.create_bucket({
-      bucket: resource[:name],
-      create_bucket_configuration: { location_constraint: resource[:region] }
-    })
+    Puppet.debug("Creating S3 Bucket #{name} in #{target_region}")
+    s3_client(target_region).create_bucket({bucket: name})
   end
 
   def destroy

--- a/lib/puppet/provider/s3_bucket/v2.rb
+++ b/lib/puppet/provider/s3_bucket/v2.rb
@@ -47,7 +47,7 @@ Puppet::Type.type(:s3_bucket).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) 
     Puppet.debug("Creating S3 Bucket #{name} in #{target_region}")
     s3_client(target_region).create_bucket({
       bucket: name,
-      create_bucket_configuration: { location_constraint: resource[:region]}
+      create_bucket_configuration: { location_constraint: resource[:region] }
     })
   end
 

--- a/lib/puppet/provider/s3_bucket/v2.rb
+++ b/lib/puppet/provider/s3_bucket/v2.rb
@@ -45,7 +45,10 @@ Puppet::Type.type(:s3_bucket).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) 
 
   def create
     Puppet.debug("Creating S3 Bucket #{name}")
-    s3_client.create_bucket({bucket: name})
+    s3_client.create_bucket({
+      bucket: resource[:name],
+      create_bucket_configuration: { location_constraint: resource[:region] }
+    })
   end
 
   def destroy

--- a/lib/puppet/provider/s3_bucket/v2.rb
+++ b/lib/puppet/provider/s3_bucket/v2.rb
@@ -47,7 +47,7 @@ Puppet::Type.type(:s3_bucket).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) 
     Puppet.debug("Creating S3 Bucket #{name} in #{target_region}")
     s3_client(target_region).create_bucket({
       bucket: name,
-      create_bucket_configuration: { location_constraint: resource[:region] }
+      create_bucket_configuration: { location_constraint: target_region }
     })
   end
 

--- a/lib/puppet/provider/s3_bucket/v2.rb
+++ b/lib/puppet/provider/s3_bucket/v2.rb
@@ -45,7 +45,10 @@ Puppet::Type.type(:s3_bucket).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) 
 
   def create
     Puppet.debug("Creating S3 Bucket #{name} in #{target_region}")
-    s3_client(target_region).create_bucket({bucket: name})
+    s3_client(target_region).create_bucket({
+      bucket: name,
+      create_bucket_configuration: { location_constraint: resource[:region]}
+    })
   end
 
   def destroy

--- a/lib/puppet/type/ec2_vpc_routetable.rb
+++ b/lib/puppet/type/ec2_vpc_routetable.rb
@@ -47,9 +47,7 @@ Puppet::Type.newtype(:ec2_vpc_routetable) do
   validate do
     routes = self[:routes]
     if routes
-      uniq_gateways = Array(routes).collect { |route| route['gateway'] }.uniq
       uniq_blocks = Array(routes).collect { |route| route['destination_cidr_block'] }.uniq
-      fail 'Only one route per gateway allowed' unless uniq_gateways.size == Array(routes).size
       fail 'destination_cidr_block must be unique' unless uniq_blocks.size == Array(routes).size
     end
   end

--- a/lib/puppet/type/s3_bucket.rb
+++ b/lib/puppet/type/s3_bucket.rb
@@ -30,5 +30,13 @@ Puppet::Type.newtype(:s3_bucket) do
     end
   end
 
+  newproperty(:region) do
+    desc 'The region in which to create the S3 bucket.'
+    validate do |value|
+      fail 'region should not contain spaces' if value =~ /\s/
+      fail 'region should be a String' unless value.is_a?(String)
+    end
+  end
+  
 end
 

--- a/spec/unit/type/s3_bucket_spec.rb
+++ b/spec/unit/type/s3_bucket_spec.rb
@@ -15,6 +15,7 @@ describe type_class do
       :ensure,
       :creation_date,
       :policy,
+      :region,
     ]
   end
 


### PR DESCRIPTION
It's an incorrect assumption that there's only one network behind a gateway. It must for example be possible to route several networks through VPN gateway.

<img width="364" alt="screen shot 2016-10-24 at 3 11 11 pm" src="https://cloud.githubusercontent.com/assets/1838006/19646946/24c77282-99fc-11e6-86c2-5b534ab887fe.png">
