### PR TITLE
(maint) Add region validation for us-gov-west-1 (Amazon GovCloud)

### DIFF
--- a/lib/puppet_x/puppetlabs/property/region.rb
+++ b/lib/puppet_x/puppetlabs/property/region.rb
@@ -4,7 +4,7 @@ module PuppetX
       validate do |value|
         name = resource[:name]
         fail 'region should be a String' unless value.is_a?(String)
-        fail 'region should be a valid AWS region' unless value =~ /^([a-z]{2}-[a-z]{4,}-\d)$/
+        fail 'region should be a valid AWS region' unless value =~ /^([a-z]{2}-([a-z]{4,}|gov-west)-\d)$/
         if ENV['AWS_REGION'] && ENV['AWS_REGION'] != value
           fail "if using AWS_REGION environment variable it must match the specified region value for #{name}"
         end


### PR DESCRIPTION
Expand the region validation regular expression to include the
Amazon GovCloud "us-gov-west-1" region. If other GovCloud regions
come online, it may make sense to generalize the matching a bit
and include the "-gov" token earlier in the expression. This change
will prevent a region like "us-gov-east-1" from matching.