### PR TITLE
Modifying logic behind dhcp_options netbios validation

### DIFF
--- a/lib/puppet/type/ec2_vpc_dhcp_options.rb
+++ b/lib/puppet/type/ec2_vpc_dhcp_options.rb
@@ -68,8 +68,7 @@ Puppet::Type.newtype(:ec2_vpc_dhcp_options) do
   end
 
   newproperty(:netbios_node_type) do
-    desc 'The netbios node type, defaults to 2.'
-    defaultto '2'
+    desc 'The netbios node type, the recommended value is 2 (Point-to-Point). Required if Netbios name server is used.'
     munge do |value|
       value.to_s
     end
@@ -78,5 +77,9 @@ Puppet::Type.newtype(:ec2_vpc_dhcp_options) do
         fail "'%s' is not a valid netbios_node_type, can be [1248]" % value
       end
     end
+  end
+
+  validate do
+    fail ('You must specify netbios node type, when using netbios name server.Recommended value is 2') if !self[:netbios_name_servers].nil? && self[:netbios_node_type].nil?
   end
 end

--- a/spec/unit/type/ec2_vpc_dhcp_options_spec.rb
+++ b/spec/unit/type/ec2_vpc_dhcp_options_spec.rb
@@ -47,9 +47,12 @@ describe type_class do
     }.to raise_error(Puppet::ResourceError, /region should not contain spaces/)
   end
 
-  it 'should default node type to 2' do
-    srv = type_class.new(:name => 'sample')
-    expect(srv[:netbios_node_type]).to eq('2')
+  ['8.8.8.8','2.2.2.2'].each do |value|
+    it 'require netbios node type when netbios name server is used' do
+      expect{
+        type_class.new(:name => 'sample', :netbios_name_servers => value)
+      }.to raise_error(Puppet::ResourceError, /You must specify netbios node type, when using netbios name server.Recommended value is 2/)
+    end
   end
 
   it 'compare a list of domain names with an array correctly' do


### PR DESCRIPTION
netbios node type = '2' is not a default value , rather it is the recommended value. Additionally, not all dhcp_options require the netbios_node_type to be specified. After initial provisioning subsequent runs puppet attempts to add the default value 2 for netbios_node_type, only to fail as it is a read-only (creation time only) value. 

This change improves the description of the netbios_node_type property, and enforces the presence of said property when the netbios_name_servers property is in use. netbios_node_type is a requirement when netbios_name_servers is in use. Will fail when both are not specified. 
