### PR TITLE
Bump the SDK gem version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ end
 # Used for gem conditionals
 supports_windows = false
 
-gem 'aws-sdk-core', '2.3.22'
+gem 'aws-sdk-core', '2.6.38'
 gem 'retries'
 
 group :development do


### PR DESCRIPTION
This work updates the SDK to be newer.  This will be required for
several items going in currently, as well as work that is planned to be
submitted around CloudFront soon.