### PR TITLE
(maint) Comment out iam acceptance tests

### DIFF
--- a/spec/acceptance/iam_instance_profile_spec.rb
+++ b/spec/acceptance/iam_instance_profile_spec.rb
@@ -1,134 +1,134 @@
-require 'spec_helper_acceptance'
-require 'securerandom'
-
-describe 'iam_instance_profile' do
-  before(:all) do
-    @default_region = 'us-east-1'
-    @aws = AwsHelper.new(@default_region)
-    @template = 'iam_instance_profile.pp.tmpl'
-  end
-
-  def get_role(name)
-    roles = @aws.get_iam_roles(name)
-    expect(roles.count).to eq(1)
-    roles.first
-  end
-
-  def get_instance_profile(name)
-    instance_profiles = @aws.get_iam_instance_profiles(name)
-    expect(instance_profiles.count).to eq(1)
-    instance_profiles.first
-  end
-
-  describe 'managing as puppet resource' do
-    before :all do
-      @name = "#{SecureRandom.uuid}"
-
-      @config = {
-          :role_name => @name,
-          :profile_name => @name,
-          :path_prefix => "/#{SecureRandom.hex(8)}/",
-          :ensure => 'present',
-      }
-    end
-
-    it "should create properly with only defaults" do
-      profile_options = { :name => @config[:profile_name], :path => @config[:path_prefix], :ensure => @config[:ensure] }
-      result = TestExecutor.puppet_resource('iam_instance_profile', profile_options, '--modulepath spec/fixtures/modules/')
-      expect(result.stderr).not_to match(/Error:/)
-    end
-
-    it "should have the specified name" do
-      profile = get_instance_profile(@config[:profile_name])
-      expect(profile.instance_profile_name).to eq(@config[:profile_name])
-    end
-
-    it "should have a valid ARN" do
-      profile = get_instance_profile(@config[:profile_name])
-      expect(profile.arn).to match(/^arn\:aws\:iam\:\:\d+\:\S+$/)
-      expect(profile.arn).to include("#{@config[:path]}#{@config[:profile_name]}")
-    end
-
-    it "should accept a role assignment after the fact" do
-      role_options = { :name => @config[:role_name], :path => @config[:path_prefix], :ensure => @config[:ensure] }
-      result = TestExecutor.puppet_resource('iam_role', role_options, '--modulepath spec/fixtures/modules/ --trace')
-      expect(result.stderr).not_to match(/Error:/)
-
-      profile_options = { :name => @config[:profile_name], :path => @config[:path_prefix], :ensure => @config[:ensure], :roles => @config[:role_name] }
-      result = TestExecutor.puppet_resource('iam_instance_profile', profile_options, '--modulepath spec/fixtures/modules/ --trace')
-      expect(result.stderr).not_to match(/Error:/)
-    end
-
-    it "should accept policy attachment" do
-      policy_options = { :name => 'IAMFullAccess', :roles => @config[:role_name] }
-      result = TestExecutor.puppet_resource('iam_policy_attachment', policy_options, '--modulepath spec/fixtures/modules/ --trace')
-      expect(result.stderr).not_to match(/Error:/)
-    end
-
-    it "should destroy and cleanup properly" do
-      new_config = @config.update({:ensure => 'absent'})
-
-      role_options = { :name => new_config[:role_name], :path => @config[:path_prefix], :ensure => new_config[:ensure] }
-      result = TestExecutor.puppet_resource('iam_role', role_options, '--modulepath spec/fixtures/modules/ --trace')
-      expect(result.stderr).not_to match(/Error:/)
-
-      profile_options = { :name => new_config[:profile_name], :path => @config[:path_prefix], :ensure => new_config[:ensure] }
-      result = TestExecutor.puppet_resource('iam_instance_profile', profile_options, '--modulepath spec/fixtures/modules/ --trace')
-      expect(result.stderr).not_to match(/Error:/)
-    end
-
-  end
-
-  describe 'managing via puppet manifest apply' do
-
-    before (:all) do
-      @name = "#{SecureRandom.uuid}"
-      @path_prefix = "/#{SecureRandom.hex(8)}/"
-      @role_policy_json = <<-'JSON'
-          {
-            "Version": "2012-10-17",
-            "Statement": [
-              {
-                "Effect": "Allow",
-                "Principal": {
-                  "Service": "ec2.amazonaws.com"
-                },
-                "Action": "sts:AssumeRole"
-              }
-            ]
-          }
-      JSON
-
-      @config = {
-          :role_name => @name,
-          :profile_name => @name,
-          :path => @path_prefix,
-          :role_policy_document => @role_policy_json.strip.gsub(/\r\n?/, " "),
-          :ensure => 'present',
-      }
-    end
-
-    it "should compile and apply" do
-      result = PuppetManifest.new(@template, @config).apply
-      expect(result.stderr).not_to match(/Error:/)
-    end
-
-    it "with the specified name" do
-      profile = get_instance_profile(@config[:profile_name])
-      expect(profile.instance_profile_name).to eq(@config[:profile_name])
-    end
-
-    it "should have valid ARN" do
-      profile = get_instance_profile(@config[:profile_name])
-      expect(profile.arn).to match(/^arn\:aws\:iam\:\:\d+\:\S+$/)
-      expect(profile.arn).to include("#{@config[:path]}#{@config[:profile_name]}")
-    end
-
-    it "should cleanup properly" do
-      new_config = @config.update({:ensure => 'absent'})
-      result = PuppetManifest.new(@template, new_config).apply
-      expect(result.stderr).not_to match(/Error:/)
-    end
-  end
-
-end
+#require 'spec_helper_acceptance'
+#require 'securerandom'
+#
+#describe 'iam_instance_profile' do
+#  before(:all) do
+#    @default_region = 'us-east-1'
+#    @aws = AwsHelper.new(@default_region)
+#    @template = 'iam_instance_profile.pp.tmpl'
+#  end
+#
+#  def get_role(name)
+#    roles = @aws.get_iam_roles(name)
+#    expect(roles.count).to eq(1)
+#    roles.first
+#  end
+#
+#  def get_instance_profile(name)
+#    instance_profiles = @aws.get_iam_instance_profiles(name)
+#    expect(instance_profiles.count).to eq(1)
+#    instance_profiles.first
+#  end
+#
+#  describe 'managing as puppet resource' do
+#    before :all do
+#      @name = "#{SecureRandom.uuid}"
+#
+#      @config = {
+#          :role_name => @name,
+#          :profile_name => @name,
+#          :path_prefix => "/#{SecureRandom.hex(8)}/",
+#          :ensure => 'present',
+#      }
+#    end
+#
+#    it "should create properly with only defaults" do
+#      profile_options = { :name => @config[:profile_name], :path => @config[:path_prefix], :ensure => @config[:ensure] }
+#      result = TestExecutor.puppet_resource('iam_instance_profile', profile_options, '--modulepath spec/fixtures/modules/')
+#      expect(result.stderr).not_to match(/Error:/)
+#    end
+#
+#    it "should have the specified name" do
+#      profile = get_instance_profile(@config[:profile_name])
+#      expect(profile.instance_profile_name).to eq(@config[:profile_name])
+#    end
+#
+#    it "should have a valid ARN" do
+#      profile = get_instance_profile(@config[:profile_name])
+#      expect(profile.arn).to match(/^arn\:aws\:iam\:\:\d+\:\S+$/)
+#      expect(profile.arn).to include("#{@config[:path]}#{@config[:profile_name]}")
+#    end
+#
+#    it "should accept a role assignment after the fact" do
+#      role_options = { :name => @config[:role_name], :path => @config[:path_prefix], :ensure => @config[:ensure] }
+#      result = TestExecutor.puppet_resource('iam_role', role_options, '--modulepath spec/fixtures/modules/ --trace')
+#      expect(result.stderr).not_to match(/Error:/)
+#
+#      profile_options = { :name => @config[:profile_name], :path => @config[:path_prefix], :ensure => @config[:ensure], :roles => @config[:role_name] }
+#      result = TestExecutor.puppet_resource('iam_instance_profile', profile_options, '--modulepath spec/fixtures/modules/ --trace')
+#      expect(result.stderr).not_to match(/Error:/)
+#    end
+#
+#    it "should accept policy attachment" do
+#      policy_options = { :name => 'IAMFullAccess', :roles => @config[:role_name] }
+#      result = TestExecutor.puppet_resource('iam_policy_attachment', policy_options, '--modulepath spec/fixtures/modules/ --trace')
+#      expect(result.stderr).not_to match(/Error:/)
+#    end
+#
+#    it "should destroy and cleanup properly" do
+#      new_config = @config.update({:ensure => 'absent'})
+#
+#      role_options = { :name => new_config[:role_name], :path => @config[:path_prefix], :ensure => new_config[:ensure] }
+#      result = TestExecutor.puppet_resource('iam_role', role_options, '--modulepath spec/fixtures/modules/ --trace')
+#      expect(result.stderr).not_to match(/Error:/)
+#
+#      profile_options = { :name => new_config[:profile_name], :path => @config[:path_prefix], :ensure => new_config[:ensure] }
+#      result = TestExecutor.puppet_resource('iam_instance_profile', profile_options, '--modulepath spec/fixtures/modules/ --trace')
+#      expect(result.stderr).not_to match(/Error:/)
+#    end
+#
+#  end
+#
+#  describe 'managing via puppet manifest apply' do
+#
+#    before (:all) do
+#      @name = "#{SecureRandom.uuid}"
+#      @path_prefix = "/#{SecureRandom.hex(8)}/"
+#      @role_policy_json = <<-'JSON'
+#          {
+#            "Version": "2012-10-17",
+#            "Statement": [
+#              {
+#                "Effect": "Allow",
+#                "Principal": {
+#                  "Service": "ec2.amazonaws.com"
+#                },
+#                "Action": "sts:AssumeRole"
+#              }
+#            ]
+#          }
+#      JSON
+#
+#      @config = {
+#          :role_name => @name,
+#          :profile_name => @name,
+#          :path => @path_prefix,
+#          :role_policy_document => @role_policy_json.strip.gsub(/\r\n?/, " "),
+#          :ensure => 'present',
+#      }
+#    end
+#
+#    it "should compile and apply" do
+#      result = PuppetManifest.new(@template, @config).apply
+#      expect(result.stderr).not_to match(/Error:/)
+#    end
+#
+#    it "with the specified name" do
+#      profile = get_instance_profile(@config[:profile_name])
+#      expect(profile.instance_profile_name).to eq(@config[:profile_name])
+#    end
+#
+#    it "should have valid ARN" do
+#      profile = get_instance_profile(@config[:profile_name])
+#      expect(profile.arn).to match(/^arn\:aws\:iam\:\:\d+\:\S+$/)
+#      expect(profile.arn).to include("#{@config[:path]}#{@config[:profile_name]}")
+#    end
+#
+#    it "should cleanup properly" do
+#      new_config = @config.update({:ensure => 'absent'})
+#      result = PuppetManifest.new(@template, new_config).apply
+#      expect(result.stderr).not_to match(/Error:/)
+#    end
+#  end
+#
+#end

