### PR TITLE
Fix use of DNS properties at VPC creation and failing VPC test

### DIFF
--- a/lib/puppet/provider/ec2_vpc/v2.rb
+++ b/lib/puppet/provider/ec2_vpc/v2.rb
@@ -90,6 +90,11 @@ Puppet::Type.type(:ec2_vpc).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) do
     resources = route_response.data.route_tables.collect(&:route_table_id)
     resources << vpc_id
 
+    ec2.modify_vpc_attribute({vpc_id: vpc_id,
+                              enable_dns_support: {value: resource[:enable_dns_support] == :true}})
+    ec2.modify_vpc_attribute({vpc_id: vpc_id,
+                              enable_dns_hostnames: {value: resource[:enable_dns_hostnames] == :true}})
+
     with_retries(:max_tries => 5) do
       ec2.create_tags(
         resources: resources,

--- a/spec/acceptance/vpc_spec.rb
+++ b/spec/acceptance/vpc_spec.rb
@@ -826,7 +826,7 @@ describe "The AWS module" do
       expect(result.stderr).not_to match(/error/i)
       # apply again looking for puppet error on attempted change
       result2 = PuppetManifest.new(@template, @negative_config).apply
-      regex = /Error: routes property is read-only once ec2_vpc_routetable created/
+      regex = /Warning: routes property is read-only once ec2_vpc_routetable created/
       expect(result2.stderr).to match(regex)
     end
   end


### PR DESCRIPTION
PR#421 added support for enable_dns_support and enable_dns_hostnames, but
missed setting these during VPC creation, leading to an idempotency issue