### PR TITLE
Remove pry from ec2_instance provider

### DIFF
--- a/lib/puppet/provider/ec2_instance/v2.rb
+++ b/lib/puppet/provider/ec2_instance/v2.rb
@@ -1,12 +1,6 @@
 require_relative '../../../puppet_x/puppetlabs/aws.rb'
 require 'base64'
 
-begin
-  require 'pry'
-rescue Gem::LoadError
-  # not installed
-end
-
 Puppet::Type.type(:ec2_instance).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) do
   confine feature: :aws
   confine feature: :retries

--- a/lib/puppet/provider/ec2_instance/v2.rb
+++ b/lib/puppet/provider/ec2_instance/v2.rb
@@ -1,6 +1,11 @@
 require_relative '../../../puppet_x/puppetlabs/aws.rb'
 require 'base64'
-require 'pry'
+
+begin
+  require 'pry'
+rescue Gem::LoadError
+  # not installed
+end
 
 Puppet::Type.type(:ec2_instance).provide(:v2, :parent => PuppetX::Puppetlabs::Aws) do
   confine feature: :aws


### PR DESCRIPTION
Previous to this commit, the pry gem was loaded as part of the v2 provider for
ec2_instance. This breaks on any system without pry installed. This PR
removes pry.