### PR TITLE
Adding puppetlabs_aws_configuration.ini to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This module now includes tasks which will facilitate in installing the module de
   export AWS_SECRET_ACCESS_KEY=your_secret_access_key
   ```
 
-  Alternatively, you can place the credentials in a file at '~/.aws/credentials' based on the following template:
+  Alternatively, you can place the credentials in a file at '~/.aws/credentials' or 'puppetlabs_aws_configuration.ini' in the Puppet confdir ('$settings::confdir') based on the following template:
 
   ```bash
  [default]


### PR DESCRIPTION
As requested in [MODULES-4425](https://tickets.puppetlabs.com/browse/MODULES-4425) The readme makes no mention of being able to set credentials in the global config file