### PR TITLE
Add initial support for CloudFront

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ You can use the aws module to audit AWS resources, launch autoscaling groups in 
 
 ### Types
 
+* `cloudfront_distribution`: Sets up a CloudFront distribution.
 * `ec2_instance`: Sets up an EC2 instance.
 * `ec2_securitygroup`: Sets up an EC2 security group.
 * `elb_loadbalancer`: Sets up an ELB load balancer.
@@ -353,6 +354,44 @@ You can use the aws module to audit AWS resources, launch autoscaling groups in 
 * `sqs_queue`: Sets up an SQS queue.
 
 ###Parameters
+
+#### Type: cloudfront_distribution
+
+##### `ensure`
+Specifies the basic state of the resource. Valid values are 'present', 'absent'.
+
+##### `arn`
+The AWS-generated ARN of the distribution. Read only.
+
+##### `id`
+The AWS-generated ID of the distribution. Read only.
+
+##### `status`
+The AWS-reported status of the distribution. Read only.
+
+##### `comment`
+*Optional* The comment on the distribution.
+
+##### `enabled`
+*Optional* Whether the distribution is enabled.
+
+##### `price_class`
+*Optional* The price class of the distribution. Takes one of 'all' (default), '100', '200'.
+
+##### `origins`
+*Required* An array of at least one origin. Each origin is a hash with the following keys:
+
+* `type` — *Required* The origin type. One of 'custom', 'S3' (not yet supported).
+* `id` — *Required* The origin ID. Must be unique within the distribution. Used to identify the origin for caching rules.
+* `domain_name` — *Required* The origin domain name.
+* `path` — *Optional* The origin path. Defaults to no path.
+* `http_port` — *Required for custom origins* The port the origin is listening on for HTTP connections.
+* `https_port` — *Required for custom origins* The port the origin is listening on for HTTPS connections.
+* `protocol_policy` — *Required for custom origins* Which protocols the origin accepts. One of 'http-only', 'https-only', 'match-viewer'.
+* `protocols` — *Required for custom origins* An array of SSL and TLS versions the origin accepts. At least one of 'SSLv3', 'TLSv1', 'TLSv1.1', 'TLSv1.2'.
+
+##### `tags`
+*Optional* The tags for the distribution. Accepts a 'key => value' hash of tags. Excludes 'Name' tag.
 
 ####Type: ec2_instance
 

