### PR TITLE
Improve ELB listener detection

### DIFF
--- a/lib/puppet/type/elb_loadbalancer.rb
+++ b/lib/puppet/type/elb_loadbalancer.rb
@@ -51,7 +51,7 @@ Puppet::Type.newtype(:elb_loadbalancer) do
       matched_listeners = normal_should.collect do |should_listener|
         # Identify the is_listener that matches this should_listener
         is_listener_match = normal_is.select {|i| i['load_balancer_port'] == should_listener['load_balancer_port']}
-        unless is_listener_match
+        unless is_listener_match and is_listener_match.size > 0
           Puppet.debug("Mathing existing listener was not found for #{should_listener['load_balancer_port']}")
           next
         end


### PR DESCRIPTION
Without this change, an ELB with no listeners causes a stacktrace due to
an incorrect detection of existing listner.  Here we adjust the logic to
account for an empty array, by checking that we have at least 1 listener
before we proceed inspecting the delta between the desired listeners and
the actual listeners.