### PR TITLE
Properly handle array of domain_name for ec2_vpc_dhcp_options

### DIFF
--- a/README.md
+++ b/README.md
@@ -919,7 +919,7 @@ The type of customer gateway. The only currently supported value --- and the def
 *Optional* The region in which to assign the DHCP option set. For valid values, see [AWS Regions](http://docs.aws.amazon.com/general/latest/gr/rande.html#ec2_region).
 
 #####`domain_name`
-*Optional* The domain name for the DHCP options. This parameter is set at creation only; it is not affected by updates. Accepts any valid domain.
+*Optional* The domain name for the DHCP options. This parameter is set at creation only; it is not affected by updates. Accepts an array or a single valid domain. An array is converted to a space separated list, as Linux supports. Other OSes may not support more than one according to Amazon.
 
 #####`domain_name_servers`
 *Optional* A list of domain name servers to use for the DHCP options set. This parameter is set at creation only; it is not affected by updates. Accepts an array of domain server names.
@@ -1340,7 +1340,7 @@ Role path (optional)
 
 #####`policy_document`
 A string containing the IAM policy in JSON format which controls which entities may assume this role, e.g. the default:
- 
+
 ```
 {
   "Version": "2012-10-17",

--- a/lib/puppet/provider/ec2_vpc_dhcp_options/v2.rb
+++ b/lib/puppet/provider/ec2_vpc_dhcp_options/v2.rb
@@ -39,13 +39,14 @@ Puppet::Type.type(:ec2_vpc_dhcp_options).provide(:v2, :parent => PuppetX::Puppet
     option.dhcp_configurations.each do |conf|
       config[conf[:key]] = conf[:values].collect(&:value)
     end
+    domain_name = config.keys.include?('domain-name') ? config['domain-name'].first.split(' ') : nil
     node_type = config.keys.include?('netbios-node-type') ? config['netbios-node-type'].first : nil
     {
       name: name_from_tag(option),
       id: option.dhcp_options_id,
       region: region,
       ensure: :present,
-      domain_name: config['domain-name'],
+      domain_name: domain_name,
       ntp_servers: config['ntp-servers'],
       domain_name_servers: config['domain-name-servers'],
       netbios_name_servers: config['netbios-name-servers'],
@@ -66,6 +67,7 @@ Puppet::Type.type(:ec2_vpc_dhcp_options).provide(:v2, :parent => PuppetX::Puppet
     options = []
     ['domain_name', 'ntp_servers', 'domain_name_servers', 'netbios_name_servers', 'netbios_node_type'].each do |key|
       value = resource[key.to_sym]
+      value = value.join(' ') if key.eql?('domain_name') and value.is_a?(Array)
       options << {:key => key.gsub('_', '-'), :values => Array(value)} if value
     end
 


### PR DESCRIPTION
The domain name should be a space separated list not a comma separated list.