### PR TITLE
Drop semantic require reference

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,4 @@
 require 'puppetlabs_spec_helper/rake_tasks'
-require 'puppet/vendor/semantic/lib/semantic'
 
 begin
   require 'puppet_blacksmith/rake_tasks'


### PR DESCRIPTION
Without this change, the Rakefile references a path in Puppet that has
changed in the recently released 4.9.  This doesn't appear to be
required any longer.