### PR TITLE
Downgrade metadata-json-lint for Ruby 1.9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,8 @@ gem 'retries'
 
 group :development do
   gem 'puppet-lint',                        :require => false
-  gem 'metadata-json-lint',                 :require => false
+  gem 'metadata-json-lint', '< 1.2.0',      :require => false if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0.0')
+  gem 'metadata-json-lint',                 :require => false if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.0.0')
   gem 'puppet_facts',                       :require => false
   gem 'puppet-blacksmith', '>= 3.4.0',      :require => false, :platforms => 'ruby'
   gem 'puppetlabs_spec_helper', '>= 1.2.1', :require => false


### PR DESCRIPTION
Without this change, tests fail. `metadata-json-lint` is not supported on
Ruby 1.9, but versions of the gem prior to 1.2.0 happen to work for our
purposes. This downgrades `metadata-json-lint` when using Ruby 1.9.