### PR TITLE
Add iam_instance_profile to ec2_launchconfiguration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1460,6 +1460,12 @@ A hint to specify the VPC. This is useful when detecting ambiguously named secur
 
 This parameter is set at creation only; it is not affected by updates.
 
+##### `iam_instance_profile`
+
+Optional.
+
+The name or the Amazon Resource Name (ARN) of the instance profile associated with the IAM role for the instance.
+
 #### Type: ec2_scalingpolicy
 
 ##### `name`

--- a/lib/puppet/provider/ec2_launchconfiguration/v2.rb
+++ b/lib/puppet/provider/ec2_launchconfiguration/v2.rb
@@ -31,7 +31,7 @@ Puppet::Type.type(:ec2_launchconfiguration).provide(:v2, :parent => PuppetX::Pup
     end
   end
 
-  read_only(:region, :image_id, :instance_type, :key_name, :security_groups)
+  read_only(:region, :image_id, :instance_type, :key_name, :security_groups, :iam_instance_profile)
 
   def self.config_to_hash(region, config)
     # It appears possible to get launch configurations manually to a state where
@@ -61,6 +61,7 @@ Puppet::Type.type(:ec2_launchconfiguration).provide(:v2, :parent => PuppetX::Pup
       region: region,
       spot_price: config.spot_price,
       ebs_optimized: config.ebs_optimized,
+      iam_instance_profile: config.iam_instance_profile,
     }
     if devices.empty?
       config[:block_device_mappings] = [ ]
@@ -105,6 +106,7 @@ Puppet::Type.type(:ec2_launchconfiguration).provide(:v2, :parent => PuppetX::Pup
       security_groups: group_ids,
       instance_type: resource[:instance_type],
       user_data: data,
+      iam_instance_profile: resource[:iam_instance_profile],
     }
 
     key = resource[:key_name] ? resource[:key_name] : false

--- a/lib/puppet/type/ec2_launchconfiguration.rb
+++ b/lib/puppet/type/ec2_launchconfiguration.rb
@@ -98,6 +98,15 @@ Puppet::Type.newtype(:ec2_launchconfiguration) do
     end
   end
 
+  newproperty(:iam_instance_profile) do
+    desc 'The name or the Amazon Resource Name (ARN) of the instance profile associated with the IAM role for the instance.'
+    validate do |value|
+      fail 'instance_type should not contains spaces' if value =~ /\s/
+      fail 'instance_type should not be blank' if value == ''
+      fail 'instance_type should be a String' unless value.is_a?(String)
+    end
+  end
+
   autorequire(:ec2_securitygroup) do
     groups = self[:security_groups]
     groups.is_a?(Array) ? groups : [groups]


### PR DESCRIPTION
This adds an additional option for assigning an IAM instance profile to
Auto Scaling EC2 instances.