### PR TITLE
Support for managing EC2 Volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ You can use the aws module to audit AWS resources, launch autoscaling groups in 
 
 * `ec2_instance`: Sets up an EC2 instance.
 * `ec2_securitygroup`: Sets up an EC2 security group.
+* `ec2_volume`: Sets up an EC2 EBS volume.
 * `elb_loadbalancer`: Sets up an ELB load balancer.
 * `cloudwatch_alarm`: Sets up a Cloudwatch Alarm.
 * `ec2_autoscalinggroup`: Sets up an EC2 auto scaling group.
@@ -527,6 +528,35 @@ back- end instances.  Accepts a hash with the following keys:
 
 #####`scheme`
 *Optional* Whether the load balancer is internal or public facing. This parameter is set at creation only; it is not affected by updates. Valid values are 'internal', 'internet-facing'. Default value is 'internet-facing' and makes the load balancer publicly available.
+
+#### Type: ec2_volume
+
+##### `name`
+*Required* The name of the volume
+
+##### `region`
+*Required* The region in which to create the volume. For valid values, see [AWS Regions](http://docs.aws.amazon.com/general/latest/gr/rande.html#ec2_region).
+
+##### `size`
+*Conditional* The size of the EBS volume in GB. if restoring from snapshot this parameter is not required.
+
+##### `iops`
+*Optional* Only valid for Provisioned IOPS SSD volumes. The number of I/O operations per second (IOPS) to provision for the volume, with a maximum ratio of 50 IOPS/GiB.
+
+##### `availability_zone`
+*Required* The availability zones in which to create the volume. Accepts an array of availability zone codes. For valid availability zone codes, see [AWS Regions and Availability Zones](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html).
+
+##### `volume_type`
+*Required* The volume type. This can be gp2 for General Purpose SSD, io1 for Provisioned IOPS SSD, st1 for Throughput Optimized HDD, sc1 for Cold HDD, or standard for Magnetic volumes.
+
+##### `encrypted`
+*Optional* Specifies whether the volume should be encrypted. Encrypted Amazon EBS volumes may only be attached to instances that support Amazon EBS encryption. Volumes that are created from encrypted snapshots are automatically encrypted. There is no way to create an encrypted volume from an unencrypted snapshot or vice versa.
+
+##### `kms_key_id`
+*Optional* The full ARN of the AWS Key Management Service (AWS KMS) customer master key (CMK) to use when creating the encrypted volume. This parameter is only required if you want to use a non-default CMK; if this parameter is not specified, the default CMK for EBS is used.
+
+##### `snapshot_id`
+*Optional* The snapshot from which to create the volume.
 
 #### Type: cloudwatch_alarm
 

--- a/lib/puppet/provider/ec2_volume/v2.rb
+++ b/lib/puppet/provider/ec2_volume/v2.rb
@@ -1,0 +1,119 @@
+require_relative '../../../puppet_x/puppetlabs/aws'
+
+Puppet::Type.type(:ec2_volume).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) do
+  confine feature: :aws
+
+  mk_resource_methods
+
+  def self.instances
+    regions.collect do |region|
+      ec2 = ec2_client(region)
+      begin
+        volumes = []
+        volume_response = ec2.describe_volumes()
+        volume_response.data.volumes.collect do |volume|
+          hash = volume_to_hash(region, volume)
+          volumes << new(hash) if has_name?(hash)
+        end
+        volumes
+      rescue Timeout::Error, StandardError => e
+        raise PuppetX::Puppetlabs::FetchingAWSDataError.new(region, self.resource_type.name.to_s, e.message)
+      end
+    end.flatten
+  end
+
+  def self.prefetch(resources)
+    instances.each do |prov|
+      if resource = resources[prov.name] # rubocop:disable Lint/AssignmentInCondition
+        resource.provider = prov if resource[:region] == prov.region
+      end
+    end
+  end
+
+  def self.volume_to_hash(region, volume)
+    name = name_from_tag(volume)
+    attachments = volume.attachments.collect do |att|
+      {
+        instance_id: att.instance_id,
+        device: att.device,
+      }
+    end
+    config = {
+      name: name,
+      volume_id: volume.volume_id,
+      size: volume.size,
+      iops: volume.iops,
+      volume_type: volume.volume_type,
+      availability_zone: volume.availability_zone,
+      snapshot_id: volume.snapshot_id,
+      ensure: :present,
+      region: region,
+    }
+    config[:attach] = attachments unless attachments.empty?
+    config
+  end
+
+  def exists?
+    Puppet.info("Checking if EC2 volume #{name} exists in region #{target_region}")
+    @property_hash[:ensure] == :present
+  end
+
+  def create_from_snapshot(config)
+    snapshot = resource[:snapshot_id] ? resource[:snapshot_id] : false
+    config['snapshot_id'] = snapshot if snapshot
+    config
+  end
+
+  def ec2
+    ec2 = ec2_client(target_region)
+    ec2
+  end
+
+  def attach_instance(volume_id)
+    config = {}
+    config[:instance_id] = resource[:attach]["instance_id"]
+    config[:volume_id] = volume_id
+    config[:device] = resource[:attach]["device"]
+    Puppet.info("Attaching Volume #{volume_id} to ec2 instance #{config[:instance_id]}")
+    ec2.wait_until(:volume_available, volume_ids: [volume_id])
+    ec2.attach_volume(config)
+  end
+
+  def create
+    Puppet.info("Creating Volume #{name} in region #{target_region}")
+    config = {
+      size: resource[:size],
+      availability_zone: resource[:availability_zone],
+      volume_type: resource[:volume_type],
+      iops: resource[:iops],
+      encrypted: resource[:encrypted],
+      kms_key_id: resource[:kms_key_id],
+    }
+
+    config = create_from_snapshot(config)
+    response = ec2.create_volume(config)
+
+    ec2.create_tags(
+      resources: [response.volume_id],
+      tags: tags_for_resource
+    ) if resource[:tags]
+
+    attach_instance(response.volume_id) if resource[:attach]
+
+    @property_hash[:id] = response.volume_id
+    @property_hash[:ensure] = :present
+  end
+
+  def destroy
+    Puppet.info("Deleting Volume #{name} in region #{target_region}")
+    # Detach if in use first
+    config = {
+      volume_id: volume_id,
+      force: true
+    }
+    ec2.detach_volume(config) unless @property_hash[:attach] == nil
+    ec2.wait_until(:volume_available, volume_ids: [volume_id])
+    ec2.delete_volume(volume_id: volume_id)
+    @property_hash[:ensure] = :absent
+  end
+end

