### PR TITLE
Allows specifying public and private ip address.

### DIFF
--- a/lib/puppet/provider/ec2_instance/v2.rb
+++ b/lib/puppet/provider/ec2_instance/v2.rb
@@ -270,13 +270,15 @@ Found #{matching_groups.length}:
         associate_public_ip_address: true,
       }]
       # If both public and private ip specified, then the private_ip_address must be within the network_interfaces structure
+      #  Module currently only supports a single network interface, therefore attatch any specified private ip address
+      #  to the first network interface.
       if resource['private_ip_address'] && using_vpc?
-      	config[:network_interfaces].first[:private_ip_address] = resource['private_ip_address']
+        config[:network_interfaces].first[:private_ip_address] = resource['private_ip_address']
       end
       config[:subnet_id] = nil
       config[:security_group_ids] = nil
     elsif resource['private_ip_address'] && using_vpc?
-      config['private_ip_address'] = resource['private_ip_address'] if resource['private_ip_address'] && using_vpc?
+      config['private_ip_address'] = resource['private_ip_address']
     end
 
     config


### PR DESCRIPTION
If both public and private ip are specified then the private_ip_address must be within the network interface structure. Otherwise an error is returned from the API request that looks like this:

"Network interfaces and an instance-level private IP address may not be specified on the same request"