--- a/spec/acceptance/iam_role_spec.rb
+++ b/spec/acceptance/iam_role_spec.rb
@@ -1,51 +1,51 @@
-require 'spec_helper_acceptance'
-require 'securerandom'
-
-describe 'iam_role' do
-  before(:all) do
-    @default_region = 'us-east-1'
-    @aws = AwsHelper.new(@default_region)
-  end
-
-  def find_role(name)
-    roles = @aws.get_iam_roles(name)
-    expect(roles.count).to eq(1)
-    roles.first
-  end
-
-  describe 'manage an iam_role' do
-
-    before (:all) do
-      @name = "#{SecureRandom.uuid}"
-      @config = {
-          :name => @name,
-      }
-    end
-
-    it 'with puppet resource' do
-      options = {:name => @config[:name], :ensure => 'present'}
-      result = TestExecutor.puppet_resource('iam_role', options, '--modulepath spec/fixtures/modules/')
-      expect(result.stderr).not_to match(/Error:/)
-      expect{ find_role(@config[:name]) }.not_to raise_error
-    end
-
-    it 'should create an IAM role with the correct name' do
-      role = find_role(@name)
-      expect(role.role_name).to eq(@name)
-    end
-
-    it 'should create an IAM role with a valid ARN' do
-      role = find_role(@name)
-      expect(role.arn).to match(/^arn\:aws\:iam\:\:\d+\:\S+$/)
-    end
-
-    it 'should destroy an IAM role' do
-      options = {:name => @config[:name], :ensure => 'absent'}
-      result = TestExecutor.puppet_resource('iam_role', options, '--modulepath spec/fixtures/modules/')
-      expect(result.stderr).not_to match(/Error:/)
-      expect(@aws.get_iam_roles(@name)).to be_empty
-    end
-
-  end
-
-end
+#require 'spec_helper_acceptance'
+#require 'securerandom'
+#
+#describe 'iam_role' do
+#  before(:all) do
+#    @default_region = 'us-east-1'
+#    @aws = AwsHelper.new(@default_region)
+#  end
+#
+#  def find_role(name)
+#    roles = @aws.get_iam_roles(name)
+#    expect(roles.count).to eq(1)
+#    roles.first
+#  end
+#
+#  describe 'manage an iam_role' do
+#
+#    before (:all) do
+#      @name = "#{SecureRandom.uuid}"
+#      @config = {
+#          :name => @name,
+#      }
+#    end
+#
+#    it 'with puppet resource' do
+#      options = {:name => @config[:name], :ensure => 'present'}
+#      result = TestExecutor.puppet_resource('iam_role', options, '--modulepath spec/fixtures/modules/')
+#      expect(result.stderr).not_to match(/Error:/)
+#      expect{ find_role(@config[:name]) }.not_to raise_error
+#    end
+#
+#    it 'should create an IAM role with the correct name' do
+#      role = find_role(@name)
+#      expect(role.role_name).to eq(@name)
+#    end
+#
+#    it 'should create an IAM role with a valid ARN' do
+#      role = find_role(@name)
+#      expect(role.arn).to match(/^arn\:aws\:iam\:\:\d+\:\S+$/)
+#    end
+#
+#    it 'should destroy an IAM role' do
+#      options = {:name => @config[:name], :ensure => 'absent'}
+#      result = TestExecutor.puppet_resource('iam_role', options, '--modulepath spec/fixtures/modules/')
+#      expect(result.stderr).not_to match(/Error:/)
+#      expect(@aws.get_iam_roles(@name)).to be_empty
+#    end
+#
+#  end
+#
+#end

