### PR TITLE
Add support for security_group changes on ec2_instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,6 +454,9 @@ instance.
 #####`iam_instance_profile_arn`
 The Amazon Resource Name for the associated IAM profile.
 
+#####`interfaces`
+The AWS generated interfaces hash for the instance.  Read-only.
+
 #### Type: ec2_securitygroup
 
 ##### `name`

--- a/lib/puppet/type/ec2_instance.rb
+++ b/lib/puppet/type/ec2_instance.rb
@@ -235,6 +235,10 @@ Puppet::Type.newtype(:ec2_instance) do
     end
   end
 
+  newproperty(:interfaces) do
+    desc 'A collected property of the interfaces attached to an instance'
+  end
+
   autorequire(:ec2_securitygroup) do
     groups = self[:security_groups]
     groups.is_a?(Array) ? groups : [groups]

--- a/spec/unit/type/ec2_instance_spec.rb
+++ b/spec/unit/type/ec2_instance_spec.rb
@@ -27,6 +27,7 @@ describe type_class do
       :subnet,
       :ebs_optimized,
       :iam_instance_profile_arn,
+      :interfaces,
     ]
   end
 


### PR DESCRIPTION
Without this work, the security_groups parameter on the ec2_instance
type is marked as read-only.  Here we remove the security_groups
parameter from the read-only list and implement a setter method and the
necessary flush logic to modify the security groups attached to an
interface.

This is currently only implemented for instances with a single
interface, as the modification for what security groups are associated
with an instance is a change needed on the interface, and not the
instance.  This is a bit confusing because the interface security groups
are represented on both the main instance object, and the interface
object.  For this reason, a new read-only parameter is also added here
to collect information about the interfaces interfaces to ensure that we
are only modifying the instances we know how, as well as collecting the
data to get the interface ID for modification in the flush method.