### PR TITLE
Drop Puppet Enterprise from metadata

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -9,10 +9,6 @@
   "issues_url": "https://github.com/puppetlabs/puppetlabs-aws/issues",
   "requirements": [
     {
-      "name": "pe",
-      "version_requirement": ">=3.7.0 < 2015.4.0"
-    },
-    {
       "name": "puppet",
       "version_requirement": ">= 3.3.0"
     }


### PR DESCRIPTION
Without this change, tests are failing due to a Puppet Forge change.