### PR TITLE
Attempt fix hash method call on nil object

### DIFF
--- a/lib/puppet/provider/rds_instance/v2.rb
+++ b/lib/puppet/provider/rds_instance/v2.rb
@@ -134,7 +134,7 @@ Puppet::Type.type(:rds_instance).provide(:v2, :parent => PuppetX::Puppetlabs::Aw
   end
 
   def flush
-    if @property_hash[:ensure] != :absent
+    if @property_hash[:ensure] != :absent and not @property_flush.nil?
       Puppet.debug("Flushing RDS instance for #{@property_hash[:name]}")
 
       if @property_flush.keys.size > 0


### PR DESCRIPTION
Without this change, we call '.keys' on a nil object.  The 'initialize'
method should have set the 'property_flush' to an empty hash, so I'm a
little confused about why this is required.