--- a/lib/puppet/provider/cloudfront_distribution/v2.rb
+++ b/lib/puppet/provider/cloudfront_distribution/v2.rb
@@ -1,0 +1,245 @@
+require_relative '../../../puppet_x/puppetlabs/aws.rb'
+
+Puppet::Type.type(:cloudfront_distribution).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) do
+  confine feature: :aws
+
+  mk_resource_methods
+
+  read_only(:arn, :id, :status)
+
+  def self.instances
+    dists = []
+    list_opts = {max_items: 100}
+
+    # Loop over paginated API responses.
+    loop do
+      dists_resp = cloudfront_client.list_distributions(list_opts).distribution_list
+
+      # Loop over each distribution in one API response.
+      dists_resp.items.each do |dist|
+        tags = cloudfront_client.list_tags_for_resource({resource: dist.arn}).tags.items
+
+        hash = self.distribution_to_hash(dist, tags)
+        dists << new(hash) if hash[:name]
+      end
+
+      break unless dists_resp.is_truncated
+      list_opts[:marker] = dists_resp.next_marker
+    end
+
+    dists.compact
+  end
+
+  def self.prefetch(resources)
+    instances.each do |prov|
+      if resource = resources[prov.name]
+        resource.provider = prov
+      end
+    end
+  end
+
+  def self.distribution_to_hash(dist, tags)
+    {
+      name: self.name_from_cloudfront_tags(tags),
+      ensure: :present,
+      arn: dist.arn,
+      id: dist.id,
+      status: dist.status,
+      comment: dist.comment,
+      enabled: dist.enabled,
+      price_class: dist.price_class.sub(/^PriceClass_/, '').downcase,
+      origins: dist.origins.items.collect { |hash| self.origin_to_hash(hash) },
+      tags: self.tags_to_hash(tags),
+    }
+  end
+
+  def self.origin_to_hash(origin)
+    type = if origin['custom_origin_config'] then
+      'custom'
+    elsif origin['s3_origin_config'] then
+      's3'
+    else
+      fail 'Unknown origin type returned from AWS API'
+    end
+
+    hash = {
+      'id' => origin[:id],
+      'type' => type,
+      'domain_name' => origin[:domain_name],
+      'path' => origin[:origin_path],
+    }
+
+    case type
+    when 'custom'
+      hash['http_port'] = origin['custom_origin_config']['http_port']
+      hash['https_port'] = origin['custom_origin_config']['https_port']
+      hash['protocol_policy'] = origin['custom_origin_config']['origin_protocol_policy']
+      hash['protocols'] = origin['custom_origin_config']['origin_ssl_protocols']['items']
+    when 's3'
+      Puppet.warning('CloudFront S3 origins are not supported.')
+    end
+
+    hash
+  end
+
+  # CloudFront tags are a unique data type.
+  def self.name_from_cloudfront_tags(tags)
+    name_tag = tags.find { |tag| tag.key.downcase == 'name' }
+    name_tag ? name_tag.value : nil
+  end
+
+  def self.tags_to_hash(tags)
+    tags_hash = {}
+    tags.each do |tag|
+      tags_hash[tag.key] = tag.value unless tag.key.downcase == 'name'
+    end
+
+    tags_hash
+  end
+
+  def exists?
+    @property_hash[:ensure] == :present
+  end
+
+  def create
+    create_resp = cloudfront_client.create_distribution_with_tags({
+      distribution_config_with_tags: {
+        distribution_config: hash_to_distribution_config(resource),
+        tags: {
+          items: tags_for_resource
+        },
+      },
+    })
+
+    @property_hash[:ensure]       = :present
+    @property_hash[:arn]          = create_resp.distribution.arn
+    @property_hash[:id]           = create_resp.distribution.id
+    @property_hash[:status]       = create_resp.distribution.status
+    @property_hash[:just_created] = true
+  end
+
+  def hash_to_distribution_config(hash)
+    dist_origins = hash['origins'].collect { |origin| hash_to_origin(origin) }
+
+    {
+      enabled: hash['enabled'],
+      caller_reference: hash['name'],
+      comment: (hash['comment'] or ''),
+      price_class: ("PriceClass_#{hash['price_class'].capitalize}"),
+      origins: {
+        quantity: dist_origins.length,
+        items: dist_origins,
+      },
+      # All values below are hard-coded defaults for now.
+      default_cache_behavior: {
+        target_origin_id: dist_origins[0][:id],
+        min_ttl: 1,
+        viewer_protocol_policy: 'allow-all',
+        allowed_methods: {
+          quantity: 2,
+          items: ['GET', 'HEAD'],
+          cached_methods: {
+            quantity: 2,
+            items: ['GET', 'HEAD'],
+          },
+        },
+        forwarded_values: {
+          query_string: false,
+          cookies: {
+            forward: 'none',
+            whitelisted_names: {
+              quantity: 0,
+            },
+          },
+          headers: {
+            quantity: 0,
+          },
+          query_string_cache_keys: {
+            quantity: 0,
+          },
+        },
+        lambda_function_associations: {
+          quantity: 0,
+        },
+        trusted_signers: {
+          enabled: false,
+          quantity: 0,
+        },
+      },
+    }
+  end
+
+  def hash_to_origin(hash)
+    {
+      id: hash['id'],
+      domain_name: hash['domain_name'],
+      custom_origin_config: {
+        http_port: hash['http_port'],
+        https_port: hash['https_port'],
+        origin_protocol_policy: hash['protocol_policy'],
+        origin_ssl_protocols: {
+          quantity: hash['protocols'].length,
+          items: hash['protocols'],
+        },
+      },
+    }
+  end
+
+  def destroy
+    # Disabling the distribution returns a new etag. Otherwise, get the current one.
+    if enabled then etag = disable end
+    etag = etag ? etag : cloudfront_client.get_distribution({id: @property_hash[:id]}).etag
+
+    begin
+      cloudfront_client.delete_distribution({
+        id: @property_hash[:id],
+        if_match: etag,
+      })
+
+      @property_hash[:ensure] = :absent
+    rescue Aws::CloudFront::Errors::DistributionNotDisabled
+      Puppet.warning("The CloudFront distribution #{@property_hash[:name]} is not finished being disabled and cannot be deleted yet.")
+    end
+  end
+
+  def enabled?
+    @property_hash[:enabled] == true
+  end
+
+  def enable
+    enable_or_disable(:enable)
+  end
+
+  def disable
+    enable_or_disable(:disable)
+  end
+
+  def enable_or_disable(which)
+    to_enable = case which
+    when :enable; true
+    when :disable; false
+    else
+      fail "'#{which}' is neither :enable nor :disable"
+    end
+
+    dist_resp = cloudfront_client.get_distribution({id: @property_hash[:id]})
+    dist_resp.distribution.distribution_config.enabled = to_enable
+    dist_disabled_resp = cloudfront_client.update_distribution({
+      id: @property_hash[:id],
+      if_match: dist_resp.etag,
+      distribution_config: dist_resp.distribution.distribution_config,
+    })
+
+    @property_hash[:enabled] = to_enable
+
+    dist_disabled_resp.etag
+  end
+
+  def flush
+    if @property_hash[:ensure] != :present then return end
+    if @property_hash[:just_created] then return end
+
+    Puppet.warning('Altering a CloudFront distribution is not supported yet.')
+  end
+
+end

