### PR TITLE
Begin KMS management

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,7 @@ You can use the aws module to audit AWS resources, launch autoscaling groups in 
 * `iam_policy_attachment`: Manage an IAM 'managed' policy attachments.
 * `iam_role`: Manage an IAM role.
 * `iam_user`: Manage IAM users.
+* `kms`: Manage KMS keys and their policies.
 * `rds_db_parameter_group`: Allows read access to DB Parameter Groups.
 * `rds_db_securitygroup`: Sets up an RDS DB Security Group.
 * `rds_instance`: Sets up an RDS Database instance.
@@ -1362,6 +1363,23 @@ iam_user { 'bob':
   ensure => present,
 }
 ```
+
+#### Type: kms
+The `kms` type manages KMS key lifecycle and their policies.  The name of the
+resource is prefixed with `alias/` to set the alias of the KMS key, since keys
+themselves don't have any notion of name, outside of an attached alias.
+
+``` Puppet
+kms { 'somekey':
+  ensure => present,
+  policy => template('my/policy.json'),
+}
+```
+
+The above resource may be viewable elsewhere as `alias/somekey`.
+
+#####`policy`
+The JSON policy document to manage on the given KMS key.
 
 #### Type: rds_db_parameter_group
 

--- a/lib/puppet/provider/kms/v2.rb
+++ b/lib/puppet/provider/kms/v2.rb
@@ -1,0 +1,139 @@
+require_relative '../../../puppet_x/puppetlabs/aws.rb'
+
+Puppet::Type.type(:kms).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) do
+  confine feature: :aws
+  mk_resource_methods
+
+  def self.instances
+    aliases = get_aliases()
+
+    aliases.collect do |key_alias|
+      alias_name = /alias\/(.*)/.match(key_alias.alias_name)[1]
+      key_alias_target = key_alias.target_key_id
+      next unless key_alias_target
+
+      key_id = key_alias.target_key_id
+      kms_key = kms_client.describe_key({key_id: key_id})
+
+      begin
+        # There is only ever one policy, and that policy is named default.
+        kms_policies = get_policy('default', key_id)
+      rescue
+        Puppet.warning("Unable to get the policy_names for #{alias_name}")
+      end
+
+      next if alias_name =~ %r{^aws/.*$}
+
+      new({
+        name: alias_name,
+        ensure: :present,
+        key_id: kms_key.key_metadata.key_id,
+        description: kms_key.key_metadata.description,
+        creation_date: kms_key.key_metadata.creation_date,
+        deletion_date: kms_key.key_metadata.deletion_date,
+        policy: kms_policies,
+        arn: kms_key.key_metadata.arn,
+      })
+    end.compact
+  end
+
+  def self.prefetch(resources)
+    instances.each do |prov|
+      if resource = resources[prov.name]
+        resource.provider = prov
+      end
+    end
+  end
+
+  def self.get_policy_names(key_id)
+    policy_name_results = kms_client.list_key_policies({
+      key_id: key_id
+    })
+    policy_names = policy_name_results.policy_names
+
+    truncated = policy_name_results.truncated
+    marker = policy_name_results.next_marker
+
+    while truncated and marker
+      Puppet.debug('KMS policy_names results truncated, proceeding with discovery')
+      response = kms_client.list_key_policies({
+        key_id: key_id,
+        marker: marker
+      })
+      response.policy_names.each {|p| policy_names << p }
+
+      truncated = response.truncated
+      marker = response.next_marker
+    end
+
+    policy_names
+  end
+
+  def self.get_aliases
+    alias_results = kms_client.list_aliases()
+    aliases = alias_results.aliases
+
+    truncated = alias_results.truncated
+    marker = alias_results.next_marker
+
+    while truncated and marker
+      Puppet.debug('KMS alias results truncated, proceeding with discovery')
+      response = kms_client.list_aliases({marker: marker})
+      response.aliases.each {|a| aliases << a }
+
+      truncated = response.truncated
+      marker = response.next_marker
+    end
+
+    aliases
+  end
+
+  def self.get_policy(policy_name, key_id)
+    policy_results = kms_client.get_key_policy({
+      key_id: key_id,
+      policy_name: policy_name
+    })
+
+    policy_data = JSON.parse(URI.unescape(policy_results.policy))
+    policy_document = JSON.pretty_generate(policy_data)
+    policy_document
+  end
+
+  def exists?
+    @property_hash[:ensure] == :present
+  end
+
+  def policy=(value)
+    Puppet.debug("Replacing policy on KMS key #{resource[:name]}")
+    kms_client.put_key_policy({
+      key_id: @property_hash[:key_id],
+      policy_name: 'default',
+      policy: resource[:policy]
+    })
+  end
+
+  def create
+    Puppet.debug("Creating new KMS key #{resource[:name]}")
+    new_key = kms_client.create_key({})
+    key_id = new_key.key_metadata.key_id
+    alias_name = "alias/#{resource[:name]}"
+
+    kms_client.create_alias({
+      alias_name: alias_name,
+      target_key_id: key_id,
+    })
+
+    kms_client.put_key_policy({
+      key_id: key_id,
+      policy_name: 'default',
+      policy: resource[:policy]
+    })
+  end
+
+  def destroy
+    Puppet.debug("Scheduling deletion KMS key #{resource[:name]}")
+    kms_client.schedule_key_deletion({
+      key_id: @property_hash[:key_id],
+    })
+  end
+end

--- a/lib/puppet/type/kms.rb
+++ b/lib/puppet/type/kms.rb
@@ -1,0 +1,43 @@
+Puppet::Type.newtype(:kms) do
+  @doc = 'Type representing a KMS key instance.'
+
+  ensurable
+
+  newparam(:name, namevar: true) do
+    desc 'The alias name of the KMS key to manage.'
+    validate do |value|
+      fail Puppet::Error, 'Empty usernames are not allowed' if value == ''
+    end
+  end
+
+  newproperty(:arn)
+  newproperty(:key_id)
+  newproperty(:enabled)
+  newproperty(:description)
+  newproperty(:creation_date)
+  newproperty(:deletion_date)
+  newproperty(:policy) do
+    desc 'The policy document JSON string'
+    isrequired
+    validate do |value|
+      fail Puppet::Error, 'Policy documents must be JSON strings' unless value.is_a? String
+      JSON.parse(value)
+    end
+
+    munge do |value|
+      begin
+        data = JSON.parse(value)
+        JSON.pretty_generate(data)
+      rescue
+        fail('Document string is not valid JSON')
+      end
+    end
+
+    def insync?(is)
+      one = JSON.parse(is)
+      two = JSON.parse(should)
+      provider.class.normalize_hash(one) == provider.class.normalize_hash(two)
+    end
+  end
+
+end

--- a/spec/unit/type/kms_spec.rb
+++ b/spec/unit/type/kms_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+type_class = Puppet::Type.type(:kms)
+
+describe type_class do
+
+  let :params do
+    [
+      :name,
+    ]
+  end
+
+  let :properties do
+    [
+      :ensure,
+      :policy,
+      :arn,
+      :enabled,
+      :description,
+      :creation_date,
+      :deletion_date,
+    ]
+  end
+
+  it 'should have expected properties' do
+    properties.each do |property|
+      expect(type_class.properties.map(&:name)).to be_include(property)
+    end
+  end
+
+  it 'should have expected parameters' do
+    params.each do |param|
+      expect(type_class.parameters).to be_include(param)
+    end
+  end
+
+  it 'should require a name' do
+    expect {
+      type_class.new({})
+    }.to raise_error(Puppet::Error, 'Title or name must be provided')
+  end
+
+  it 'should require a non-blank name' do
+    expect {
+      type_class.new({ name: '' })
+    }.to raise_error(Puppet::Error, /Empty usernames are not allowed/)
+  end
+
+  context 'with a valid name' do
+    it 'should create a valid instance' do
+      type_class.new({ name: 'name' })
+    end
+  end
+
+end
+


### PR DESCRIPTION
Without this change, there is no functionality in this module to manage
the lifecycle and policy of a KMS key in amazon.  Here we add a simple
type and provider with just enough to create, destroy, and manage the
policy.  There are testing updates for the normalization code here,
since the KMS policy exercises data structures that are not exercised
elsewhere, so we extend the use case a bit of the normalize method
calls.