### PR TITLE
Add role management for ECS tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1083,8 +1083,6 @@ In the case where a user wishes to remove an option from the container, one of t
 
 It's a small kludge, I know.
 
-
-
 ##### `container_definitions`
 An array of hashes representing the container definition.  See the example
 above.
@@ -1102,6 +1100,10 @@ to create, but not modify the image of a container once created.
 This is useful in environments where external CI tooling is responsible for
 modifying the image of a container, allowing a dualistic approach for managing
 ECS.
+
+##### `role`
+A string of the short name or full ARN of the IAM role that containers in this task should assume.
+
 
 #### Type: iam_group
 

--- a/lib/puppet/type/ecs_task_definition.rb
+++ b/lib/puppet/type/ecs_task_definition.rb
@@ -1,6 +1,10 @@
 Puppet::Type.newtype(:ecs_task_definition) do
   @doc = 'Type representing ECS clusters.'
 
+  autorequire(:iam_role) do
+    self[:role]
+  end
+
   ensurable
 
   newparam(:name, namevar: true) do
@@ -28,7 +32,7 @@ Puppet::Type.newtype(:ecs_task_definition) do
     desc 'An array of hashes to handle for the task'
   end
 
-  newproperty( :container_definitions, :array_matching => :all) do
+  newproperty(:container_definitions, :array_matching => :all) do
     desc 'An array of hashes representing the container definition'
     isrequired
     def insync?(is)
@@ -38,6 +42,10 @@ Puppet::Type.newtype(:ecs_task_definition) do
       one == two
     end
 
+  end
+
+  newproperty(:role) do
+    desc 'The short name or full ARN of the IAM role that containers in this task can assume.'
   end
 end
 

--- a/spec/unit/provider/ecs_task_definition/v2_spec.rb
+++ b/spec/unit/provider/ecs_task_definition/v2_spec.rb
@@ -64,7 +64,7 @@ describe provider_class do
   describe 'destroy' do
     it 'shold make the call to create the task definition' do
       VCR.use_cassette('destroy-ecs_task_definition') do
-        data = provider.class.prefetch({"lb-1" => resource})
+        data = provider.class.prefetch({"testtask" => resource})
         prov = data.select {|m| m.name == 'testtask' }[0]
         expect(prov.destroy).to be_truthy
         expect(prov.exists?).to be_falsy
@@ -75,7 +75,7 @@ describe provider_class do
   describe 'container_definitions' do
     it 'should retrieve the container_definition' do
       VCR.use_cassette('ecs_task_definition-setup') do
-        data = provider.class.prefetch({"lb-1" => resource})
+        data = provider.class.prefetch({"testtask" => resource})
         prov = data.select {|m| m.name == 'testtask' }[0]
         expect(prov.name).to eq('testtask')
         container1 = prov.container_definitions[1]
@@ -90,7 +90,8 @@ describe provider_class do
   describe 'container_definitions=' do
     it 'should set the container_definition' do
       VCR.use_cassette('ecs_task_definition-setup') do
-        instance = provider.class.instances.first
+        data = provider.class.prefetch({"testtask" => resource})
+        prov = data.select {|m| m.name == 'testtask' }[0]
 
         container_defs = [
           {
@@ -98,8 +99,8 @@ describe provider_class do
           }
         ]
 
-        instance.container_definitions=container_defs
-        instance.flush
+        prov.container_definitions=container_defs
+        prov.flush
       end
     end
   end

--- a/spec/unit/type/ecs_task_definition_spec.rb
+++ b/spec/unit/type/ecs_task_definition_spec.rb
@@ -16,6 +16,7 @@ describe type_class do
       :revision,
       :volumes,
       :container_definitions,
+      :role,
     ]
   end
 


### PR DESCRIPTION
Without this change, the ECS tasks are unable to assume a role when
under puppet management.  This work adds a new 'role' property that
allows tasks to assume a given IAM role.