### PR TITLE
Manage iam_role policy_document updates

### DIFF
--- a/lib/puppet/provider/iam_role/v2.rb
+++ b/lib/puppet/provider/iam_role/v2.rb
@@ -48,6 +48,14 @@ Puppet::Type.type(:iam_role).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) d
     @property_hash[:ensure] = :present
   end
 
+  def policy_document=(value)
+    Puppet.debug('Updating assume_role policy')
+    iam_client.update_assume_role_policy({
+      role_name: @property_hash[:name],
+      policy_document: value,
+    })
+  end
+
   def get_iam_instance_profiles_for_role(role)
     response = iam_client.list_instance_profiles_for_role({
                                                               role_name: role


### PR DESCRIPTION
Without this change, IAM role policy changes are not updated as requested by the
user.  Here we add a setter method for the policy_document param that handles
the policy update for a role.