### PR TITLE
(MODULES-9005) Remove regions which are disabled by default

### DIFF
--- a/lib/puppet_x/puppetlabs/aws.rb
+++ b/lib/puppet_x/puppetlabs/aws.rb
@@ -24,13 +24,24 @@ This could be because some other process is modifying AWS at the same time."""
 
     class Aws < Puppet::Provider
       def self.regions
+        #Remove the new AWS Regions which are disabled by default.
+        disabled_regions = [ "ap-southeast-1", "ap-southeast-2", "ap-northeast-1", "ap-northeast-2", "ap-east1", "ap-south-1"]
+
         if ENV['AWS_REGION'] and not ENV['AWS_REGION'].empty?
           [ENV['AWS_REGION']]
         elsif global_configuration and global_configuration['default'] and global_configuration['default']['region']
           [global_configuration['default']['region']]
         else
-          ec2_client(default_region).describe_regions.data.regions.map(&:region_name)
+          regions = ec2_client(default_region).describe_regions.data.regions.map(&:region_name)
+          
+          #Remove the new AWS Regions which are disabled by default.
+          disabled_regions.collect do |disabled_region|
+            regions.delete_if { |x| x == disabled_region }
+          end
+          
+          regions
         end
+        
       end
 
       def regions


### PR DESCRIPTION
This will remove regions which are disabled by default.

Please find the test results

**Test Results**
`with processor Puppet::Reports::Store
      on the ec2_vpc
      on the ec2_vpc_dhcp_options
      on the ec2_vpc_routetable
      on the vpc_subnet
      on the vpc_internet_gateway
      on the ec2_vpc_customer_gateway
      on the ec2_vpc_vpn

Finished in 26 minutes 39 seconds (files took 0.69828 seconds to load)
59 examples, 0 failures`