### PR TITLE
(MAINT) Prepare for 2.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
-## Supported Version 1.5.0
+## Supported Version 2.0.0
 
 This release includes:
+- Drop support for Puppet 3
 - RDS extensions including snapshot restore and VPC support
 - Support for managing EC2 volumes
+- Support for SSD-based EBS volumes and made these the default for storage
 - Early IAM (role, group, instance profile) and KMS support
 - S3 bucket support with policy management
 - ECS (service, task, role) support
@@ -28,11 +30,11 @@ As well as following fixes and improvements:
 - Add alias_target property for Route53
 - Retry for ELB request limits
 - Add dns_name property to elb_loadbalancer
-- Support for SSD-based EBS volumes
 - Add block_device_mappings for launch_config type
 - associate_public_ip_address for ec2 instances
 - Dedicated tenancy for ec2 instances
 - Tags support and additional properties for ec2_autoscalinggroup
+- Remove default netbios_node_type value for ec2_vpc_dhcp_options
 
 ## Supported Version 1.4.0
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ In the simplest case, this allows you to create new EC2 instances from Puppet co
 
 ### Requirements
 
-* Puppet 4.2 or greater
+* Puppet 4.7 or greater
 * Ruby 1.9 or greater
 * Amazon AWS Ruby SDK (available as a gem)
 * Retries gem

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-aws",
-  "version": "1.5.0",
+  "version": "2.0.0",
   "author": "puppetlabs",
   "summary": "This module provides the ability to manage AWS resources",
   "license": "Apache-2.0",
@@ -10,7 +10,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.2.0"
+      "version_requirement": ">= 4.7.0 < 5.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Now updating to a major release, considering removal of Puppet 3 support