--- a/lib/puppet/type/cloudfront_distribution.rb
+++ b/lib/puppet/type/cloudfront_distribution.rb
@@ -1,0 +1,102 @@
+require_relative '../../puppet_x/puppetlabs/property/tag.rb'
+
+Puppet::Type.newtype(:cloudfront_distribution) do
+  @doc = 'Type representing a CloudFront distribution.'
+
+  ensurable
+
+  newparam(:name, namevar: true) do
+    desc 'The name of the distribution to manage.'
+    validate do |value|
+      fail Puppet::Error, 'Empty distribution names are not allowed' if value == ''
+    end
+  end
+
+  newproperty(:arn) do
+    desc 'Read-only unique AWS resource name assigned to the distribution'
+  end
+
+  newproperty(:id) do
+    desc 'Read-only unique distribution ID'
+  end
+
+  newproperty(:status) do
+    desc 'Read-only status of the distribution'
+  end
+
+  newproperty(:comment) do
+    desc 'Comment for the distribution'
+  end
+
+  newproperty(:enabled, :boolean => true) do
+    desc 'If the distribution is enabled'
+    defaultto true
+  end
+
+  newproperty(:price_class) do
+    desc 'Price class of the distribution'
+    defaultto 'all'
+    validate do |value|
+      fail "Invalid price class '#{value}'" unless ['all', '100', '200'].include? value
+    end
+  end
+
+  newproperty(:origins, :array_matching => :all) do
+    desc 'Array of origins for the distribution'
+    validate do |value|
+      fail 'Origin requires an ID' unless value['id']
+      fail 'Origin requires a domain name' unless value['domain_name']
+
+      case value['type'].downcase
+      when nil, 'custom'
+        if value['http_port'] then
+          fail 'Invalid HTTP port number' unless value['http_port'].to_i > 0
+        end
+        if value['https_port'] then
+          fail 'Invalid HTTPS port number' unless value['https_port'].to_i > 0
+        end
+        if value['protocol_policy'] then
+          fail 'Invalid protocol policy' unless value['protocol_policy'].all? do |policy|
+            ['match-viewer', 'http-only', 'https-only'].include? policy.downcase
+          end
+        end
+        if value['protocols'] then
+          fail 'Invalid protocol set' unless value['protocols'].all? do |proto|
+            ['SSLv3', 'TLSv1', 'TLSv1.1', 'TLSv1.2'].include? proto
+          end
+        end
+      when 's3'
+        fail 'S3 origins are not supported'
+      else
+        fail "Unknown origin type: #{value['type']}"
+      end
+    end
+
+    munge do |value|
+      clean = {
+        # Default origin type to custom
+        'type' => value['type'] ? value['type'].downcase : 'custom',
+        # Default to no path
+        'path' => value['path'] ? value['path'] : '',
+        # Make ports ints and default to 80 and 443
+        'http_port' => value['http_port'] ? value['http_port'] : '80',
+        'https_port' => value['https_port'] ? value['https_port'] : '443',
+        # Default protocol policy to match viewer
+        'protocol_policy' => value['protocol_policy'] ? value['protocol_policy'].downcase : 'match-viewer',
+        # Default protocols to any TLS
+        'protocols' => value['protocols'] ? value['protocols'] : ['TLSv1', 'TLSv1.1', 'TLSv1.2'],
+      }
+
+      value.merge clean
+    end
+
+    def insync?(is)
+      provider.class.normalize_values(is) == provider.class.normalize_values(should)
+    end
+  end
+
+  newproperty(:tags, :parent => PuppetX::Property::AwsTag) do
+    desc 'The tags for the distribution'
+  end
+
+end

--- a/lib/puppet_x/puppetlabs/aws.rb
+++ b/lib/puppet_x/puppetlabs/aws.rb
@@ -226,6 +226,14 @@ This could be because some other process is modifying AWS at the same time."""
         self.class.ecs_client(region)
       end
 
+      def self.cloudfront_client(region = default_region)
+        ::Aws::CloudFront::Client.new(client_config(region))
+      end
+
+      def cloudfront_client(region = default_region)
+        self.class.cloudfront_client(region)
+      end
+
       def tags_for_resource
         tags = resource[:tags] ? resource[:tags].map { |k,v| {key: k, value: v} } : []
         tags << {key: 'Name', value: name}


### PR DESCRIPTION
This adds support for creating, destroying, and enumerating CloudFront web
distributions. Basic parameters and custom origins may be set up. Modification,
several parameters, and S3 origins are left for future work.