### PR TITLE
Remove requirement for unique gateway in route table

### DIFF
--- a/lib/puppet/type/ec2_vpc_routetable.rb
+++ b/lib/puppet/type/ec2_vpc_routetable.rb
@@ -47,9 +47,7 @@ Puppet::Type.newtype(:ec2_vpc_routetable) do
   validate do
     routes = self[:routes]
     if routes
-      uniq_gateways = Array(routes).collect { |route| route['gateway'] }.uniq
       uniq_blocks = Array(routes).collect { |route| route['destination_cidr_block'] }.uniq
-      fail 'Only one route per gateway allowed' unless uniq_gateways.size == Array(routes).size
       fail 'destination_cidr_block must be unique' unless uniq_blocks.size == Array(routes).size
     end
   end


### PR DESCRIPTION
It's an incorrect assumption that there's only one network behind a gateway. It must for example be possible to route several networks through VPN gateway.

<img width="364" alt="24c77282-99fc-11e6-86c2-5b534ab887fe" src="https://cloud.githubusercontent.com/assets/1838006/19698322/1f41f33e-9aef-11e6-89d2-23dc2cf2a58b.png">
