### PR TITLE
Fix subnet name resolution for ELBs

### DIFF
--- a/lib/puppet/provider/elb_loadbalancer/v2.rb
+++ b/lib/puppet/provider/elb_loadbalancer/v2.rb
@@ -192,7 +192,7 @@ Puppet::Type.type(:elb_loadbalancer).provide(:v2, :parent => PuppetX::Puppetlabs
       end
 
       unless subnets_to_resolve.empty?
-        subnets_to_resolve += subnet_names_from_ids(region, subnets_to_resolve)
+        subnet_names += subnet_names_from_ids(region, subnets_to_resolve)
       end
     end
     subnet_names


### PR DESCRIPTION
This work fixes a bug where the subnet_names variable is not populated correctly
due to an incorrect variable reference.  Here we change that variable name to
ensure that the subnet_names are returned correctly.