### PR TITLE
Remove print from IAM user provider

### DIFF
--- a/lib/puppet/provider/iam_user/v2.rb
+++ b/lib/puppet/provider/iam_user/v2.rb
@@ -65,7 +65,6 @@ Puppet::Type.type(:iam_user).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) d
 
       begin
         iam_client.list_access_keys({user_name: user.user_name}).access_key_metadata.each {|k|
-          pp k
           iam_client.delete_access_key({
             user_name: user.user_name,
             access_key_id: k['access_key_id'],


### PR DESCRIPTION
This mistakenly made it through and should be removed.  We should not be
printing data here.