### PR TITLE
Enable autorequire for iam_role for policy attachment

### DIFF
--- a/lib/puppet/type/iam_policy_attachment.rb
+++ b/lib/puppet/type/iam_policy_attachment.rb
@@ -9,9 +9,9 @@ Puppet::Type.newtype(:iam_policy_attachment) do
     self[:users]
   end
 
-  #autorequire(:iam_role) do
-  #  self[:users]
-  #end
+  autorequire(:iam_role) do
+    self[:roles]
+  end
 
   autorequire(:iam_policy) do
     self[:name]


### PR DESCRIPTION
Without this change, the autorequire for iam_role is not enabled for the
iam_policy_attachment.  This was originally commented because the
iam_role code had not been merged.  Now that the code has been merged,
we can enable this here to allow the automatic and correct ordering for
IAM resources.