### PR TITLE
Fix bug on ecs_task_definition flush

### DIFF
--- a/lib/puppet/provider/ecs_task_definition/v2.rb
+++ b/lib/puppet/provider/ecs_task_definition/v2.rb
@@ -177,6 +177,8 @@ Puppet::Type.type(:ecs_task_definition).provide(:v2, :parent => PuppetX::Puppetl
       container_definitions = resource[:container_definitions]
     end
 
+    Puppet.debug("#{container_definitions}")
+
     task = {
       family: resource[:name],
       container_definitions: self.class.serialize_container_definitions(container_definitions),

--- a/lib/puppet/provider/ecs_task_definition/v2.rb
+++ b/lib/puppet/provider/ecs_task_definition/v2.rb
@@ -169,12 +169,12 @@ Puppet::Type.type(:ecs_task_definition).provide(:v2, :parent => PuppetX::Puppetl
       end
     end
 
-    Puppet.debug("Registering new task definition for #{@property_hash[:name]}")
+    Puppet.debug("Registering new task definition for #{resource[:name]}")
 
     if containers.size > 0
       container_definitions = containers
     else
-      container_definitions = @property_hash[:container_definitions]
+      container_definitions = resource[:container_definitions]
     end
 
     task = {

--- a/lib/puppet/provider/ecs_task_definition/v2.rb
+++ b/lib/puppet/provider/ecs_task_definition/v2.rb
@@ -13,9 +13,13 @@ Puppet::Type.type(:ecs_task_definition).provide(:v2, :parent => PuppetX::Puppetl
 
   def self.instances
 
-    task_families = ecs_client.list_task_definition_families({status: 'ACTIVE'}).families
+    task_families_results = ecs_client.list_task_definition_families({status: 'ACTIVE'})
+    task_families = task_families_results.families
 
-    results = task_families.collect do |task_family|
+    next_token = task_families_results.next_token
+    Puppet.debug("next token #{next_token}")
+
+    task_families.collect do |task_family|
 
       begin
         task = ecs_client.describe_task_definition({task_definition: task_family}).task_definition
@@ -154,7 +158,7 @@ Puppet::Type.type(:ecs_task_definition).provide(:v2, :parent => PuppetX::Puppetl
   end
 
   def flush
-    Puppet.debug("Flushing ECS task definition for #{@property_hash[:name]}")
+    Puppet.debug("Flushing ECS task definition for #{resource[:name]}")
 
     containers = []
     if @property_hash[:container_definitions] and @property_flush[:container_definitions]

--- a/lib/puppet/provider/ecs_task_definition/v2.rb
+++ b/lib/puppet/provider/ecs_task_definition/v2.rb
@@ -15,9 +15,18 @@ Puppet::Type.type(:ecs_task_definition).provide(:v2, :parent => PuppetX::Puppetl
 
     task_families_results = ecs_client.list_task_definition_families({status: 'ACTIVE'})
     task_families = task_families_results.families
-
     next_token = task_families_results.next_token
-    Puppet.debug("next token #{next_token}")
+
+    while next_token
+      Puppet.debug('ecs_task_definition results truncated, proceeding with discovery')
+      response = ecs_client.list_task_definition_families({
+        status: 'ACTIVE',
+        next_token: next_token
+      })
+
+      response.families.each {|f| task_families << f }
+      next_token = response.next_token
+    end
 
     task_families.collect do |task_family|
 

--- a/lib/puppet/provider/ecs_task_definition/v2.rb
+++ b/lib/puppet/provider/ecs_task_definition/v2.rb
@@ -177,6 +177,8 @@ Puppet::Type.type(:ecs_task_definition).provide(:v2, :parent => PuppetX::Puppetl
       container_definitions = resource[:container_definitions]
     end
 
+    Puppet.debug("#{task}")
+
     task = {
       family: resource[:name],
       container_definitions: self.class.serialize_container_definitions(container_definitions),

--- a/lib/puppet/provider/ecs_task_definition/v2.rb
+++ b/lib/puppet/provider/ecs_task_definition/v2.rb
@@ -18,7 +18,7 @@ Puppet::Type.type(:ecs_task_definition).provide(:v2, :parent => PuppetX::Puppetl
     next_token = task_families_results.next_token
 
     while next_token
-      Puppet.debug('ecs_task_definition results truncated, proceeding with discovery')
+      Puppet.debug('Results truncated, proceeding with discovery')
       response = ecs_client.list_task_definition_families({
         status: 'ACTIVE',
         next_token: next_token

--- a/lib/puppet/provider/ecs_task_definition/v2.rb
+++ b/lib/puppet/provider/ecs_task_definition/v2.rb
@@ -178,7 +178,7 @@ Puppet::Type.type(:ecs_task_definition).provide(:v2, :parent => PuppetX::Puppetl
     end
 
     task = {
-      family: @property_hash[:name],
+      family: resource[:name],
       container_definitions: self.class.serialize_container_definitions(container_definitions),
     }
 

--- a/lib/puppet/provider/ecs_task_definition/v2.rb
+++ b/lib/puppet/provider/ecs_task_definition/v2.rb
@@ -177,8 +177,6 @@ Puppet::Type.type(:ecs_task_definition).provide(:v2, :parent => PuppetX::Puppetl
       container_definitions = resource[:container_definitions]
     end
 
-    Puppet.debug("#{task}")
-
     task = {
       family: resource[:name],
       container_definitions: self.class.serialize_container_definitions(container_definitions),
@@ -191,6 +189,8 @@ Puppet::Type.type(:ecs_task_definition).provide(:v2, :parent => PuppetX::Puppetl
     if resource[:volumes]
       task[:volumes] = resource[:volumes]
     end
+
+    Puppet.debug("#{task}")
 
     ecs_client.register_task_definition(task)
   end


### PR DESCRIPTION
Without this change, ecs_task_definitions are not created correctly initially
due to a reference to the @property_hash, which may not be populated.  This
change replaces the use of @property_hash to use when generating a new container
definition.  This should allow new contains to get spun up correctly, while also
allowing existing containers to be modified as desired.