### PR TITLE
Fix restoring PostgreSQL RDS from snapshot

### DIFF
--- a/lib/puppet/provider/rds_instance/v2.rb
+++ b/lib/puppet/provider/rds_instance/v2.rb
@@ -203,7 +203,7 @@ Puppet::Type.type(:rds_instance).provide(:v2, :parent => PuppetX::Puppetlabs::Aw
         :vpc_security_group_ids,
       ]
 
-      if ['mysql', 'mariadb'].include?(resource[:engine].downcase)
+      if ['mariadb', 'mysql', 'postgres'].include?(resource[:engine].downcase)
         remove_from_config << :db_name
       end
 

--- a/lib/puppet/type/rds_instance.rb
+++ b/lib/puppet/type/rds_instance.rb
@@ -215,7 +215,7 @@ Not applicable. Must be null.'
     end
   end
 
-  newproperty(:restore_snapshot) do
+  newparam(:restore_snapshot) do
     desc 'The database snapshot to restore as this RDS instance.'
     validate do |value|
       fail 'restore_snapshot should be a String' unless value.is_a?(String)

--- a/spec/unit/type/rds_instance_spec.rb
+++ b/spec/unit/type/rds_instance_spec.rb
@@ -10,6 +10,7 @@ describe type_class do
       :master_user_password,
       :skip_final_snapshot,
       :final_db_snapshot_identifier,
+      :restore_snapshot,
     ]
   end
 
@@ -35,7 +36,6 @@ describe type_class do
       :db_parameter_group,
       :backup_retention_period,
       :db_subnet,
-      :restore_snapshot,
     ]
   end
 
@@ -92,7 +92,6 @@ describe type_class do
     'master_user_password',
     :db_parameter_group,
     'final_db_snapshot_identifier',
-    'restore_snapshot',
   ].each do |property|
     it "should require #{property} to be a string" do
       expect(type_class).to require_string_for(property)


### PR DESCRIPTION
Without this change, attempting to create a new RDS instance from a snapshot
fails when the engine is PostgreSQL. This adds PostgreSQL to the list of
engines that cannot have the DB name specified when restoring from snapshot.

This also corrects the restore snapshot to be a parameter, not a property.