--- a/lib/puppet/type/ec2_volume.rb
+++ b/lib/puppet/type/ec2_volume.rb
@@ -1,0 +1,102 @@
+require_relative '../../puppet_x/puppetlabs/property/tag.rb'
+require 'puppet/property/boolean'
+
+Puppet::Type.newtype(:ec2_volume) do
+  @doc = 'type representing an EC2 Block Device'
+
+  ensurable
+
+  newparam(:name, namevar: true) do
+    desc 'the name of the security group'
+    validate do |value|
+      fail 'Volume must have a name' if value == ''
+      fail 'name should be a String' unless value.is_a?(String)
+    end
+  end
+
+  newproperty(:region) do
+    desc 'the region in which to launch the volume'
+    validate do |value|
+      fail 'region should not contain spaces' if value =~ /\s/
+      fail 'region should be a String' unless value.is_a?(String)
+    end
+  end
+
+  newproperty(:tags, :parent => PuppetX::Property::AwsTag) do
+    desc 'the tags for the volume'
+  end
+
+  newproperty(:description) do
+    desc 'a short description of the volume'
+    validate do |value|
+      fail 'description cannot be blank' if value == ''
+      fail 'description should be a String' unless value.is_a?(String)
+    end
+  end
+
+  newproperty(:availability_zone) do
+    desc 'The availability zone in which to place the instance.'
+    validate do |value|
+      fail 'availability_zone should not contain spaces' if value =~ /\s/
+      fail 'availability_zone should not be blank' if value == ''
+      fail 'availability_zone should be a String' unless value.is_a?(String)
+    end
+  end
+
+  newproperty(:size) do
+    desc 'The size in GB of the volume.'
+    validate do |value|
+      fail 'Size should be a integer' unless value =~ /^\d+$/
+    end
+  end
+
+  newproperty(:volume_id) do
+    desc 'aws id of volume'
+    validate do |value|
+      fail "Volume Type should be a String: #{value}" unless value.is_a?(String)
+    end
+  end
+
+  newproperty(:volume_type) do
+    desc 'standard, io1, gp2'
+    validate do |value|
+      fail "Volume Type should be a String: #{value}" unless value.is_a?(String)
+    end
+  end
+
+  newproperty(:snapshot_id) do
+    desc 'The snapshot that this volume should be created from'
+    validate do |value|
+      fail 'snapshot_id should be an string' unless value.is_a?(String)
+    end
+  end
+
+  newproperty(:attach) do
+    desc 'The ec2 instance that this volume should attach to'
+    validate do |value|
+      attachments = value.is_a?(Array) ? value : [value]
+      attachments.each do |params|
+        fail "must supply instance id" unless value.keys.include?('instance_id')
+        fail "must supply device name" unless value.keys.include?('device')
+      end
+    end
+  end
+
+  newproperty(:iops) do
+    desc 'Provisioned iops for volume'
+    validate do |value|
+      fail 'iops should be an integer' unless value =~ /^\d+$/
+    end
+  end
+
+  newproperty(:kms_key_id) do
+    desc 'The full ARN of the AWS Key Management Service (AWS KMS) customer master key (CMK) to use when creating the encrypted volume.'
+    validate do |value|
+      fail 'kms_key_id should be an string' unless value.is_a?(String)
+    end
+  end
+
+  newproperty(:encrypted, parent: Puppet::Property::Boolean) do
+    desc 'Indicates whether newly created volume should be encrypted.'
+  end
+end

