### PR TITLE
Update exception for ELB retry

### DIFF
--- a/lib/puppet/provider/elb_loadbalancer/v2.rb
+++ b/lib/puppet/provider/elb_loadbalancer/v2.rb
@@ -14,7 +14,7 @@ Puppet::Type.type(:elb_loadbalancer).provide(:v2, :parent => PuppetX::Puppetlabs
           retries = 0
           begin
             load_balancers << new(load_balancer_to_hash(region, lb, ref_catalog))
-          rescue Aws::EC2::Errors::RequestLimitExceeded => e
+          rescue Aws::EC2::Errors::RequestLimitExceeded, Aws::ElasticLoadBalancing::Errors::Throttling => e
             retries += 1
             if retries <= 8
               sleep_time = 2 ** retries


### PR DESCRIPTION
Without this change, we're failing to catch the correct exception for retry.
This looks to be something that has changed in the SDK, so here we just update
to match the class of what was caught.