### PR TITLE
Add support for ELB listener modifications

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,8 +50,9 @@ group :development do
   gem 'rubocop-rspec', '~> 1.6',            :require => false if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.3.0')
   gem 'pry',                                :require => false
   gem 'json_pure', '<= 2.0.1',              :require => false if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0.0')
-  gem 'json', '<= 2.0.0',              :require => false if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0.0')
-  gem 'webmock'
+  gem 'json', '<= 2.0.0',                   :require => false if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0.0')
+  gem 'webmock',                            :require => false if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.0.0')
+  gem 'webmock', '~> 1.24',                 :require => false if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0.0')
   gem 'public_suffix', '< 1.5.0'            if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0.0')
   gem 'vcr'
 end

--- a/README.md
+++ b/README.md
@@ -490,12 +490,14 @@ The AWS generated interfaces hash for the instance.  Read-only.
 *Required* The region in which to launch the load balancer. For valid values, see [AWS Regions](http://docs.aws.amazon.com/general/latest/gr/rande.html#ec2_region).
 
 #####`listeners`
-*Required* The ports and protocols the load balancer listens to. This parameter is set at creation only; it is not affected by updates. Accepts an array of the following values:
+*Required* The ports and protocols the load balancer listens to.  Accepts an
+array of the following values:
   * protocol
   * load_balancer_port
   * instance_protocol
   * instance_port
-  * ssl_certificate_id (optional if protocol is HTTPS )
+  * ssl_certificate_id (required if protocol is HTTPS)
+  * policy_names (optional array of policy name strings for HTTPS)
 
 #####`health_check`
 The configuration for an ELB health check used to determine the health of the

--- a/lib/puppet/type/elb_loadbalancer.rb
+++ b/lib/puppet/type/elb_loadbalancer.rb
@@ -24,12 +24,13 @@ Puppet::Type.newtype(:elb_loadbalancer) do
   newproperty(:listeners, :array_matching => :all) do
     desc 'The ports and protocols the load balancer listens to.'
     def insync?(is)
-      normalise(is).to_set == normalise(should).to_set
-    end
-    def normalise(listeners)
-      listeners.collect do |obj|
+      one = provider.class.normalize_values(is).collect do |obj|
         obj.each { |k,v| obj[k] = v.to_s.downcase }
       end
+      two = provider.class.normalize_values(should).collect do |obj|
+        obj.each { |k,v| obj[k] = v.to_s.downcase }
+      end
+      one == two
     end
     validate do |value|
       value = [value] unless value.is_a?(Array)


### PR DESCRIPTION
Without this change, the listeners on elb_loadbalancer resources are
marked as read-only in the type and are thus not modifiable.  This work
adds support for modifying listeners and setting the 'policy' for HTTPS
listeners to control which cipher suites are available.