### PR TITLE
Fix credentials file name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This module now includes tasks which will facilitate in installing the module de
   export AWS_SECRET_ACCESS_KEY=your_secret_access_key
   ```
 
-  Alternatively, you can place the credentials in a file at `~/.aws/credentials` or `puppetlabs_aws_configuration.ini` in the Puppet confdir ('$settings::confdir') based on the following template:
+  Alternatively, you can place the credentials in a file at `~/.aws/credentials` or `puppetlabs_aws_credentials.ini` in the Puppet confdir ('$settings::confdir') based on the following template:
 
   ```bash
  [default]


### PR DESCRIPTION
The module tries to retrieve the AWS access credentials from '$::settings::confdir/puppetlabs_aws_credentials.ini' and not from '$::settings::confdir/puppetlabs_aws_configuration.ini', which only stores other module configuration like AWS region or a proxy server url but no credentials.