### PR TITLE
Add refresh for Ecs_service resources

### DIFF
--- a/lib/puppet/provider/ecs_service/v2.rb
+++ b/lib/puppet/provider/ecs_service/v2.rb
@@ -166,6 +166,17 @@ Puppet::Type.type(:ecs_service).provide(:v2, :parent => PuppetX::Puppetlabs::Aws
     @property_hash[:ensure] = :absent
   end
 
+  def update
+    service_def = {
+      service: resource[:name],
+      cluster: resource[:cluster],
+      task_definition: resource[:task_definition],
+    }
+    Puppet.debug("Updating ECS service #{resource[:name]} to latest task definition")
+
+    ecs_client.update_service(service_def)
+  end
+
   def flush
     if @property_hash[:ensure] != :absent
       Puppet.debug("Flushing ECS service for #{@property_hash[:name]}")

--- a/lib/puppet/type/ecs_service.rb
+++ b/lib/puppet/type/ecs_service.rb
@@ -56,6 +56,7 @@ Puppet::Type.newtype(:ecs_service) do
   newproperty(:task_definition) do
     isrequired
   end
+
   newproperty(:deployment_configuration) do
     desc 'The deployment configuration of the service.
 
@@ -84,5 +85,8 @@ Puppet::Type.newtype(:ecs_service) do
     isrequired
     defaultto "default"
   end
-end
 
+  def refresh
+    provider.update
+  end
+end


### PR DESCRIPTION
Without this change, the ECS service is unable to track changes to the
task.  This leaves the code in a state where the task definition is
updated, but the service is not refreshed to be running on that code.
Here we implement the ability for the Ecs_service resources to subscribe
to Ecs_task_definition resources.  The autosubscribe in my testing
didn't seem to work correctly, but I think the code is correct.  In any
case, users are able to specify 'subscribe =>' relationships between ECS
services and their tasks with this update.