--- a/spec/unit/provider/ec2_volume/v2_spec.rb
+++ b/spec/unit/provider/ec2_volume/v2_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+provider_class = Puppet::Type.type(:ec2_volume).provider(:v2)
+
+ENV['AWS_ACCESS_KEY_ID'] = 'redacted'
+ENV['AWS_SECRET_ACCESS_KEY'] = 'redacted'
+ENV['AWS_REGION'] = 'sa-east-1'
+
+describe provider_class do
+
+  let(:resource) {
+    Puppet::Type.type(:ec2_volume).new(
+      name: 'test-volume',
+      region: 'sa-east-1',
+      size: '10',
+      volume_type: 'gp2',
+      iops: '300',
+      availability_zone: 'sa-east-1a',
+    )
+  }
+
+  let(:provider) { resource.provider }
+
+  let(:instance) { provider.class.instances.first }
+
+  it 'should be an instance of the ProviderV2' do
+    expect(provider).to be_an_instance_of Puppet::Type::Ec2_volume::ProviderV2
+  end
+end

--- a/spec/unit/type/ec2_volume_spec.rb
+++ b/spec/unit/type/ec2_volume_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+type_class = Puppet::Type.type(:ec2_volume)
+
+describe type_class do
+
+  let :params do
+    [
+      :name,
+    ]
+  end
+
+  let :properties do
+    [
+      :ensure,
+      :availability_zone,
+      :size,
+      :volume_type,
+      :iops,
+      :attach,
+      :region,
+      :tags,
+    ]
+  end
+
+  it 'should have expected properties' do
+    properties.each do |property|
+      expect(type_class.properties.map(&:name)).to be_include(property)
+    end
+  end
+
+  it 'should have expected parameters' do
+    params.each do |param|
+      expect(type_class.parameters).to be_include(param)
+    end
+  end
+
+  it 'should require a name' do
+    expect {
+      type_class.new({})
+    }.to raise_error(Puppet::Error, 'Title or name must be provided')
+  end
+
+  it 'should require region to not contain spaces' do
+    expect {
+      type_class.new({name: 'name', region: 'invalid region'})
+    }.to raise_error(Puppet::Error, /region should not contain spaces/)
+  end
+
+  [
+    'name',
+    'availability_zone',
+    'region',
+  ].each do |property|
+    it "should require #{property} to be a string" do
+      expect(type_class).to require_string_for(property)
+    end
+  end
+
+  it "should require tags to be a hash" do
+    expect(type_class).to require_hash_for('tags')
+  end
+
+  it 'should order tags on output' do
+    expect(type_class).to order_tags_on_output
+  end
+
+end


### PR DESCRIPTION
I am adding support for managing EC2 Block device volumes. With this you can create and attach volumes to already running instances as well as detach and destroy.

Volumes can be created from scratch or built from a snapshot.

