### PR TITLE
Adds parameter to rds_instance to specify an option group

### DIFF
--- a/README.md
+++ b/README.md
@@ -2564,6 +2564,11 @@ This parameter is set at creation only; it is not affected by updates.
 
 ##### `restore_snapshot`
 
+#####`db_option_group`
+The name of an associated DB option group. Should be a string. This
+parameter is set at creation only; it is not affected by updates.
+
+#####`restore_snapshot
 Specify the snapshot name to optionally trigger creating the RDS DB from a snapshot.
 
 ##### `final_db_snapshot_identifier`

--- a/lib/puppet/provider/rds_db_option_group/v2.rb
+++ b/lib/puppet/provider/rds_db_option_group/v2.rb
@@ -1,0 +1,30 @@
+require_relative '../../../puppet_x/puppetlabs/aws.rb'
+
+Puppet::Type.type(:rds_db_option_group).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) do
+  confine feature: :aws
+
+  mk_resource_methods
+
+  def self.instances
+    regions.collect do |region|
+      instances = []
+      rds_client(region).describe_option_groups.each do |response|
+        response.data.option_groups_list.each do |db_option_group|
+          # There's always a default class
+          hash = db_option_group_to_hash(region, db_option_group)
+          instances << new(hash) if hash[:name]
+        end
+      end
+      instances
+    end.flatten
+  end
+
+  def self.db_option_group_to_hash(region, db_option_group)
+    {
+      :name => db_option_group.option_group_name,
+      :description => db_option_group.option_group_description,
+      :region => region,
+    }
+  end
+
+end

--- a/lib/puppet/provider/rds_instance/v2.rb
+++ b/lib/puppet/provider/rds_instance/v2.rb
@@ -68,12 +68,14 @@ Puppet::Type.type(:rds_instance).provide(:v2, :parent => PuppetX::Puppetlabs::Aw
       rds_tags: rds_tags,
       db_subnet: db_subnet,
       db_parameter_group: instance.db_parameter_groups.collect(&:db_parameter_group_name).first,
+      db_option_group: instance.option_group_memberships.collect(&:option_group_name).first,
       db_security_groups: instance.db_security_groups.collect(&:db_security_group_name),
       vpc_security_groups: vpc_security_groups,
       backup_retention_period: instance.backup_retention_period,
       availability_zone: instance.availability_zone,
       arn: instance.db_instance_arn
     }
+
     if instance.respond_to?('endpoint') && !instance.endpoint.nil?
       config[:endpoint] = instance.endpoint.address
       config[:port]     = instance.endpoint.port
@@ -181,6 +183,7 @@ Puppet::Type.type(:rds_instance).provide(:v2, :parent => PuppetX::Puppetlabs::Aw
       db_security_groups: resource[:db_security_groups],
       db_parameter_group_name: resource[:db_parameter_group],
       vpc_security_group_ids: vpc_sg_ids,
+      option_group_name: resource[:db_option_group],
       backup_retention_period: resource[:backup_retention_period],
       availability_zone: resource[:availability_zone],
       tags: tags,

--- a/lib/puppet/type/rds_db_option_group.rb
+++ b/lib/puppet/type/rds_db_option_group.rb
@@ -1,0 +1,32 @@
+Puppet::Type.newtype(:rds_db_option_group) do
+  @doc = 'Type representing an RDS DB Option group.'
+
+  newparam(:name, namevar: true) do
+    desc 'The name of the DB Option Group (also known as the db_option_group_name).'
+    validate do |value|
+      fail 'name should be a String' unless value.is_a?(String)
+    end
+  end
+
+  newproperty(:description) do
+    desc 'The description of a DB option group.'
+    validate do |value|
+      fail 'description should be a String' unless value.is_a?(String)
+    end
+  end
+
+  newproperty(:options) do
+    desc 'The additional options to apply to the RDS instance'
+    validate do |value|
+      fail 'description should be a String' unless value.is_a?(String)
+    end
+  end
+
+  newproperty(:region) do
+    desc 'The region in which to create the db_option_group.'
+    validate do |value|
+      fail 'region should be a String' unless value.is_a?(String)
+      fail 'region should not contain spaces' if value =~ /\s/
+    end
+  end
+end

--- a/lib/puppet/type/rds_instance.rb
+++ b/lib/puppet/type/rds_instance.rb
@@ -196,6 +196,13 @@ Not applicable. Must be null.'
     end
   end
 
+  newproperty(:db_option_group) do
+    desc 'The DB option group for this RDS instance.'
+    validate do |value|
+      fail 'db_option_group should be a String' unless value.is_a?(String)
+    end
+  end
+
   newparam(:final_db_snapshot_identifier) do
     desc 'Name given to the last snapshot on deletion.'
     validate do |value|


### PR DESCRIPTION
This PR add the db_option_group to rds_instance to allow users to specify the option group with their RDS instance creation. 

example:

    db_option_group         => 'custom-sqlserver-se-12-00',

The PR also adds the puppet resource "rds_db_option_group". There is no functionality as of yet to manage the option groups themselves. 