### PR TITLE
Enable volume management for ECS tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1209,7 +1209,17 @@ above.
 *Required* The name of the task to manage.
 
 ##### `volumes`
-An array of hashes to handle for the task.
+An array of hashes to handle for the task.  The hashes representing a volume should be in the following form:
+
+```
+{
+  name => "StringNameForReference",
+  host => {
+    source_path => "/some/path",
+  },
+}
+
+```
 
 ##### `replace_image`
 A boolean to turn off the replacement of container images.  This enables Puppet

--- a/lib/puppet/type/ecs_task_definition.rb
+++ b/lib/puppet/type/ecs_task_definition.rb
@@ -28,8 +28,14 @@ Puppet::Type.newtype(:ecs_task_definition) do
     desc 'Read-only revision number of the task definition'
   end
 
-  newproperty(:volumes) do
+  newproperty(:volumes, :array_matching => :all) do
     desc 'An array of hashes to handle for the task'
+
+    def insync?(is)
+      one = provider.class.normalize_values(is)
+      two = provider.class.normalize_values(should)
+      one == two
+    end
   end
 
   newproperty(:container_definitions, :array_matching => :all) do
@@ -41,7 +47,6 @@ Puppet::Type.newtype(:ecs_task_definition) do
       two = provider.class.normalize_values(is)
       one == two
     end
-
   end
 
   newproperty(:role) do


### PR DESCRIPTION
Without this change, the volumes property is not property respected,
either on modification, or on creation.  Here we add the necessary logic
to to set the volumes for a task upon creation of an ECS task, as well
as modification after the initial creation.