### PR TITLE
Feature/autoscale update

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,8 +597,14 @@ back- end instances.  Accepts a hash with the following keys:
 ##### `load_balancers`
 *Optional* A list of load balancer names that should be attached to this autoscaling group.
 
+##### `target_groups`
+*Optional* A list of ELBv2 Target Group names that should be attached to this autoscaling group.
+
 ##### `subnets`
 *Optional* The subnets to associate with the autoscaling group.
+
+##### `termination_policies`
+*Optional* A list of termination policies to use when scaling in instances. For valid termination policies, see [Controlling Which Instances Auto Scaling Terminates During Scale In](http://docs.aws.amazon.com/autoscaling/latest/userguide/as-instance-termination.html).
 
 #####`tags`
 *Optional* The tags to assign to the autoscaling group. Accepts a 'key => value' hash of tags. The tags are not propagated to launched instances.

--- a/lib/puppet/provider/ec2_launchconfiguration/v2.rb
+++ b/lib/puppet/provider/ec2_launchconfiguration/v2.rb
@@ -62,7 +62,11 @@ Puppet::Type.type(:ec2_launchconfiguration).provide(:v2, :parent => PuppetX::Pup
       spot_price: config.spot_price,
       ebs_optimized: config.ebs_optimized,
     }
-    config[:block_device_mappings] = devices unless devices.empty?
+    if devices.empty?
+      config[:block_device_mappings] = [ ]
+    else
+      config[:block_device_mappings] = devices
+    end
     config
   end
 

--- a/lib/puppet/type/ec2_autoscalinggroup.rb
+++ b/lib/puppet/type/ec2_autoscalinggroup.rb
@@ -135,6 +135,24 @@ Puppet::Type.newtype(:ec2_autoscalinggroup) do
     end
   end
 
+  newproperty(:target_groups, :array_matching => :all) do
+    desc 'The target groups attached to this group.'
+    validate do |value|
+      fail 'target_groups cannot be blank' if value == ''
+      fail 'target_groups should be a String' unless value.is_a?(String)
+    end
+    def insync?(is)
+      is.to_set == should.to_set
+    end
+  end
+
+  newproperty(:termination_policies, :array_matching => :all) do
+    desc 'The termination policies attached to this group.'
+    def insync?(is)
+      is.to_set == should.to_set
+    end
+  end
+
   newproperty(:subnets, :array_matching => :all) do
     desc 'The subnets to associate the autoscaling group.'
     validate do |value|

--- a/lib/puppet_x/puppetlabs/aws.rb
+++ b/lib/puppet_x/puppetlabs/aws.rb
@@ -162,6 +162,14 @@ This could be because some other process is modifying AWS at the same time."""
         self.class.elb_client(region)
       end
 
+      def self.elbv2_client(region = default_region)
+        ::Aws::ElasticLoadBalancingV2::Client.new(client_config(region))
+      end
+
+      def elbv2_client(region = default_region)
+        self.class.elbv2_client(region)
+      end
+
       def self.autoscaling_client(region = default_region)
         ::Aws::AutoScaling::Client.new(client_config(region))
       end


### PR DESCRIPTION
Hi, this is a first attempt at adding some of the new functionality to the ec2_autoscalegroup resource.
It allows for the setting of the Termination Policies and Target Groups (feature of elbv2)