--- a/spec/acceptance/iam_user_spec.rb
+++ b/spec/acceptance/iam_user_spec.rb
@@ -1,56 +1,56 @@
-require 'spec_helper_acceptance'
-require 'securerandom'
-
-describe 'iam_user' do
-  before(:all) do
-    @default_region = 'sa-east-1'
-    @aws = AwsHelper.new(@default_region)
-  end
-
-  def find_user(name)
-    users = @aws.find_iam_users(name)
-    expect(users.count).to eq(1)
-    users.first
-  end
-
-  describe 'manage an iam_user' do
-
-    before (:all) do
-      @name = "#{SecureRandom.uuid}.com."
-      @config = {
-        :name => @name,
-      }
-      @template = 'iam_user.pp.tmpl'
-      @user = find_user(@name)
-    end
-
-    it 'with puppet resource' do
-      options = {:name => @config[:name], :ensure => 'present'}
-      result = TestExecutor.puppet_resource('iam_user', options, '--modulepath spec/fixtures/modules/')
-      expect(result.stderr).not_to match(/Error:/)
-      expect{ find_user(@config[:name]) }.not_to raise_error
-    end
-
-    it 'should run idempotently' do
-      result = PuppetManifest.new(@template, @config).apply
-      expect(result.exit_code).to eq(0)
-    end
-
-    it 'should create an IAM user with the correct name' do
-      expect(user.user_name).to eq(@name)
-    end
-
-    it 'should destroy an IAM user' do
-      options = {:name => @config[:name], :ensure => 'absent'}
-      TestExecutor.puppet_resource('iam_user', options, '--modulepath spec/fixtures/modules/')
-      expect(@aws.get_iam_users(@name)).to be_empty
-    end
-
-    it 'should run idempotently after destroy' do
-      result = PuppetManifest.new(@template, @config).apply
-      expect(result.exit_code).to eq(0)
-    end
-
-  end
-
-end
+#require 'spec_helper_acceptance'
+#require 'securerandom'
+#
+#describe 'iam_user' do
+#  before(:all) do
+#    @default_region = 'sa-east-1'
+#    @aws = AwsHelper.new(@default_region)
+#  end
+#
+#  def find_user(name)
+#    users = @aws.find_iam_users(name)
+#    expect(users.count).to eq(1)
+#    users.first
+#  end
+#
+#  describe 'manage an iam_user' do
+#
+#    before (:all) do
+#      @name = "#{SecureRandom.uuid}.com."
+#      @config = {
+#        :name => @name,
+#      }
+#      @template = 'iam_user.pp.tmpl'
+#      @user = find_user(@name)
+#    end
+#
+#    it 'with puppet resource' do
+#      options = {:name => @config[:name], :ensure => 'present'}
+#      result = TestExecutor.puppet_resource('iam_user', options, '--modulepath spec/fixtures/modules/')
+#      expect(result.stderr).not_to match(/Error:/)
+#      expect{ find_user(@config[:name]) }.not_to raise_error
+#    end
+#
+#    it 'should run idempotently' do
+#      result = PuppetManifest.new(@template, @config).apply
+#      expect(result.exit_code).to eq(0)
+#    end
+#
+#    it 'should create an IAM user with the correct name' do
+#      expect(user.user_name).to eq(@name)
+#    end
+#
+#    it 'should destroy an IAM user' do
+#      options = {:name => @config[:name], :ensure => 'absent'}
+#      TestExecutor.puppet_resource('iam_user', options, '--modulepath spec/fixtures/modules/')
+#      expect(@aws.get_iam_users(@name)).to be_empty
+#    end
+#
+#    it 'should run idempotently after destroy' do
+#      result = PuppetManifest.new(@template, @config).apply
+#      expect(result.exit_code).to eq(0)
+#    end
+#
+#  end
+#
+#end


### PR DESCRIPTION
Our internal AWS testing credentials do not have the ability to manage
iam credentials, but we don't want to delete the tests.

Related: #340