### PR TITLE
Remove the securitygroup autorequire

### DIFF
--- a/lib/puppet/type/ec2_securitygroup.rb
+++ b/lib/puppet/type/ec2_securitygroup.rb
@@ -53,18 +53,8 @@ Puppet::Type.newtype(:ec2_securitygroup) do
     end
   end
 
-  newproperty(:id)
-
-  def should_autorequire?(rule)
-    !rule.nil? and rule.key? 'security_group' and rule['security_group'] != name
-  end
-
-  autorequire(:ec2_securitygroup) do
-    rules = self[:ingress]
-    rules = [rules] unless rules.is_a?(Array)
-    rules.collect do |rule|
-      rule['security_group'] if should_autorequire?(rule)
-    end
+  newproperty(:id) do
+    desc 'The unique identifier for the security group'
   end
 
   autorequire(:ec2_vpc) do


### PR DESCRIPTION
Without this change, it is not possible for security groups to use other
security groups in a circular fashion due to creating a dependency loop
in Puppet.  As of the following commit, we no longer fail when a
security group reference to another security group is not found, and
instead simply throw a warning and drop the rule's inclusion in the
rule set.

    bd0ac4b5e3e6df864dc04ac2318d0931b92de64e

This now means that two security groups that have not yet been created,
can be set to reference eachother, but will take two runs to be
accurate.  The first run to create the security groups, which will skip
the rules that reference the currently nonexistent security group peers,
and the second run to set the reference rules correctly.

This now opens up the potential for circular dependencies.

    Ec2_securitygroup {
      ensure => present,
      region => 'us-west-2',
      vpc    => 'Z',
    }

    ec2_securitygroup { 'first':
      description => 'first',
      ingress     => [{'port' => '666', 'protocol' => 'tcp', 'security_group' => 'second'}],
    }
    ec2_securitygroup { 'second':
      description => 'second',
      ingress     => [{'port' => '666', 'protocol' => 'tcp', 'security_group' => 'third'}],
    }
    ec2_securitygroup { 'third':
      description => 'thrid',
      ingress     => [{'port' => '666', 'protocol' => 'tcp', 'security_group' => 'first'}],
    }

This is a valid use case for security groups, but not in Puppet.  This is now
only possible to function in this way because we skip security group references
that don't exist.  However, this now means that the autorequire rules will
create a circular dependency and fail to deploy.

Here we remove the autorequrie from the securitygroup type for other security
group references  to allow the above scenario to complete the catalog compile
and manage the groups as needed completely.  This solves both the case of
creation of groups that don't exist, but are referenced in other security
groups, as well as circular group references, without causing puppet to loop.