### PR TITLE
Fix RDS instance flush region

### DIFF
--- a/lib/puppet/provider/rds_instance/v2.rb
+++ b/lib/puppet/provider/rds_instance/v2.rb
@@ -253,7 +253,7 @@ Puppet::Type.type(:rds_instance).provide(:v2, :parent => PuppetX::Puppetlabs::Aw
           rds_instance_update[k] = v
         }
 
-        rds_client.modify_db_instance(rds_instance_update)
+        rds_client(@property_hash[:region]).modify_db_instance(rds_instance_update)
       end
     end
 


### PR DESCRIPTION
Without this change, the AWS API call to modify an RDS instance (during a
flush) fails when the instance is not in the default region. This adds the
region to the RDS client as elsewhere.